### PR TITLE
Improve performance of calculating completion percentage in challenges

### DIFF
--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -323,8 +323,6 @@ object Config {
     s"$SUB_GROUP_SCHEDULER.archiveChallenges.staleTimeInMonths"
   val KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_INTERVAL =
     s"$SUB_GROUP_SCHEDULER.updateChallengeCompletionMetrics.interval"
-  val KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_START =
-    s"$SUB_GROUP_SCHEDULER.updateChallengeCompletionMetrics.startTime"
   val KEY_SCHEDULER_NOTIFICATION_DIGEST_EMAIL_INTERVAL =
     s"$SUB_GROUP_SCHEDULER.notifications.digestEmail.interval"
   val KEY_SCHEDULER_NOTIFICATION_DIGEST_EMAIL_START =

--- a/app/org/maproulette/framework/service/ChallengeService.scala
+++ b/app/org/maproulette/framework/service/ChallengeService.scala
@@ -123,17 +123,9 @@ class ChallengeService @Inject() (
   }
 
   /**
-    * update challenge completion metrics
-    * @param challengeId
-    * @param tasksRemaining
-    * @param completionPercentage
+    * Refreshes the 'completion_percentage' metric for all active (neither deleted nor archived) challenges.
     */
-  def updateChallengeCompletionMetrics(
-      challengeId: Long,
-      tasksRemaining: Integer,
-      completionPercentage: Integer
-  ): Unit = {
-    this.repository
-      .updateChallengeCompletionMetrics(challengeId, tasksRemaining, completionPercentage);
+  def updateCompletionMetricsOfActiveChallenges(): Unit = {
+    this.repository.updateCompletionMetricsOfActiveChallenges();
   }
 }

--- a/app/org/maproulette/jobs/Scheduler.scala
+++ b/app/org/maproulette/jobs/Scheduler.scala
@@ -96,6 +96,13 @@ class Scheduler @Inject() (
     Config.KEY_SCHEDULER_NOTIFICATION_IMMEDIATE_EMAIL_INTERVAL
   )
 
+  schedule(
+    "updateChallengeCompletionMetrics",
+    "Updating Challenge Completion Metrics",
+    5.minutes,
+    Config.KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_INTERVAL
+  )
+
   scheduleAtTime(
     "sendCountNotificationDailyEmails",
     "Sending Count Notification Daily Emails",
@@ -108,13 +115,6 @@ class Scheduler @Inject() (
     "Archiving Challenges",
     config.getValue(Config.KEY_SCHEDULER_ARCHIVE_CHALLENGES_START),
     Config.KEY_SCHEDULER_ARCHIVE_CHALLENGES_INTERVAL
-  )
-
-  scheduleAtTime(
-    "updateChallengeCompletionMetrics",
-    "Updating Challenge Completion Metrics",
-    config.getValue(Config.KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_START),
-    Config.KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_INTERVAL
   )
 
   scheduleAtTime(

--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -649,42 +649,20 @@ class SchedulerActor @Inject() (
     logger.info(s"Archive Challenges job completed. Time spent: %1d ms".format(totalTime))
   }
 
-  def handleUpdateChallengeCompletionMetrics(action: String) = {
-    val start = System.currentTimeMillis
-    logger.info(action)
+  /**
+    * Updates completion metrics for all active challenges.
+    *
+    * @param action An action descriptor, providing more context for logging.
+    */
+  def handleUpdateChallengeCompletionMetrics(action: String): Unit = {
+    val startTime = System.currentTimeMillis
+    logger.info(s"Starting scheduled job: action=$action")
 
-    this.serviceManager.challenge
-      .activeChallenges(true)
-      .foreach(challenge => {
-        val tasks = this.serviceManager.challenge.getTasksByParentId(challenge.id);
+    this.serviceManager.challenge.updateCompletionMetricsOfActiveChallenges()
 
-        val taskCount            = tasks.length;
-        var tasksRemaining       = 0;
-        var completionPercentage = 0;
-
-        if (taskCount == 0) {
-          completionPercentage = 100;
-        } else {
-          tasks.foreach(task => {
-            if (task.status == 0) {
-              tasksRemaining = tasksRemaining + 1;
-            }
-          })
-
-          val tasksCompleted = taskCount - tasksRemaining;
-
-          if (tasksCompleted != 0) {
-            completionPercentage = tasksCompleted * 100 / taskCount
-          }
-        }
-
-        this.serviceManager.challenge
-          .updateChallengeCompletionMetrics(challenge.id, tasksRemaining, completionPercentage);
-      })
-
-    val totalTime = System.currentTimeMillis - start
+    val elapsedTime = System.currentTimeMillis - startTime
     logger.info(
-      s"Update Challenge Completion Metrics job completed. Time spent: %1d ms".format(totalTime)
+      s"Update Challenge Completion Metrics job completed (action=$action). Time spent: ${elapsedTime} ms"
     )
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -247,7 +247,6 @@ maproulette {
     }
 
     updateChallengeCompletionMetrics {
-      startTime = "05:01:00"
       interval = "20 minutes"
     }
 

--- a/conf/evolutions/default/92.sql
+++ b/conf/evolutions/default/92.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+CREATE INDEX IF NOT EXISTS idx_tasks_status_non_zero ON tasks(status) WHERE status != 0;
+CREATE INDEX IF NOT EXISTS idx_tasks_parent_id_status ON tasks (parent_id, status);
+CREATE INDEX IF NOT EXISTS idx_challenges_id_deleted_archived ON challenges (id) WHERE NOT deleted AND NOT is_archived;
+
+# --- !Downs
+DROP INDEX IF EXISTS idx_tasks_status_non_zero;
+DROP INDEX IF EXISTS idx_tasks_parent_id_status;
+DROP INDEX IF EXISTS idx_challenges_id_deleted_archived;


### PR DESCRIPTION
This commit changes how the challenge completion percentage is updated. This new approach uses a single SQL query to update all challenges and will complete much faster than the previous.

The new query uses two subqueries to separate the computation of total tasks and completed tasks where, specifically, it makes use of the index on 'tasks.status'.

Resolves #1043 and there's more technical comments there.