### PR TITLE
Simplify the application.conf and dev.conf.example

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -88,21 +88,21 @@ jobs:
       run: |
         touch ./conf/dev.conf
         echo 'include "application.conf"' >> ./conf/dev.conf
-        echo 'db.default {' >> ./conf/dev.conf
-        echo '  url="jdbc:postgresql://localhost:5432/mr_test"' >> ./conf/dev.conf
-        echo '  username="osm"' >> ./conf/dev.conf
-        echo '  password="osm"' >> ./conf/dev.conf
-        echo '}' >> ./conf/dev.conf
         echo 'maproulette {' >> ./conf/dev.conf
         echo '  debug=true' >> ./conf/dev.conf
         echo '  bootstrap=true' >> ./conf/dev.conf
-        echo '  super.key="1234"' >> ./conf/dev.conf
-        echo '  super.accounts=""' >> ./conf/dev.conf
         echo '}' >> ./conf/dev.conf
-    - name: Run the maproulette-java-client integration tests
+    - name: Run maproulette and the maproulette-java-client integration tests
       env:
+        # maproulette overrides
         CI: true
         SBT_OPTS: "-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M"
+        MR_SUPER_KEY: 1234
+        MR_DATABASE_URL: "jdbc:postgresql://localhost:5432/mr_test"
+        MR_DATABASE_USERNAME: "osm"
+        MR_DATABASE_PASSWORD: "osm"
+
+        # maproulette-java-client overrides
         host: 127.0.0.1
         scheme: http
         apiKey: 1234

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -33,8 +33,13 @@ db {
     driver="org.postgresql.Driver"
     url="jdbc:postgresql://localhost:5432/mr_prod"
     url=${?MR_DATABASE_URL}
+
     username="mrdbuser"
+    username=${?MR_DATABASE_USERNAME}
+
     password="mrdbpassword"
+    password=${?MR_DATABASE_PASSWORD}
+
     hikaricp {
       connectionTestQuery="SELECT 1"
       # The database connection pool size can be tweaked based on available system resources and needed throughput.
@@ -49,9 +54,19 @@ db {
 }
 
 akka {
+  # Refer to the manual for akka logging options
+  # https://doc.akka.io/docs/akka/current/logging.html
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "WARNING"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+
   actor {
     provider = "cluster"
-
+    debug {
+      # receive = on
+      # autoreceive = on
+      # lifecycle = on
+    }
     # By default Akka uses the CPU core count to determine the number of threads used
     # to service requests. There are endpoints that block due to the JDBC driver not
     # supporting async, and it is suggested to greatly increase the Akka thread count.

--- a/conf/dev.conf.example
+++ b/conf/dev.conf.example
@@ -2,26 +2,14 @@ include "application.conf"
 
 db.default {
   url="jdbc:postgresql://localhost:5432/mp_dev"
+  url=${?MR_DATABASE_URL}
   username="osm"
+  username=${?MR_DATABASE_USERNAME}
   password="osm"
+  password=${?MR_DATABASE_PASSWORD}
 
   # Set this to 'true' to see the sql statements sent to the database. Very useful when debugging.
   logSql=false
-}
-
-akka {
-  # Refer to the manual for akka logging options
-  # https://doc.akka.io/docs/akka/current/logging.html
-  loggers = ["akka.event.slf4j.Slf4jLogger"]
-  loglevel = "WARNING"
-  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
-  actor {
-    debug {
-      # receive = on
-      # autoreceive = on
-      # lifecycle = on
-    }
-  }
 }
 
 maproulette {
@@ -45,16 +33,17 @@ maproulette {
 osm {
   # The OSM server we will interact with.
   # Note that you need to register your OAuth app with this server as well.
-
   server="https://master.apis.dev.openstreetmap.org"
+  server=${?MR_OSM_SERVER}
 
   # needed if system intends to store MR API keys in osm user preferences.
   # replace maproulette_apikey_v2 with a unique parameter
   # see https://wiki.openstreetmap.org/wiki/API_v0.6#Preferences_of_the_logged-in_user
   preferences="/api/0.6/user/preferences/maproulette_apikey_v2"
 
-  # The Consumer and Secret keys as provided by your OAuth app
-
+  # The Consumer and Secret keys as provided by your OAuth app. Set via conf or environment variables.
   consumerKey="CHANGE_ME"
+  consumerKey=${?MR_OAUTH_CONSUMER_KEY}
   consumerSecret="CHANGE_ME"
+  consumerSecret=${?MR_OAUTH_CONSUMER_SECRET}
 }


### PR DESCRIPTION
There are some redundancies between the application.conf and the dev.conf, and some variables should be overridable via env.

- Support setting database username from env `MR_DATABASE_USERNAME`
- Support setting database password from env `MR_DATABASE_PASSWORD`
- Support setting openstreemap server from env `MR_OSM_SERVER`
- Move akka logging configuration to application.conf