### PR TITLE
prevent duplicate notifications in task bundles

### DIFF
--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -155,6 +155,7 @@ class TaskBundleController @Inject() (
         case None => throw new InvalidException("No tasks found in this bundle.")
       }
 
+      var notify = true
       for (task <- tasks) {
         val action = this.actionManager.setAction(
           Some(user),
@@ -168,7 +169,10 @@ class TaskBundleController @Inject() (
         }
 
         this.serviceManager.taskReview
-          .setTaskReviewStatus(task, reviewStatus, user, actionId, comment, errorTags)
+          .setTaskReviewStatus(task, reviewStatus, user, actionId, comment, errorTags, notify)
+
+        //disable notifications after the first task to prevent duplicates
+        notify = false
 
         if (tags.nonEmpty) {
           val tagList = tags.split(",").toList

--- a/app/org/maproulette/framework/service/CommentService.scala
+++ b/app/org/maproulette/framework/service/CommentService.scala
@@ -115,8 +115,10 @@ class CommentService @Inject() (
       case None    => throw new InvalidException("No tasks found in this bundle.")
     }
 
+    var notify = true
     for (task <- tasks) {
-      this.create(user, task.id, URLDecoder.decode(comment, "UTF-8"), actionId)
+      this.create(user, task.id, URLDecoder.decode(comment, "UTF-8"), actionId, notify)
+      notify = false
     }
     bundle
   }
@@ -128,9 +130,10 @@ class CommentService @Inject() (
     * @param taskId The id of the task that the user is adding the comment too
     * @param comment The actual comment being added
     * @param actionId If there is any actions associated with this add
+    * @param notify enable/disable notification, used to prevent multiple notifications in task bundles
     * @return The newly created comment object
     */
-  def create(user: User, taskId: Long, comment: String, actionId: Option[Long]): Comment = {
+  def create(user: User, taskId: Long, comment: String, actionId: Option[Long], notify: Boolean = true): Comment = {
     val task = this.taskDAL.retrieveById(taskId) match {
       case Some(t) => t
       case None =>
@@ -140,7 +143,9 @@ class CommentService @Inject() (
       throw new InvalidException("Invalid empty string supplied. Comment could not be created.")
     }
     val newComment = this.repository.create(user, task.id, comment, actionId)
-    this.serviceManager.notification.createMentionNotifications(user, newComment, task)
+    if (notify) {
+      this.serviceManager.notification.createMentionNotifications(user, newComment, task)
+    }
     newComment
   }
 

--- a/app/org/maproulette/framework/service/CommentService.scala
+++ b/app/org/maproulette/framework/service/CommentService.scala
@@ -133,7 +133,13 @@ class CommentService @Inject() (
     * @param notify enable/disable notification, used to prevent multiple notifications in task bundles
     * @return The newly created comment object
     */
-  def create(user: User, taskId: Long, comment: String, actionId: Option[Long], notify: Boolean = true): Comment = {
+  def create(
+      user: User,
+      taskId: Long,
+      comment: String,
+      actionId: Option[Long],
+      notify: Boolean = true
+  ): Comment = {
     val task = this.taskDAL.retrieveById(taskId) match {
       case Some(t) => t
       case None =>

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -434,7 +434,8 @@ class TaskReviewService @Inject() (
       user: User,
       actionId: Option[Long],
       commentContent: String = "",
-      errorTags: String = ""
+      errorTags: String = "",
+      notify: Boolean = true
   ): Int = {
     if (!permission.isSuperUser(user) && !user.settings.isReviewer.get && reviewStatus != Task.REVIEW_STATUS_REQUESTED &&
         reviewStatus != Task.REVIEW_STATUS_DISPUTED && reviewStatus != Task.REVIEW_STATUS_UNNECESSARY) {
@@ -517,7 +518,7 @@ class TaskReviewService @Inject() (
 
     val comment = commentContent.nonEmpty match {
       case true =>
-        Some(this.serviceManager.comment.create(user, task.id, commentContent, actionId))
+        Some(this.serviceManager.comment.create(user, task.id, commentContent, actionId, notify))
       case false => None
     }
 


### PR DESCRIPTION
In review/revise flows, when submitting a task bundle, mentioning a user will cause duplicate notifications.  Adding variables to prevent duplicates.