### PR TITLE
Set caffeine as the default cache type

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -95,7 +95,6 @@ jobs:
         echo '}' >> ./conf/dev.conf
         echo 'maproulette {' >> ./conf/dev.conf
         echo '  debug=true' >> ./conf/dev.conf
-        echo '  caching.type="caffeine"' >> ./conf/dev.conf
         echo '  bootstrap=true' >> ./conf/dev.conf
         echo '  super.key="1234"' >> ./conf/dev.conf
         echo '  super.accounts=""' >> ./conf/dev.conf

--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -190,9 +190,8 @@ class Config @Inject() (implicit val configuration: Configuration) {
     this.config.getOptional[Boolean](Config.KEY_SIGNIN).getOrElse(Config.DEFAULT_SIGNIN)
 
   //caching properties
-  // TODO(ljdelight): After the caffeine cache is better tested, use it as the default cache.
   lazy val cacheType: String =
-    this.config.getOptional[String](Config.KEY_CACHING_TYPE).getOrElse(CacheManager.BASIC_CACHE)
+    this.config.getOptional[String](Config.KEY_CACHING_TYPE).getOrElse(CacheManager.CAFFEINE_CACHE)
   lazy val cacheLimit: Int = this.config
     .getOptional[Int](Config.KEY_CACHING_CACHE_LIMIT)
     .getOrElse(CacheManager.DEFAULT_CACHE_LIMIT)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -277,7 +277,7 @@ maproulette {
     default = 0
   }
   caching {
-    type="Basic"
+    type="caffeine"
     type=${?MR_CACHING_TYPE}
     cacheLimit=10000
     cacheExpiry=900


### PR DESCRIPTION
The cache has been sufficiently tested and caffeine is now the default. Admins can override this with `maproulette.caching.type` in the conf or MR_CACHING_TYPE env.