### PR TITLE
Log NotAuthorized at the debug level instead of Error

### DIFF
--- a/app/org/maproulette/exception/MPExceptionUtil.scala
+++ b/app/org/maproulette/exception/MPExceptionUtil.scala
@@ -75,7 +75,8 @@ object MPExceptionUtil {
         logger.error(e.getMessage, e)
         BadRequest(Json.toJson(StatusMessage("KO", JsString(e.getMessage))))
       case e: OAuthNotAuthorizedException =>
-        logger.error(e.getMessage)
+        // When a user is not authorized, log it at debug level to avoid simple DoS with logging
+        logger.debug(e.getMessage)
         Unauthorized(Json.toJson(StatusMessage("NotAuthorized", JsString(e.getMessage)))).withNewSession
       case e: IllegalAccessException =>
         logger.error(e.getMessage, e)


### PR DESCRIPTION
Whenever a request fails authN, this log entry is created at the Error level:

[scala-execution-context-global-1871] o.m.e.MPExceptionUtil$.manageException(MPExceptionUtil.scala:79) - Authorization failed (server replied with a 401). This can happen if the consumer key was not correct or the signatures did not match.

This is not useful for day-to-day monitoring so it's annoying at the least, and at the worst a runaway script etc could cause the service to have issues (logging does take compute time, after all).

Resolve this by logging authN issues at `debug`. Developers will have no issues and we'll see less annoyance with prod logs.