### PR TITLE
fixed the base url for users to update their email preferences

### DIFF
--- a/app/org/maproulette/provider/EmailProvider.scala
+++ b/app/org/maproulette/provider/EmailProvider.scala
@@ -105,6 +105,6 @@ class EmailProvider @Inject() (mailerClient: MailerClient, config: Config) {
       |P.S. You received this because you asked to be emailed when you
       |received this type of notification in MapRoulette. You can manage
       |your notification subscriptions and email preferences at:
-      |${urlPrefix}/profile""".stripMargin
+      |${urlPrefix}/user/profile""".stripMargin
   }
 }


### PR DESCRIPTION
**Issue**
Incorrect link reference to unsubscribe option in the footer of email notifications

**Approach / Solution**
Fixed the link to point to the correct area on the user profile in email settings.

**Resolves:**
https://github.com/maproulette/maproulette3/issues/1930
