### PR TITLE
fix link in emails to user profile page

### DIFF
--- a/app/org/maproulette/provider/EmailProvider.scala
+++ b/app/org/maproulette/provider/EmailProvider.scala
@@ -105,6 +105,6 @@ class EmailProvider @Inject() (mailerClient: MailerClient, config: Config) {
       |P.S. You received this because you asked to be emailed when you
       |received this type of notification in MapRoulette. You can manage
       |your notification subscriptions and email preferences at:
-      |${urlPrefix}/profile""".stripMargin
+      |${urlPrefix}/user/profile""".stripMargin
   }
 }


### PR DESCRIPTION
the footer of our email notifications has a link to the user profile page that doesn't work because it's an incorrect reference.  This PR fixes it.

resolves https://github.com/maproulette/maproulette3/issues/1930