### PR TITLE
move notificationIds to json in services

### DIFF
--- a/app/org/maproulette/framework/controller/NotificationController.scala
+++ b/app/org/maproulette/framework/controller/NotificationController.scala
@@ -67,23 +67,24 @@ class NotificationController @Inject() (
     }
   }
 
-  def markNotificationsRead(userId: Long, notificationIds: String): Action[AnyContent] =
-    Action.async { implicit request =>
+  def markNotificationsRead(userId: Long): Action[JsValue] =
+    Action.async(bodyParsers.json) { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        if (!StringUtils.isEmpty(notificationIds)) {
-          val parsedNotificationIds = Utils.split(notificationIds).map(_.toLong)
-          this.service.markNotificationsRead(userId, user, parsedNotificationIds)
+        val notificationIds = (request.body \ "notificationIds").as[List[Long]]
+        if (!notificationIds.isEmpty) {
+          this.service.markNotificationsRead(userId, user, notificationIds)
         }
         Ok(Json.toJson(StatusMessage("OK", JsString(s"Notifications marked as read"))))
       }
     }
 
-  def deleteNotifications(userId: Long, notificationIds: String): Action[AnyContent] =
-    Action.async { implicit request =>
+  def deleteNotifications(userId: Long): Action[JsValue] =
+    Action.async(bodyParsers.json) { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        if (!StringUtils.isEmpty(notificationIds)) {
-          val parsedNotificationIds = Utils.split(notificationIds).map(_.toLong)
-          this.service.deleteNotifications(userId, user, parsedNotificationIds)
+        val notificationIds = (request.body \ "notificationIds").as[List[Long]]
+
+        if (!notificationIds.isEmpty) {
+          this.service.deleteNotifications(userId, user, notificationIds)
         }
         Ok(Json.toJson(StatusMessage("OK", JsString(s"Notifications deleted"))))
       }

--- a/app/org/maproulette/framework/controller/NotificationController.scala
+++ b/app/org/maproulette/framework/controller/NotificationController.scala
@@ -5,13 +5,12 @@
 package org.maproulette.framework.controller
 
 import javax.inject.Inject
-import org.apache.commons.lang3.StringUtils
 import org.maproulette.exception.StatusMessage
 import org.maproulette.framework.service.{NotificationService}
 import org.maproulette.framework.model.{NotificationSubscriptions}
 import org.maproulette.framework.psql.{Order, OrderField, Paging}
 import org.maproulette.session.SessionManager
-import org.maproulette.utils.{Crypto, Utils}
+import org.maproulette.utils.Crypto
 import play.api.libs.json._
 import play.api.mvc._
 

--- a/conf/v2_route/notification.api
+++ b/conf/v2_route/notification.api
@@ -60,17 +60,20 @@ GET     /user/:userId/notifications                 @org.maproulette.framework.c
 #     in: path
 #     description: The id of the user that owns the notifications
 #   - name: notificationIds
-#     in: query
-#     description: One or more comma-separated ids of notifications to mark as read
-#     type: string,
+#     in: body
+#     description: A JSON array of notification ids
 #     required: true
+#     schema:
+#       type: array
+#       items:
+#         type: integer
 #   - name: apiKey
 #     in: header
 #     description: The user's apiKey to authorize the request
 #     required: true
 #     type: string
 ###
-PUT     /user/:userId/notifications                 @org.maproulette.framework.controller.NotificationController.markNotificationsRead(userId:Long, notificationIds:String)
+PUT     /user/:userId/notifications                 @org.maproulette.framework.controller.NotificationController.markNotificationsRead(userId:Long)
 ###
 # tags: [ Notification ]
 # summary: Delete user notifications
@@ -86,17 +89,20 @@ PUT     /user/:userId/notifications                 @org.maproulette.framework.c
 #     in: path
 #     description: The id of the user that owns the notifications
 #   - name: notificationIds
-#     in: query
-#     description: One or more comma-separated ids of notifications to delete
-#     type: string,
+#     in: body
+#     description: A JSON array of notification ids
 #     required: true
+#     schema:
+#       type: array
+#       items:
+#         type: integer
 #   - name: apiKey
 #     in: header
 #     description: The user's apiKey to authorize the request
 #     required: true
 #     type: string
 ###
-DELETE  /user/:userId/notifications                 @org.maproulette.framework.controller.NotificationController.deleteNotifications(userId:Long, notificationIds:String)
+PUT  /user/:userId/notifications/delete                 @org.maproulette.framework.controller.NotificationController.deleteNotifications(userId:Long)
 ###
 # tags: [ Notification ]
 # summary: Retrieves Users notification subscriptions


### PR DESCRIPTION
If a user has many notifications and tries to delete them all at once, the URL paramter notificationIds can surpass the length that is allowed.

Moving notificaitonIds in both the delete and markRead services to the json payload of the requests.

Resolves https://github.com/maproulette/maproulette3/issues/1569

To be released with https://github.com/maproulette/maproulette3/pull/1887