### PR TITLE
Support conf overrides of max tasks per challenge

### DIFF
--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -125,6 +125,10 @@ class Config @Inject() (implicit val configuration: Configuration) {
     this.config
       .getOptional[Int](Config.KEY_TASK_BASE_COMPLETED_TIME_SPENT)
       .getOrElse(Config.DEFAULT_TASK_BASE_COMPLETED_TIME_SPENT)
+  lazy val maxTasksPerChallenge: Int =
+    this.config
+      .getOptional[Int](Config.KEY_TASK_MAX_TASKS_PER_CHALLENGE)
+      .getOrElse(Config.DEFAULT_MAX_TASKS_PER_CHALLENGE)
   lazy val osmMatcherEnabled: Boolean =
     this.config
       .getOptional[Boolean](Config.KEY_SCHEDULER_OSM_MATCHER_ENABLED)
@@ -271,6 +275,7 @@ object Config {
   val KEY_TASK_SCORE_TOO_HARD            = s"$GROUP_MAPROULETTE.task.score.tooHard"
   val KEY_TASK_SCORE_SKIPPED             = s"$GROUP_MAPROULETTE.task.score.skipped"
   val KEY_TASK_BASE_COMPLETED_TIME_SPENT = s"$GROUP_MAPROULETTE.task.base_completed_time_spent"
+  val KEY_TASK_MAX_TASKS_PER_CHALLENGE   = s"$GROUP_MAPROULETTE.task.max_tasks_per_challenge"
   val KEY_REVIEW_NEEDED_DEFAULT          = s"$GROUP_MAPROULETTE.review.default"
 
   val SUB_GROUP_SCHEDULER                      = s"$GROUP_MAPROULETTE.scheduler"

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -61,7 +61,7 @@ class ChallengeController @Inject() (
     val serviceManager: ServiceManager,
     wsClient: WSClient,
     permission: Permission,
-    config: Config,
+    override val config: Config,
     components: ControllerComponents,
     override val bodyParsers: PlayBodyParsers,
     implicit val snapshotManager: SnapshotManager
@@ -1390,10 +1390,10 @@ class ChallengeController @Inject() (
                   val sourceDataLength = Source.fromFile(f.ref.getAbsoluteFile).getLines().length
                   if (lineByLine) {
                     val total = currentTaskCount + sourceDataLength;
-                    if (total > Config.DEFAULT_MAX_TASKS_PER_CHALLENGE) {
+                    if (total > config.maxTasksPerChallenge) {
                       if (currentTaskCount == 0) {
                         val statusMessage =
-                          s"Tasks were not accepted. Your total challenge tasks would exceed the ${Config.DEFAULT_MAX_TASKS_PER_CHALLENGE} cap."
+                          s"Tasks were not accepted. Your total challenge tasks would exceed the ${config.maxTasksPerChallenge} cap."
                         dalManager.challenge.update(
                           Json.obj(
                             "status"        -> Challenge.STATUS_FAILED,
@@ -1407,7 +1407,7 @@ class ChallengeController @Inject() (
                         )
                       } else {
                         throw new InvalidException(
-                          s"Total challenge tasks would exceed cap of ${Config.DEFAULT_MAX_TASKS_PER_CHALLENGE}"
+                          s"Total challenge tasks would exceed cap of ${config.maxTasksPerChallenge}"
                         )
                       }
                     } else {

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -64,7 +64,7 @@ class TaskController @Inject() (
     dalManager: DALManager,
     wsClient: WSClient,
     webSocketProvider: WebSocketProvider,
-    config: Config,
+    override val config: Config,
     components: ControllerComponents,
     changeService: ChangesetProvider,
     taskClusterService: TaskClusterService,

--- a/app/org/maproulette/controllers/api/VirtualChallengeController.scala
+++ b/app/org/maproulette/controllers/api/VirtualChallengeController.scala
@@ -38,7 +38,7 @@ class VirtualChallengeController @Inject() (
     override val actionManager: ActionManager,
     override val dal: VirtualChallengeDAL,
     taskDAL: TaskDAL,
-    config: Config,
+    override val config: Config,
     components: ControllerComponents,
     override val bodyParsers: PlayBodyParsers
 ) extends AbstractController(components)

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -218,9 +218,9 @@ class ChallengeProvider @Inject() (
 
           if (this.isLineByLineGeoJson(splitJson)) {
             val splitJsonLength = resp.body.split("\n").length;
-            if (splitJsonLength > Config.DEFAULT_MAX_TASKS_PER_CHALLENGE) {
+            if (splitJsonLength > config.maxTasksPerChallenge) {
               val statusMessage =
-                s"Tasks were not accepted. Your feature list size must be under ${Config.DEFAULT_MAX_TASKS_PER_CHALLENGE}."
+                s"Tasks were not accepted. Your feature list size must be under ${config.maxTasksPerChallenge}."
               this.challengeDAL.update(
                 Json.obj("status" -> Challenge.STATUS_FAILED, "statusMessage" -> statusMessage),
                 user
@@ -379,10 +379,10 @@ class ChallengeProvider @Inject() (
     val featureList       = (jsonData \ "features").as[List[JsValue]]
     val featureListLength = (jsonData \ "features").as[List[JsValue]].length
     try {
-      if (featureListLength + currentTaskCount > Config.DEFAULT_MAX_TASKS_PER_CHALLENGE) {
+      if (featureListLength + currentTaskCount > config.maxTasksPerChallenge) {
         if (currentTaskCount == 0) {
           val statusMessage =
-            s"Tasks were not accepted. Your feature list size must be under ${Config.DEFAULT_MAX_TASKS_PER_CHALLENGE}."
+            s"Tasks were not accepted. Your feature list size must be under ${config.maxTasksPerChallenge}."
           this.challengeDAL.update(
             Json.obj("status" -> Challenge.STATUS_FAILED, "statusMessage" -> statusMessage),
             user
@@ -394,7 +394,7 @@ class ChallengeProvider @Inject() (
           List.empty
         } else {
           throw new InvalidException(
-            s"Total challenge tasks would exceed cap of ${Config.DEFAULT_MAX_TASKS_PER_CHALLENGE}"
+            s"Total challenge tasks would exceed cap of ${config.maxTasksPerChallenge}"
           )
         }
       } else {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -164,13 +164,16 @@ maproulette {
   publicOrigin="https://maproulette.org"
   emailFrom="maproulette@example.com"
 
-  # number of days till we reset the status if it has not been fixed
   task {
+    # number of days till we reset the status if it has not been fixed
     reset = 14
     changesets {
       timeLimit="1 hour"
       enabled=false
     }
+
+    # The maximum number of tasks per Challenge
+    max_tasks_per_challenge=50000
   }
   #logo="/assets/images/companylogo.png"
   signin=false


### PR DESCRIPTION
Allow for overriding the max tasks per challenge using conf key `maproulette.task.max_tasks_per_challenge`.