### PR TITLE
Fix links to Postman collection

### DIFF
--- a/postman/README.md
+++ b/postman/README.md
@@ -1,9 +1,9 @@
 # Testing MapRoulette 2 API with Postman
 
-MapRoulette 2 can be easily tested using Postman with the [Collection File](maproulette2.postman_collection). To test the API execute the following:
+MapRoulette 2 can be easily tested using Postman with the [Collection File](maproulette2.postman_collection.json). To test the API execute the following:
 
 1. Download Postman if you don't already have it [here](https://www.getpostman.com/)
-2. Open Postman and import the [MapRoulette 2 Collection file](maproulette2.postman_collection)
+2. Open Postman and import the [MapRoulette 2 Collection file](maproulette2.postman_collection.json)
 3. Open the Postman runner.
 4. Run tests for collection folders Project, Challenge and Tag.
 


### PR DESCRIPTION
Currently the links are broken, resulting in 404 errors in Github when reading the Postman documentation on https://github.com/maproulette/maproulette-backend/blob/dev/postman/README.md. 

![image](https://user-images.githubusercontent.com/1073881/230926853-18f8f75d-6553-44f9-b93f-9354ac36ceda.png)
