### PR TITLE
Generate `BuildInfo.scala` with useful build-time data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import java.io.{BufferedWriter, FileWriter}
 import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+import java.time.ZoneOffset
 import scala.io.Source
 import scala.util.Using
 
@@ -13,6 +15,15 @@ Universal / packageName := "MapRouletteAPI"
 
 // Developers can run 'sbt format' to easily format their source; this is required to pass a PR build.
 addCommandAlias("format", "scalafmtAll; scalafmtSbt; scalafixAll")
+
+// Setup BuildInfo plugin to write important build-time values to a generated file (org.maproulette.info.BuildInfo)
+enablePlugins(BuildInfoPlugin)
+buildInfoPackage := "org.maproulette.info"
+buildInfoOptions += BuildInfoOption.ToJson
+buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion)
+buildInfoKeys += BuildInfoKey.action("buildDate")(LocalDate.now(ZoneOffset.UTC).toString)
+buildInfoKeys += BuildInfoKey.action("javaVersion")(sys.props("java.version"))
+buildInfoKeys += BuildInfoKey.action("javaVendor")(sys.props("java.vendor"))
 
 // Configure scalastyle. This does not run during compile, run it with 'sbt scalastyle' or 'sbt test:scalastyle'.
 Compile / scalastyleConfig := baseDirectory.value / "conf/scalastyle-config.xml"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,5 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.4.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.3")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")

--- a/test/org/maproulette/info/BuildInfoSpec.scala
+++ b/test/org/maproulette/info/BuildInfoSpec.scala
@@ -1,0 +1,31 @@
+package org.maproulette.info;
+
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsValue, Json};
+
+class BuildInfoSpec extends PlaySpec {
+  val buildInfoJson: JsValue = Json.parse(BuildInfo.toJson)
+  "BuildInfo object" should {
+    "have a buildDate" in {
+      BuildInfo.buildDate mustEqual (buildInfoJson \ "buildDate").validate[String].get
+    }
+    "have a name" in {
+      BuildInfo.name mustEqual (buildInfoJson \ "name").validate[String].get
+    }
+    "have a sbtVersion" in {
+      BuildInfo.sbtVersion mustEqual (buildInfoJson \ "sbtVersion").validate[String].get
+    }
+    "have a scalaVersion" in {
+      BuildInfo.scalaVersion mustEqual (buildInfoJson \ "scalaVersion").validate[String].get
+    }
+    "have a version" in {
+      BuildInfo.version mustEqual (buildInfoJson \ "version").validate[String].get
+    }
+    "have a javaVendor" in {
+      BuildInfo.javaVendor mustEqual (buildInfoJson \ "javaVendor").validate[String].get
+    }
+    "have a javaVersion" in {
+      BuildInfo.javaVersion mustEqual (buildInfoJson \ "javaVersion").validate[String].get
+    }
+  }
+}


### PR DESCRIPTION
Integrate the BuildInfo sbt plugin into the project. This will generate `org.maproulette.info.BuildInfo` and include useful build-time information such as the jdk version, jdk vendor, sbt version, etc.

This information will be useful in creating an endpoint to show compiletime/runtime metadata of maproulette, to validate deployment state and investigate issues.

Example:
```
/** This object was generated by sbt-buildinfo. */
case object BuildInfo {
  val name: String = "MapRouletteAPI"
  val version: String = "4.0.0"
  val scalaVersion: String = "2.13.10"
  val sbtVersion: String = "1.7.2"
  val buildDate: String = "2023-01-16"
  val javaVersion: String = "11.0.17"
  val javaVendor: String = "Eclipse Adoptium"
```