### PR TITLE
Enforce max task count for POST /api/v2/tasks

### DIFF
--- a/app/org/maproulette/controllers/CRUDController.scala
+++ b/app/org/maproulette/controllers/CRUDController.scala
@@ -132,6 +132,12 @@ trait CRUDController[T <: BaseObject[Long]] extends SessionController {
             case None => None
           }
         } else {
+          logger.warn(
+            "challengeId='{}' has exceeded the maximum tasks per challenge (count={} max={})",
+            parentId,
+            currentTaskCount,
+            config.maxTasksPerChallenge
+          )
           throw new InvalidException(
             s"Challenges cannot exceed ${config.maxTasksPerChallenge} tasks"
           )
@@ -410,6 +416,16 @@ trait CRUDController[T <: BaseObject[Long]] extends SessionController {
                           logger.warn(s"Invalid json for type: ${JsError.toJson(errors).toString}"),
                         validT => this.internalCreate(element, validT, user)
                       )
+                  } else {
+                    logger.warn(
+                      "challengeId='{}' has exceeded the maximum tasks per challenge (count={} max={})",
+                      parentId,
+                      currentTaskCount,
+                      config.maxTasksPerChallenge
+                    )
+                    throw new InvalidException(
+                      s"Challenges cannot exceed ${config.maxTasksPerChallenge} tasks"
+                    )
                   }
                 case None =>
                   this

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -1391,6 +1391,14 @@ class ChallengeController @Inject() (
                   if (lineByLine) {
                     val total = currentTaskCount + sourceDataLength;
                     if (total > config.maxTasksPerChallenge) {
+                      logger.warn(
+                        "Cannot add {} tasks to challengeId='{}' because it would exceed the maximum tasks per challenge (count={} max={})",
+                        sourceDataLength,
+                        challengeId,
+                        currentTaskCount,
+                        config.maxTasksPerChallenge
+                      )
+
                       if (currentTaskCount == 0) {
                         val statusMessage =
                           s"Tasks were not accepted. Your total challenge tasks would exceed the ${config.maxTasksPerChallenge} cap."


### PR DESCRIPTION
This resolves a bug where a `POST /api/v2/tasks` would silently fail to create tasks after exceeding the maximum number of tasks per challenge.

The code will now throw an exception, resulting in HTTP 400 for clients. Note that tasks may be created and saved in the database before the excess triggers the exception.

A test of this using 1000 max tasks and a maproulette-java-client upload of around 2000 tasks does now fail with an exception:
maproulette-java-client logs:
```
[main] DEBUG org.maproulette.client.connection.MapRouletteConnection - Request: POST /api/v2/tasks

org.maproulette.client.exception.MapRouletteRuntimeException: org.maproulette.client.exception.MapRouletteException: Invalid response status code 400 - {"status":"KO","message":"Challenges cannot exceed 1000 tasks"}
```

maproulette api logs:
```
22:06:32,355 [info] [scala-execution-context-global-7527023] o.m.m.Metrics$.timer(Metrics.scala:24) - BatchUpload LOOP block took 6865ms
22:06:39,225 [info] [scala-execution-context-global-7527023] o.m.m.Metrics$.timer(Metrics.scala:24) - BatchUpload LOOP block took 6855ms
22:06:39,239 [warn] [scala-execution-context-global-7527023] o.m.c.CRUDController.$anonfun$internalBatchUpload$3(CRUDController.scala:424) - challengeId='105' has exceeded the maximum tasks per challenge (count=1000 max=1000)
22:06:39,239 [error] [scala-execution-context-global-7527023] o.m.e.MPExceptionUtil$.manageException(MPExceptionUtil.scala:75) - Challenges cannot exceed 1000 tasks
org.maproulette.exception.InvalidException: Challenges cannot exceed 1000 tasks
	at org.maproulette.controllers.CRUDController.$anonfun$internalBatchUpload$3(CRUDController.scala:427)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at org.maproulette.controllers.CRUDController.$anonfun$internalBatchUpload$2(CRUDController.scala:403)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at org.maproulette.metrics.Metrics$.timer(Metrics.scala:19)
	at org.maproulette.controllers.CRUDController.$anonfun$internalBatchUpload$1(CRUDController.scala:402)
	at org.maproulette.controllers.CRUDController.$anonfun$internalBatchUpload$1$adapted(CRUDController.scala:401)
	at play.api.db.DefaultDatabase.$anonfun$withTransaction$1(Databases.scala:189)
	at play.api.db.DefaultDatabase.withConnection(Databases.scala:180)
	at play.api.db.DefaultDatabase.withTransaction(Databases.scala:187)
	at org.maproulette.controllers.CRUDController.internalBatchUpload(CRUDController.scala:401)
	at org.maproulette.controllers.CRUDController.internalBatchUpload$(CRUDController.scala:395)
	at org.maproulette.controllers.api.TaskController.internalBatchUpload(TaskController.scala:58)
	at org.maproulette.controllers.CRUDController.$anonfun$batchUpload$4(CRUDController.scala:380)
	at play.api.libs.json.JsSuccess.fold(JsResult.scala:18)
	at org.maproulette.controllers.CRUDController.$anonfun$batchUpload$2(CRUDController.scala:379)
	at org.maproulette.session.SessionManager.$anonfun$authenticated$2(SessionManager.scala:184)
	at scala.util.Try$.apply(Try.scala:210)
	at org.maproulette.session.SessionManager.$anonfun$authenticated$1(SessionManager.scala:184)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:484)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```