### PR TITLE
Add Review Table CSV

### DIFF
--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -249,23 +249,23 @@ class TaskReviewController @Inject() (
     * Returns a CSV export of the data displayed in the review table.
     *
     * SearchParameters:
-    * @param taskId Optional limit reviews to equivalent taskId
-    * @param reviewStatus Optional limit reviews to equivalent reviewStatus
-    * @param mapper Optional limit reviews to equivalent mapper
-    * @param challengeId Optional limit reviews to equivalent challengeId
-    * @param projectIds Optional limit reviews to equivalent projectIds
-    * @param mappedOn Optional limit reviews to equivalent mappedOn
-    * @param reviewedBy Optional limit reviews to equivalent reviewedBy
-    * @param reviewedAt Optional limit reviews to equivalent reviewedAt
-    * @param metaReviewedBy Optional limit reviews to equivalent metaReviewedBy
-    * @param metaReviewStatus Optional limit reviews to equivalent metaReviewStatus
-    * @param status Optional limit reviews to equivalent status
-    * @param priority Optional limit reviews to equivalent priority
-    * @param tagFilter Optional limit reviews to equivalent tagFilter
-    * @param sortBy Optional limit reviews to equivalent sortBy
-    * @param direction Optional limit reviews to equivalent direction
-    * @param displayedColumns Optional limit reviews to equivalent displayedColumns
-    * @param invertedFilters Optional limit reviews to equivalent invertedFilters
+    * @param taskId Reviews to equivalent taskId
+    * @param reviewStatus Reviews to equivalent reviewStatus
+    * @param mapper Reviews to equivalent mapper
+    * @param challengeId Reviews to equivalent challengeId
+    * @param projectIds Reviews to equivalent projectIds
+    * @param mappedOn Reviews to equivalent mappedOn
+    * @param reviewedBy Reviews to equivalent reviewedBy
+    * @param reviewedAt Reviews to equivalent reviewedAt
+    * @param metaReviewedBy Reviews to equivalent metaReviewedBy
+    * @param metaReviewStatus Reviews to equivalent metaReviewStatus
+    * @param status Reviews to equivalent status
+    * @param priority Reviews to equivalent priority
+    * @param tagFilter Reviews to equivalent tagFilter
+    * @param sortBy Sort order direction. Either ASC or DESC
+    * @param direction Reviews to equivalent direction
+    * @param displayedColumns Reviews to equivalent displayedColumns
+    * @param invertedFilters Reviews to equivalent invertedFilters
     * @param onlySaved Only include saved challenges
     * @return
     */

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -18,8 +18,7 @@ import org.maproulette.framework.repository.TaskRepository
 import org.maproulette.session.{
   SessionManager,
   SearchParameters,
-  SearchLocation,
-  SearchTaskParameters
+  SearchLocation
 }
 import org.maproulette.utils.Utils
 import play.api.mvc._

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -274,6 +274,9 @@ class TaskReviewController @Inject() (
       status: String,
       priority: String,
       tagFilter: String,
+      sortBy: String,
+      direction: String,
+      invertedFilters: String,
       onlySaved: Boolean = false
   ): Action[AnyContent] = {
 
@@ -289,6 +292,9 @@ class TaskReviewController @Inject() (
       status,
       priority,
       tagFilter,
+      sortBy,
+      direction,
+      invertedFilters,
       onlySaved
     )
   }
@@ -305,10 +311,18 @@ class TaskReviewController @Inject() (
       status: String,
       priority: String,
       tagFilter: String,
+      sortBy: String,
+      direction: String,
+      invertedFilters: String,
       onlySaved: Boolean = false
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
+        val invertFiltering = if (StringUtils.isEmpty(invertedFilters)) {
+          None
+        } else {
+          Some(Utils.split(invertedFilters).map(_.toString))
+        }
         val statusFilter = if (StringUtils.isEmpty(status)) {
           None
         } else {
@@ -357,7 +371,7 @@ class TaskReviewController @Inject() (
         val reviewByFilter = if (StringUtils.isEmpty(reviewedBy)) {
           None
         } else {
-          Some((reviewedBy))
+          Some(reviewedBy)
         }
         val reviewedAtFilter = if (StringUtils.isEmpty(reviewedAt)) {
           None
@@ -385,9 +399,12 @@ class TaskReviewController @Inject() (
               .copy(
                 endDate = reviewedAtFilter
               ),
+            invertFields = invertFiltering,
             mapper = mapperFilter,
             reviewer = reviewByFilter
           ),
+          sortBy,
+          direction,
           onlySaved
         )
 

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -420,7 +420,7 @@ class TaskReviewController @Inject() (
           val result = new StringBuilder(
             s"${row.review.taskId},${Task.reviewStatusMap.get(row.review.reviewStatus.get).get}," +
               s"${row.review.reviewRequestedByUsername.getOrElse("")},${row.review.challengeName.getOrElse("")}," +
-              s"${row.task.parent},${row.task.mappedOn
+              s"${row.review.projectName.getOrElse("")},${row.task.mappedOn
                 .getOrElse("")},${row.review.reviewedByUsername.getOrElse("")}," +
               s"${row.review.reviewedAt.getOrElse("")},${Task.statusMap.get(row.task.status.get).get}," +
               s"${Challenge.priorityMap.get(row.task.priority).get},${taskLink},${comments},${row.task.errorTags},${row.review.additionalReviewers

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -437,32 +437,34 @@ class TaskReviewController @Inject() (
         val seqString = metrics
           .map(row => {
             val mappedData =
-              (displayedColumns.split(",")).map { key =>
-                val updatedKey = key match {
-                  case "Internal Id"   => row.review.taskId
-                  case "Review Status" => Task.reviewStatusMap.get(row.review.reviewStatus.get).get
-                  case "Mapper"        => row.review.reviewRequestedByUsername.getOrElse("")
-                  case "Challenge"     => row.review.challengeName.getOrElse("")
-                  case "Project"       => row.review.projectName.getOrElse("")
-                  case "Mapped On"     => row.task.mappedOn.getOrElse("")
-                  case "Reviewer"      => row.review.reviewedByUsername.getOrElse("")
-                  case "Reviewed On"   => row.review.reviewedAt.getOrElse("")
-                  case "Status"        => Task.statusMap.get(row.task.status.get).get
-                  case "Priority"      => Challenge.priorityMap.get(row.task.priority).get
-                  case "Actions" =>
-                    s"[[Task Link=${urlPrefix}challenge/${row.task.parent}/task/${row.review.taskId}]]"
-                  case "View Comments"        => ""
-                  case "Tags"                 => row.task.errorTags
-                  case "Additional Reviewers" => row.review.additionalReviewers.getOrElse("")
-                  case "Meta Review Status"   => row.review.metaReviewStatus
-                  case "Meta Reviewed By"     => row.review.metaReviewedByUsername.getOrElse("")
-                  case "Meta Reviewed At"     => row.review.metaReviewedAt.getOrElse("")
-                }
-                updatedKey
+              (displayedColumns.split(",")).map {
+                key =>
+                  val updatedKey = key match {
+                    case "Internal Id" => row.review.taskId
+                    case "Review Status" =>
+                      Task.reviewStatusMap.get(row.review.reviewStatus.get).get
+                    case "Mapper"      => row.review.reviewRequestedByUsername.getOrElse("")
+                    case "Challenge"   => row.review.challengeName.getOrElse("")
+                    case "Project"     => row.review.projectName.getOrElse("")
+                    case "Mapped On"   => row.task.mappedOn.getOrElse("")
+                    case "Reviewer"    => row.review.reviewedByUsername.getOrElse("")
+                    case "Reviewed On" => row.review.reviewedAt.getOrElse("")
+                    case "Status"      => Task.statusMap.get(row.task.status.get).get
+                    case "Priority"    => Challenge.priorityMap.get(row.task.priority).get
+                    case "Actions" =>
+                      s"[[Task Link=${urlPrefix}challenge/${row.task.parent}/task/${row.review.taskId}]]"
+                    case "View Comments"        => ""
+                    case "Tags"                 => row.task.errorTags
+                    case "Additional Reviewers" => row.review.additionalReviewers.getOrElse("")
+                    case "Meta Review Status"   => row.review.metaReviewStatus
+                    case "Meta Reviewed By"     => row.review.metaReviewedByUsername.getOrElse("")
+                    case "Meta Reviewed At"     => row.review.metaReviewedAt.getOrElse("")
+                  }
+                  updatedKey
               }
             val result = new StringBuilder(mappedData.mkString(","))
             result.toString
-        })
+          })
 
         Result(
           header = ResponseHeader(

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -249,17 +249,23 @@ class TaskReviewController @Inject() (
     * Returns a CSV export of the data displayed in the review table.
     *
     * SearchParameters:
-    *   taskId Optional limit to reviews to equivalent taskId structure
-    *   reviewStatus Optional limit reviews to equivalent reviewStatus
-    *   reviewRequestedByUsername Optional limit reviews to equivalent mapper name
-    *   challengeName Optional limit reviews to equivalent challenge name
-    *   parent Optional limit reviews to equivalent project name
-    *   mappedOn Optional limit reviews to equivalent submittion date
-    *   reviewedBy Optional limit reviews to equivalent reviewer
-    *   reviewedAt Optional limit reviews to equivalent reviewed At date
-    *   status Optional limit reviews to equivalent status
-    *   priority Optional limit reviews to equivalent priority
-    *   additionalReviewers Optional limit reviews to equivalent priority
+    * @param taskId Optional limit reviews to equivalent taskId
+    * @param reviewStatus Optional limit reviews to equivalent reviewStatus
+    * @param mapper Optional limit reviews to equivalent mapper
+    * @param challengeId Optional limit reviews to equivalent challengeId
+    * @param projectIds Optional limit reviews to equivalent projectIds
+    * @param mappedOn Optional limit reviews to equivalent mappedOn
+    * @param reviewedBy Optional limit reviews to equivalent reviewedBy
+    * @param reviewedAt Optional limit reviews to equivalent reviewedAt
+    * @param metaReviewedBy Optional limit reviews to equivalent metaReviewedBy
+    * @param metaReviewStatus Optional limit reviews to equivalent metaReviewStatus
+    * @param status Optional limit reviews to equivalent status
+    * @param priority Optional limit reviews to equivalent priority
+    * @param tagFilter Optional limit reviews to equivalent tagFilter
+    * @param sortBy Optional limit reviews to equivalent sortBy
+    * @param direction Optional limit reviews to equivalent direction
+    * @param displayedColumns Optional limit reviews to equivalent displayedColumns
+    * @param invertedFilters Optional limit reviews to equivalent invertedFilters
     * @param onlySaved Only include saved challenges
     * @return
     */
@@ -285,11 +291,6 @@ class TaskReviewController @Inject() (
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
-        val columnsToDisplay = if (displayedColumns == "") {
-          "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,View Comments,Tags,Additional Reviewers"
-        } else {
-          displayedColumns
-        }
         val invertFiltering        = parseParameterString(invertedFilters)
         val statusFilter           = parseParameterInt(status)
         val reviewStatusFilter     = parseParameterInt(reviewStatus)
@@ -337,7 +338,7 @@ class TaskReviewController @Inject() (
         val urlPrefix = config.getPublicOrigin.fold(s"https://${request.host}/")(_ + "/")
 
         val csvRows = metrics.map { row =>
-          columnsToDisplay.split(",").flatMap {
+          displayedColumns.split(",").flatMap {
             case "Internal Id"   => Seq(row.review.taskId)
             case "Review Status" => Seq(Task.reviewStatusMap(row.review.reviewStatus.get))
             case "Mapper"        => Seq(row.review.reviewRequestedByUsername.getOrElse(""))
@@ -369,7 +370,7 @@ class TaskReviewController @Inject() (
         val csvWriter  = new CSVWriter(csvContent)
 
         // Write header
-        csvWriter.writeRow(columnsToDisplay.split(",").toVector)
+        csvWriter.writeRow(displayedColumns.split(",").toVector)
 
         // Write rows
         csvRows.foreach(row => csvWriter.writeRow(row.toVector))

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -249,24 +249,24 @@ class TaskReviewController @Inject() (
     * Returns a CSV export of the data displayed in the review table.
     *
     * SearchParameters:
-    * @param taskId Reviews to equivalent taskId
-    * @param reviewStatus Reviews to equivalent reviewStatus
-    * @param mapper Reviews to equivalent mapper
-    * @param challengeId Reviews to equivalent challengeId
-    * @param projectIds Reviews to equivalent projectIds
-    * @param mappedOn Reviews to equivalent mappedOn
-    * @param reviewedBy Reviews to equivalent reviewedBy
-    * @param reviewedAt Reviews to equivalent reviewedAt
-    * @param metaReviewedBy Reviews to equivalent metaReviewedBy
-    * @param metaReviewStatus Reviews to equivalent metaReviewStatus
-    * @param status Reviews to equivalent status
-    * @param priority Reviews to equivalent priority
-    * @param tagFilter Reviews to equivalent tagFilter
-    * @param sortBy Sort order direction. Either ASC or DESC
-    * @param direction Reviews to equivalent direction
-    * @param displayedColumns Reviews to equivalent displayedColumns
-    * @param invertedFilters Reviews to equivalent invertedFilters
-    * @param onlySaved Only include saved challenges
+    * @param taskId Reviews to equivalent taskId. Example (Int) - 14
+    * @param reviewStatus Reviews to equivalent reviewStatus. Available Values - 0,1,2,3,4,5,6,7,-1
+    * @param mapper Reviews to equivalent mapper. Example (String) - Username123
+    * @param challengeId Reviews to equivalent challengeId. Example (Int)'s (no spaces) - 23,45,1,12
+    * @param projectIds Reviews to equivalent projectIds. Example (Int)'s (no spaces) - 1,12,3
+    * @param mappedOn Reviews to equivalent mappedOn. format - YYYY-MM-DD
+    * @param reviewedBy Reviews to equivalent reviewedBy. Example - Username567
+    * @param reviewedAt Reviews to equivalent reviewedAt. format - YYYY-MM-DD
+    * @param metaReviewedBy Reviews to equivalent metaReviewedBy. Example - Username987
+    * @param metaReviewStatus Reviews to equivalent metaReviewStatus. Available Values - 2,0,1,2,3,6
+    * @param status Reviews to equivalent status. Available Values - 0,1,2,3,4,5,6,9
+    * @param priority Reviews to equivalent priority. Available Values - 0,1,2
+    * @param tagFilter Reviews to equivalent tagFilter. Example - Geometries
+    * @param sortBy Reviews to equivalent sortBy. (You must pick only one) Available Values - Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,Additional Reviewers
+    * @param direction Sort order direction. Either ASC or DESC.
+    * @param displayedColumns Reviews to equivalent displayedColumns. Available Values - Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,Additional Reviewers
+    * @param invertedFilters Reviews to equivalent invertedFilters. Available Values - cid,priorities,pid,m,trStatus,r,tStatus
+    * @param onlySaved Reviews to equivalent onlySaved.
     * @return
     */
   def extractReviewTableData(
@@ -298,7 +298,6 @@ class TaskReviewController @Inject() (
         val metaReviewStatusFilter = parseParameterInt(metaReviewStatus)
         val projectIdsFilter       = parseParameterLong(projectIds)
         val challengeIdsFilter     = parseParameterLong(challengeId)
-        val tagFiltering           = parseParameterString(tagFilter)
         val taskIdFilter           = parseParameterLong(taskId).map(_.head)
         val mappedOnFilter         = parseParameterString(mappedOn).map(_.head)
         val mapperFilter           = parseParameterString(mapper).map(_.head)
@@ -315,7 +314,6 @@ class TaskReviewController @Inject() (
             ),
             taskParams = params.taskParams.copy(
               taskId = taskIdFilter,
-              taskTags = tagFiltering,
               taskStatus = statusFilter,
               taskReviewStatus = reviewStatusFilter,
               taskPriorities = priorityFilter,
@@ -353,8 +351,6 @@ class TaskReviewController @Inject() (
               Seq(
                 s"[[Task Link=${urlPrefix}challenge/${row.task.parent}/task/${row.review.taskId}]]"
               )
-            case "View Comments"        => Seq("")
-            case "Tags"                 => Seq(row.task.errorTags)
             case "Additional Reviewers" => Seq(row.review.additionalReviewers.getOrElse(""))
             case "Meta Review Status"   => Seq(row.review.metaReviewStatus)
             case "Meta Reviewed By"     => Seq(row.review.metaReviewedByUsername.getOrElse(""))

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -437,7 +437,7 @@ class TaskReviewController @Inject() (
           body = HttpEntity.Strict(
             ByteString(
               s"INTERNAL ID,REVIEW STATUS,MAPPER,CHALLENGE,PROJECT,MAPPED ON,REVIEWER," +
-                s"REVIEWED ON,STATUS,PRIORITY,ACTIONS, COMMENTS,TAGS,ADDITIONAL REVIEWERS\n"
+                s"REVIEWED ON,STATUS,PRIORITY,ACTIONS,COMMENTS,TAGS,ADDITIONAL REVIEWERS\n"
             ).concat(ByteString(seqString.mkString("\n"))),
             Some("text/csv; header=present")
           )

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -13,7 +13,12 @@ import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.model.{Challenge, ChallengeListing, Project, User, Tag, Task}
 import org.maproulette.framework.mixins.{ParentMixin, TagsControllerMixin}
 import org.maproulette.framework.repository.TaskRepository
-import org.maproulette.session.{SessionManager, SearchParameters, SearchLocation, SearchTaskParameters}
+import org.maproulette.session.{
+  SessionManager,
+  SearchParameters,
+  SearchLocation,
+  SearchTaskParameters
+}
 import org.maproulette.utils.Utils
 import play.api.mvc._
 import play.api.libs.json._
@@ -241,8 +246,7 @@ class TaskReviewController @Inject() (
     }
   }
 
-
-   /**
+  /**
     * Returns a CSV export of the data displayed in the review table.
     *
     * SearchParameters:
@@ -260,60 +264,62 @@ class TaskReviewController @Inject() (
     * @param onlySaved Only include saved challenges
     * @return
     */
-    def extractReviewTableData(
-        onlySaved: Boolean = false
-    ): Action[AnyContent] = Action.async { implicit request =>
-      this.sessionManager.userAwareRequest { implicit user =>
-        SearchParameters.withSearch { implicit params =>
-         val allReviewStatuses = List(
+  def extractReviewTableData(
+      onlySaved: Boolean = false
+  ): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      SearchParameters.withSearch { implicit params =>
+        val allReviewStatuses = List(
           0
         )
         val allStatuses = List(
-          Task.STATUS_CREATED,
+          Task.STATUS_CREATED
         )
         val allPriorities = List(
-          Challenge.PRIORITY_LOW  
+          Challenge.PRIORITY_LOW
         )
 
-          val metrics = this.service.getReviewTableData(
-            User.userOrMocked(user),
-            params.copy(
+        val metrics = this.service.getReviewTableData(
+          User.userOrMocked(user),
+          params.copy(
             taskParams = SearchTaskParameters(
               taskReviewStatus = Some(allReviewStatuses),
-              taskStatus= Some(allStatuses),
+              taskStatus = Some(allStatuses),
               taskPriorities = Some(allPriorities)
             )
           ),
-            onlySaved
-          )
+          onlySaved
+        )
 
-          val seqString = metrics.map(row => {
-            val result = new StringBuilder(
-              s"${row.review.taskId},${Task.reviewStatusMap.get(row.review.reviewStatus.get).get}," +
+        val seqString = metrics.map(row => {
+          val result = new StringBuilder(
+            s"${row.review.taskId},${Task.reviewStatusMap.get(row.review.reviewStatus.get).get}," +
               s"${row.review.reviewRequestedByUsername.getOrElse("")},${row.review.challengeName.getOrElse("")}," +
-              s"${row.task.parent},${row.task.mappedOn.getOrElse("")},${row.review.reviewedByUsername.getOrElse("")}," +
+              s"${row.task.parent},${row.task.mappedOn
+                .getOrElse("")},${row.review.reviewedByUsername.getOrElse("")}," +
               s"${row.review.reviewedAt.getOrElse("")},${Task.statusMap.get(row.task.status.get).get}," +
-              s"${Challenge.priorityMap.get(row.task.priority).get},${row.review.additionalReviewers.getOrElse("")}"
-            )
-            result.toString
-          })
-
-          Result(
-            header = ResponseHeader(
-              OK,
-              Map(CONTENT_DISPOSITION -> s"attachment; filename=review_table.csv")
-            ),
-            body = HttpEntity.Strict(
-              ByteString(
-                s"INTERNAL ID,REVIEW STATUS,MAPPER,CHALLENGE,PROJECT,MAPPED ON,REVIEWER," +
-                s"REVIEWED ON,STATUS,PRIORITY,ADDITIONAL REVIEWERS\n"
-              ).concat(ByteString(seqString.mkString("\n"))),
-              Some("text/csv; header=present")
-            )
+              s"${Challenge.priorityMap.get(row.task.priority).get},${row.review.additionalReviewers
+                .getOrElse("")}"
           )
-        }
+          result.toString
+        })
+
+        Result(
+          header = ResponseHeader(
+            OK,
+            Map(CONTENT_DISPOSITION -> s"attachment; filename=review_table.csv")
+          ),
+          body = HttpEntity.Strict(
+            ByteString(
+              s"INTERNAL ID,REVIEW STATUS,MAPPER,CHALLENGE,PROJECT,MAPPED ON,REVIEWER," +
+                s"REVIEWED ON,STATUS,PRIORITY,ADDITIONAL REVIEWERS\n"
+            ).concat(ByteString(seqString.mkString("\n"))),
+            Some("text/csv; header=present")
+          )
+        )
       }
     }
+  }
 
   /**
     * Gets clusters of review tasks. Uses kmeans method in postgis.

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -15,11 +15,7 @@ import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.model.{Challenge, ChallengeListing, Project, User, Tag, Task}
 import org.maproulette.framework.mixins.{ParentMixin, TagsControllerMixin}
 import org.maproulette.framework.repository.TaskRepository
-import org.maproulette.session.{
-  SessionManager,
-  SearchParameters,
-  SearchLocation
-}
+import org.maproulette.session.{SessionManager, SearchParameters, SearchLocation}
 import org.maproulette.utils.Utils
 import play.api.mvc._
 import play.api.libs.json._

--- a/app/org/maproulette/framework/mixins/TaskParserMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskParserMixin.scala
@@ -144,6 +144,7 @@ trait TaskParserMixin {
       get[Option[Long]]("tasks.bundle_id") ~
       get[Option[Boolean]]("tasks.is_bundle_primary") ~
       get[Option[String]]("challenge_name") ~
+      get[Option[String]]("project_name") ~
       get[Option[String]]("review_requested_by_username") ~
       get[Option[String]]("reviewed_by_username") ~
       get[Option[String]]("responses") map {
@@ -151,7 +152,7 @@ trait TaskParserMixin {
             cooperativeWork ~ mappedOn ~ completedTimeSpent ~ completedBy ~ reviewStatus ~ reviewRequestedBy ~
             reviewedBy ~ reviewedAt ~ metaReviewedBy ~ metaReviewStatus ~ metaReviewedAt ~ reviewStartedAt ~
             reviewClaimedBy ~ reviewClaimedAt ~ additionalReviewers ~ errorTags ~
-            priority ~ changesetId ~ bundleId ~ isBundlePrimary ~ challengeName ~ reviewRequestedByUsername ~
+            priority ~ changesetId ~ bundleId ~ isBundlePrimary ~ challengeName ~ projectName ~ reviewRequestedByUsername ~
             reviewedByUsername ~ responses =>
         val values = updateAndRetrieve(id, geojson, location, cooperativeWork)
         TaskWithReview(
@@ -194,6 +195,7 @@ trait TaskParserMixin {
             id,
             reviewStatus,
             challengeName,
+            projectName,
             reviewRequestedBy,
             reviewRequestedByUsername,
             reviewedBy,

--- a/app/org/maproulette/framework/mixins/TaskParserMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskParserMixin.scala
@@ -152,8 +152,8 @@ trait TaskParserMixin {
             cooperativeWork ~ mappedOn ~ completedTimeSpent ~ completedBy ~ reviewStatus ~ reviewRequestedBy ~
             reviewedBy ~ reviewedAt ~ metaReviewedBy ~ metaReviewStatus ~ metaReviewedAt ~ reviewStartedAt ~
             reviewClaimedBy ~ reviewClaimedAt ~ additionalReviewers ~ errorTags ~
-            priority ~ changesetId ~ bundleId ~ isBundlePrimary ~ challengeName ~ projectName ~ reviewRequestedByUsername ~
-            reviewedByUsername ~ responses =>
+            priority ~ changesetId ~ bundleId ~ isBundlePrimary ~ challengeName ~ projectName ~
+            reviewRequestedByUsername ~ reviewedByUsername ~ responses =>
         val values = updateAndRetrieve(id, geojson, location, cooperativeWork)
         TaskWithReview(
           Task(

--- a/app/org/maproulette/framework/model/TaskReview.scala
+++ b/app/org/maproulette/framework/model/TaskReview.scala
@@ -16,6 +16,7 @@ case class TaskReview(
     taskId: Long,
     reviewStatus: Option[Int],
     challengeName: Option[String],
+    projectName: Option[String],
     reviewRequestedBy: Option[Long],
     reviewRequestedByUsername: Option[String],
     reviewedBy: Option[Long],

--- a/app/org/maproulette/framework/repository/TaskHistoryRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskHistoryRepository.scala
@@ -63,6 +63,7 @@ class TaskHistoryRepository @Inject() (override val db: Database) extends Reposi
           reviewStatus,
           None,
           None,
+          None,
           requestedBy,
           None,
           reviewedBy,

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -14,7 +14,7 @@ import anorm.{ToParameterValue, SimpleSql, Row, SqlParser, RowParser, ~, SQL}
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.maproulette.framework.model.{Task, TaskReview, TaskWithReview, User}
-import org.maproulette.framework.psql.{Query, Grouping, GroupField, Order, Paging}
+import org.maproulette.framework.psql.{Query, Grouping, Order, Paging}
 import org.maproulette.framework.mixins.{Locking, TaskParserMixin}
 import org.maproulette.framework.service.UserService
 import org.maproulette.session.SearchParameters

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -14,7 +14,7 @@ import anorm.{ToParameterValue, SimpleSql, Row, SqlParser, RowParser, ~, SQL}
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.maproulette.framework.model.{Task, TaskReview, TaskWithReview, User}
-import org.maproulette.framework.psql.{Query, Grouping, Order, Paging}
+import org.maproulette.framework.psql.{Query, Grouping, OrderField, Order, Paging}
 import org.maproulette.framework.mixins.{Locking, TaskParserMixin}
 import org.maproulette.framework.service.UserService
 import org.maproulette.session.SearchParameters
@@ -466,10 +466,15 @@ class TaskReviewRepository @Inject() (
       direction: String = ""
   ): List[TaskWithReview] = {
     this.withMRConnection { implicit c =>
-      // val orderByClause = if (sortBy.nonEmpty) s"ORDER BY $sortBy $direction" else ""
-      //  ORDER BY id ASC
-      //  ${orderByClause}
-      query
+      val directionByColumn = if (direction == "ASC") {
+        Order.ASC
+      } else {
+        Order.DESC
+      }
+      val querySimple =
+        query.copy(order = Order(List(OrderField(sortBy, directionByColumn, table = Some("")))))
+
+      querySimple
         .build(
           s"""
             SELECT

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -49,7 +49,7 @@ class TaskReviewRepository @Inject() (
       query.build(s"""
         SELECT $retrieveColumnsWithReview,
                challenges.name as challenge_name,
-               p.name as project_name
+               projects.name as project_name,
                mappers.name as review_requested_by_username,
                reviewers.name as reviewed_by_username
         FROM tasks
@@ -57,7 +57,7 @@ class TaskReviewRepository @Inject() (
         LEFT OUTER JOIN users mappers ON task_review.review_requested_by = mappers.id
         LEFT OUTER JOIN users reviewers ON task_review.reviewed_by = reviewers.id
         INNER JOIN challenges ON challenges.id = tasks.parent_id
-        INNER JOIN projects p ON p.id = c.parent_id
+        INNER JOIN projects ON projects.id = challenges.parent_id
         WHERE tasks.id = {taskId}
       """).on(Symbol("taskId") -> taskId).as(this.reviewParser.single)
     }

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -49,7 +49,7 @@ class TaskReviewRepository @Inject() (
       query.build(s"""
         SELECT $retrieveColumnsWithReview,
                challenges.name as challenge_name,
-               p.name as project_name,
+               projects.name as project_name,
                mappers.name as review_requested_by_username,
                reviewers.name as reviewed_by_username
         FROM tasks
@@ -57,7 +57,7 @@ class TaskReviewRepository @Inject() (
         LEFT OUTER JOIN users mappers ON task_review.review_requested_by = mappers.id
         LEFT OUTER JOIN users reviewers ON task_review.reviewed_by = reviewers.id
         INNER JOIN challenges ON challenges.id = tasks.parent_id
-        INNER JOIN projects p ON p.id = c.parent_id
+        INNER JOIN projects ON projects.id = challenges.parent_id
         WHERE tasks.id = {taskId}
       """).on(Symbol("taskId") -> taskId).as(this.reviewParser.single)
     }

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -460,8 +460,15 @@ class TaskReviewRepository @Inject() (
   /**
     * Builds a query to retreive data for the review table data.
     */
-  def executeReviewTableData(query: Query): List[TaskWithReview] = {
+  def executeReviewTableData(
+      query: Query,
+      sortBy: String = "",
+      direction: String = ""
+  ): List[TaskWithReview] = {
     this.withMRConnection { implicit c =>
+      // val orderByClause = if (sortBy.nonEmpty) s"ORDER BY $sortBy $direction" else ""
+      //  ORDER BY id ASC
+      //  ${orderByClause}
       query
         .build(
           s"""

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -49,6 +49,7 @@ class TaskReviewRepository @Inject() (
       query.build(s"""
         SELECT $retrieveColumnsWithReview,
                challenges.name as challenge_name,
+               p.name as project_name
                mappers.name as review_requested_by_username,
                reviewers.name as reviewed_by_username
         FROM tasks
@@ -56,6 +57,7 @@ class TaskReviewRepository @Inject() (
         LEFT OUTER JOIN users mappers ON task_review.review_requested_by = mappers.id
         LEFT OUTER JOIN users reviewers ON task_review.reviewed_by = reviewers.id
         INNER JOIN challenges ON challenges.id = tasks.parent_id
+        INNER JOIN projects p ON p.id = c.parent_id
         WHERE tasks.id = {taskId}
       """).on(Symbol("taskId") -> taskId).as(this.reviewParser.single)
     }
@@ -508,6 +510,7 @@ class TaskReviewRepository @Inject() (
               tasks.bundle_id,
               tasks.is_bundle_primary,
               c.name AS challenge_name,
+              p.display_name AS project_name,
               mappers.name AS review_requested_by_username,
               reviewers.name AS reviewed_by_username,
               NULL AS responses

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -49,7 +49,7 @@ class TaskReviewRepository @Inject() (
       query.build(s"""
         SELECT $retrieveColumnsWithReview,
                challenges.name as challenge_name,
-               p.name as project_name
+               p.name as project_name,
                mappers.name as review_requested_by_username,
                reviewers.name as reviewed_by_username
         FROM tasks

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -468,20 +468,13 @@ class TaskReviewRepository @Inject() (
       direction: String = ""
   ): List[TaskWithReview] = {
     this.withMRConnection { implicit c =>
-      val sortByColumn = if (sortBy == "") {
-        "tasks.id"
-      } else {
-        sortBy
-      }
       val directionByColumn = if (direction == "ASC") {
         Order.ASC
       } else {
         Order.DESC
       }
       val querySimple =
-        query.copy(order =
-          Order(List(OrderField(sortByColumn, directionByColumn, table = Some(""))))
-        )
+        query.copy(order = Order(List(OrderField(sortBy, directionByColumn, table = Some("")))))
 
       querySimple
         .build(

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -14,7 +14,7 @@ import anorm.{ToParameterValue, SimpleSql, Row, SqlParser, RowParser, ~, SQL}
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.maproulette.framework.model.{Task, TaskReview, TaskWithReview, User}
-import org.maproulette.framework.psql.{Query, Grouping, Order, Paging}
+import org.maproulette.framework.psql.{Query, Grouping, GroupField, Order, Paging}
 import org.maproulette.framework.mixins.{Locking, TaskParserMixin}
 import org.maproulette.framework.service.UserService
 import org.maproulette.session.SearchParameters
@@ -454,6 +454,61 @@ class TaskReviewRepository @Inject() (
                     ${if (reviewClaimedAt != null) s"'${reviewClaimedAt}'"
       else "NULL"}, ${if (!errorTags.isEmpty) s"'${errorTags}'" else "NULL"})
          """).executeUpdate()
+    }
+  }
+
+ /**
+    * Builds a query to retreive data for the review table data.
+ */
+def executeReviewTableData(query: Query): List[TaskWithReview] = {
+   this.withMRConnection { implicit c =>
+      val query = Query.simple(List())
+      query
+        .build(
+          s"""
+            SELECT
+              tasks.id,
+              tasks.name,
+              tasks.created,
+              tasks.modified,
+              tasks.parent_id,
+              tasks.instruction,
+              NULL AS geo_location,
+              tasks.status,
+              NULL AS geo_json,
+              NULL AS cooperative_work,
+              tasks.mapped_on,
+              tasks.completed_time_spent,
+              tasks.completed_by,
+              task_review.review_status,
+              task_review.review_requested_by,
+              task_review.reviewed_by,
+              task_review.reviewed_at,
+              task_review.meta_reviewed_by,
+              task_review.meta_review_status,
+              task_review.meta_reviewed_at,
+              task_review.review_started_at,
+              task_review.review_claimed_by,
+              task_review.review_claimed_at,
+              task_review.additional_reviewers,
+              task_review.error_tags,
+              tasks.priority,
+              tasks.changeset_id,
+              tasks.bundle_id,
+              tasks.is_bundle_primary,
+              c.name AS challenge_name,
+              mappers.name AS review_requested_by_username,
+              reviewers.name AS reviewed_by_username,
+              NULL AS responses
+            FROM
+              tasks
+              INNER JOIN task_review ON task_review.task_id = tasks.id
+              LEFT OUTER JOIN users mappers ON task_review.review_requested_by = mappers.id
+              LEFT OUTER JOIN users reviewers ON task_review.reviewed_by = reviewers.id
+              INNER JOIN challenges c ON c.id = tasks.parent_id
+              INNER JOIN projects p ON p.id = c.parent_id
+      """
+      ).as(reviewParser.*)
     }
   }
 }

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -462,7 +462,6 @@ class TaskReviewRepository @Inject() (
     */
   def executeReviewTableData(query: Query): List[TaskWithReview] = {
     this.withMRConnection { implicit c =>
-      val query = Query.simple(List())
       query
         .build(
           s"""

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -457,11 +457,11 @@ class TaskReviewRepository @Inject() (
     }
   }
 
- /**
+  /**
     * Builds a query to retreive data for the review table data.
- */
-def executeReviewTableData(query: Query): List[TaskWithReview] = {
-   this.withMRConnection { implicit c =>
+    */
+  def executeReviewTableData(query: Query): List[TaskWithReview] = {
+    this.withMRConnection { implicit c =>
       val query = Query.simple(List())
       query
         .build(
@@ -508,7 +508,8 @@ def executeReviewTableData(query: Query): List[TaskWithReview] = {
               INNER JOIN challenges c ON c.id = tasks.parent_id
               INNER JOIN projects p ON p.id = c.parent_id
       """
-      ).as(reviewParser.*)
+        )
+        .as(reviewParser.*)
     }
   }
 }

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -197,7 +197,7 @@ class TaskReviewService @Inject() (
       .headOption
   }
 
-    /**
+  /**
     * Gets a list of the data in the Review Table
     *
     * @param user      The user executing the request
@@ -216,11 +216,11 @@ class TaskReviewService @Inject() (
       params,
       4,
       true,
-      onlySaved,
+      onlySaved
     )
 
     this.repository.executeReviewTableData(
-      query,
+      query
     )
   }
 

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -207,6 +207,8 @@ class TaskReviewService @Inject() (
   def getReviewTableData(
       user: User,
       params: SearchParameters,
+      sortBy: String = "",
+      direction: String = "",
       onlySaved: Boolean = false
   ): List[TaskWithReview] = {
     val query = this.setupReviewSearchClause(
@@ -220,7 +222,9 @@ class TaskReviewService @Inject() (
     )
 
     this.repository.executeReviewTableData(
-      query
+      query,
+      sortBy,
+      direction
     )
   }
 

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -197,6 +197,33 @@ class TaskReviewService @Inject() (
       .headOption
   }
 
+    /**
+    * Gets a list of the data in the Review Table
+    *
+    * @param user      The user executing the request
+    * @param searchParameters
+    * @param onlySaved Only include saved challenges
+    */
+  def getReviewTableData(
+      user: User,
+      params: SearchParameters,
+      onlySaved: Boolean = false
+  ): List[TaskWithReview] = {
+    val query = this.setupReviewSearchClause(
+      Query.empty,
+      user,
+      permission,
+      params,
+      4,
+      true,
+      onlySaved,
+    )
+
+    this.repository.executeReviewTableData(
+      query,
+    )
+  }
+
   /**
     * Gets a list of tasks that have requested review (and are in this user's project group)
     *

--- a/build.sbt
+++ b/build.sbt
@@ -92,17 +92,18 @@ libraryDependencies ++= Seq(
   "joda-time"               % "joda-time"       % "2.12.0",
   // TODO(ljdelight): The vividsolutions package was moved to the Eclipse Foundation as LocationTech.
   //                  See the upgrade guide https://github.com/locationtech/jts/blob/master/MIGRATION.md
-  "com.vividsolutions" % "jts"                 % "1.13",
-  "org.wololo"         % "jts2geojson"         % "0.14.3",
-  "org.apache.commons" % "commons-lang3"       % "3.12.0",
-  "commons-codec"      % "commons-codec"       % "1.14",
-  "com.typesafe.play"  %% "play-mailer"        % "8.0.1",
-  "com.typesafe.play"  %% "play-mailer-guice"  % "8.0.1",
-  "com.typesafe.akka"  %% "akka-cluster-tools" % "2.6.20",
-  "com.typesafe.akka"  %% "akka-cluster-typed" % "2.6.20",
-  "com.typesafe.akka"  %% "akka-slf4j"         % "2.6.20",
-  "net.debasishg"      %% "redisclient"        % "3.42",
-  "com.github.blemale" %% "scaffeine"          % "5.2.1"
+  "com.vividsolutions"   % "jts"                 % "1.13",
+  "org.wololo"           % "jts2geojson"         % "0.14.3",
+  "org.apache.commons"   % "commons-lang3"       % "3.12.0",
+  "commons-codec"        % "commons-codec"       % "1.14",
+  "com.typesafe.play"    %% "play-mailer"        % "8.0.1",
+  "com.typesafe.play"    %% "play-mailer-guice"  % "8.0.1",
+  "com.typesafe.akka"    %% "akka-cluster-tools" % "2.6.20",
+  "com.typesafe.akka"    %% "akka-cluster-typed" % "2.6.20",
+  "com.typesafe.akka"    %% "akka-slf4j"         % "2.6.20",
+  "net.debasishg"        %% "redisclient"        % "3.42",
+  "com.github.blemale"   %% "scaffeine"          % "5.2.1",
+  "com.github.tototoshi" %% "scala-csv"          % "1.3.10"
 )
 
 val jacksonVersion         = "2.13.4"

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -352,7 +352,7 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 #     in: query 
 #     description: Optional limit reviews to equivalent priority
 ###
-GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String, mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", status: String, priority: String, tagFilter: String ?= "", onlySaved: Boolean = false)
+GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", status: String ?= "", priority: String ?= "", tagFilter: String ?= "", onlySaved: Boolean = false)
 ###
 # tags: [ Review ]
 # summary: Retrieve a summary of meta-review coverage for reviewers

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -312,6 +312,34 @@ GET     /taskCluster/review                                @org.maproulette.fram
 GET     /tasks/review/mappers/export                          @org.maproulette.framework.controller.TaskReviewMetricsController.extractMapperMetrics(onlySaved:Boolean ?= false)
 ###
 # tags: [ Review ]
+# summary: Retrieve a summary of review coverage for tasks
+# description: This will retrieve a summary of review coverage for each mapper and respond with a csv
+# response:
+#   '200':
+#     description: A CSV file containing the following data "Tasks,Approved,Rejected,ApprovedWithFixes,Disputed,Total"
+# parameters:
+#   - name: tasks
+#     in: query
+#     description: the task ids to search by (extractAllReviewRelatedTasks)
+#   - name: reviewers
+#     in: query
+#     description: the reviewer ids to search by (reviewed_by)
+#   - name: priorities
+#     in: query
+#     description: the priorities to search by
+#   - name: startDate
+#     in: query
+#     description: Whether results should be tasks that have been reviewed after this date (format 'YYYY-MM-DD')
+#   - name: endDate
+#     in: query
+#     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
+#   - name: onlySaved
+#     in: query
+#     description: Only show challenges that have been saved.
+###
+GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(onlySaved:Boolean ?= false)
+###
+# tags: [ Review ]
 # summary: Retrieve a summary of meta-review coverage for reviewers
 # description: This will retrieve a summary of meta-review coverage for each reviewer and respond with a csv
 # responses:

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -318,7 +318,7 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 #   '200':
 #     description: A CSV file containing the following data "internal id,review status,mapper,challenge,project,mapped on,reviewer,reviewed on,status,priority,additional reviewers"
 # parameters:
-#   - name:taskId 
+#   - name: taskId 
 #     in: query 
 #     description: Optional limit to reviews to equivalent taskId structure
 #   - name: reviewStatus 

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -312,30 +312,46 @@ GET     /taskCluster/review                                @org.maproulette.fram
 GET     /tasks/review/mappers/export                          @org.maproulette.framework.controller.TaskReviewMetricsController.extractMapperMetrics(onlySaved:Boolean ?= false)
 ###
 # tags: [ Review ]
-# summary: Retrieve a summary of review coverage for tasks
-# description: This will retrieve a summary of review coverage for each mapper and respond with a csv
+# summary: Retrieve a summary of review coverage for review related tasks
+# description: This will retrieve a summary of review coverage for each review related task and respond with a csv
 # response:
 #   '200':
-#     description: A CSV file containing the following data "Tasks,Approved,Rejected,ApprovedWithFixes,Disputed,Total"
+#     description: A CSV file containing the following data: 
+#     "internal id,review status,mapper,challenge,project,mapped on,reviewer,reviewed on,status,priority,additional reviewers"
 # parameters:
-#   - name: tasks
-#     in: query
-#     description: the task ids to search by (extractAllReviewRelatedTasks)
-#   - name: reviewers
-#     in: query
-#     description: the reviewer ids to search by (reviewed_by)
-#   - name: priorities
-#     in: query
-#     description: the priorities to search by
-#   - name: startDate
-#     in: query
-#     description: Whether results should be tasks that have been reviewed after this date (format 'YYYY-MM-DD')
-#   - name: endDate
-#     in: query
-#     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
-#   - name: onlySaved
-#     in: query
-#     description: Only show challenges that have been saved.
+#   - name:taskId 
+#     in: query 
+#     description: Optional limit to reviews to equivalent taskId structure
+#   - name: reviewStatus 
+#     in: query 
+#     description: Optional limit reviews to equivalent reviewStatus
+#   - name: reviewRequestedByUsername 
+#     in: query 
+#     description: Optional limit reviews to equivalent mapper name
+#   - name: challengeName 
+#     in: query 
+#     description: Optional limit reviews to equivalent challenge name
+#   - name: parent 
+#     in: query 
+#     description: Optional limit reviews to equivalent project name
+#   - name: mappedOn 
+#     in: query 
+#     description: Optional limit reviews to equivalent submittion date
+#   - name: reviewedBy 
+#     in: query 
+#     description: Optional limit reviews to equivalent reviewer
+#   - name: reviewedAt 
+#     in: query 
+#     description: Optional limit reviews to equivalent reviewed At date
+#   - name: status 
+#     in: query 
+#     description: Optional limit reviews to equivalent status
+#   - name: priority 
+#     in: query 
+#     description: Optional limit reviews to equivalent priority
+#   - name: additionalReviewers 
+#     in: query 
+#     description: Optional limit reviews to equivalent priority
 ###
 GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(onlySaved:Boolean ?= false)
 ###

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -316,8 +316,7 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 # description: This will retrieve a summary of review coverage for each review related task and respond with a csv
 # response:
 #   '200':
-#     description: A CSV file containing the following data: 
-#     "internal id,review status,mapper,challenge,project,mapped on,reviewer,reviewed on,status,priority,additional reviewers"
+#     description: A CSV file containing the following data "internal id,review status,mapper,challenge,project,mapped on,reviewer,reviewed on,status,priority,additional reviewers"
 # parameters:
 #   - name:taskId 
 #     in: query 

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -316,43 +316,64 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 # description: This will retrieve a summary of review coverage for each review related task and respond with a csv
 # response:
 #   '200':
-#     description: A CSV file containing the following data "internal id,review status,mapper,challenge,project,mapped on,reviewer,reviewed on,status,priority,additional reviewers"
+#     description: A CSV file containing the following data "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,View Comments,Tags,Additional Reviewers"
 # parameters:
-#   - name: taskId 
-#     in: query 
-#     description: Optional limit to reviews to equivalent taskId structure
-#   - name: reviewStatus 
-#     in: query 
-#     description: Optional limit reviews to equivalent reviewStatus
-#   - name: reviewRequestedByUsername 
-#     in: query 
-#     description: Optional limit reviews to equivalent mapper name
-#   - name: challengeName 
-#     in: query 
-#     description: Optional limit reviews to equivalent challenge name
-#   - name: parent 
-#     in: query 
-#     description: Optional limit reviews to equivalent project name
-#   - name: mappedOn 
-#     in: query 
-#     description: Optional limit reviews to equivalent submittion date
-#   - name: reviewedBy 
-#     in: query 
-#     description: Optional limit reviews to equivalent reviewer
-#   - name: reviewedAt 
-#     in: query 
-#     description: Optional limit reviews to equivalent reviewed At date
-#   - name: status 
-#     in: query 
-#     description: Optional limit reviews to equivalent status
-#   - name: priority 
-#     in: query 
-#     description: Optional limit reviews to equivalent priority
-#   - name: additionalReviewers 
-#     in: query 
-#     description: Optional limit reviews to equivalent priority
+#  - name: taskId
+#    in: query
+#    description: Optional limit reviews to equivalent taskId.
+#  - name: reviewStatus
+#    in: query
+#    description: Optional limit reviews to equivalent reviewStatus.
+#  - name: mapper
+#    in: query
+#    description: Optional limit reviews to equivalent mapper.
+#  - name: challengeId
+#    in: query
+#    description: Optional limit reviews to equivalent challengeId.
+#  - name: projectIds
+#    in: query
+#    description: Optional limit reviews to equivalent projectIds.
+#  - name: mappedOn
+#    in: query
+#    description: Optional limit reviews to equivalent mappedOn.
+#  - name: reviewedBy
+#    in: query
+#    description: Optional limit reviews to equivalent reviewedBy.
+#  - name: reviewedAt
+#    in: query
+#    description: Optional limit reviews to equivalent reviewedAt.
+#  - name: metaReviewedBy
+#    in: query
+#    description: Optional limit reviews to equivalent metaReviewedBy.
+#  - name: metaReviewStatus
+#    in: query
+#    description: Optional limit reviews to equivalent metaReviewStatus.
+#  - name: status
+#    in: query
+#    description: Optional limit reviews to equivalent status.
+#  - name: priority
+#    in: query
+#    description: Optional limit reviews to equivalent priority.
+#  - name: tagFilter
+#    in: query
+#    description: Optional limit reviews to equivalent tagFilter.
+#  - name: sortBy
+#    in: query
+#    description: Optional limit reviews to equivalent sortBy.
+#  - name: direction
+#    in: query
+#    description: Optional limit reviews to equivalent direction.
+#  - name: displayedColumns
+#    in: query
+#    description: Optional limit reviews to equivalent displayedColumns.
+#  - name: invertedFilters
+#    in: query
+#    description: Optional limit reviews to equivalent invertedFilters.
+#  - name: onlySaved
+#    in: query
+#    description: Optional limit reviews to equivalent onlySaved.
 ###
-GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", metaReviewedBy: String ?= "", metaReviewStatus: String ?= "", status: String ?= "", priority: String ?= "", tagFilter: String ?= "", sortBy: String ?= "", direction: String ?= "", displayedColumns: String ?= "", invertedFilters: String ?= "", onlySaved: Boolean = false)
+GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "0,1,2,3,4,5,6,7,-1", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", metaReviewedBy: String ?= "", metaReviewStatus: String ?= "2,0,1,2,3,6", status: String ?= "0,1,2,3,4,5,6,9", priority: String ?= "0,1,2", tagFilter: String ?= "", sortBy: String ?= "mapped_on", direction: String ?= "ASC", displayedColumns: String ?= "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,View Comments,Tags,Additional Reviewers", invertedFilters: String ?= "", onlySaved: Boolean = false)
 ###
 # tags: [ Review ]
 # summary: Retrieve a summary of meta-review coverage for reviewers

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -352,7 +352,7 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 #     in: query 
 #     description: Optional limit reviews to equivalent priority
 ###
-GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(onlySaved:Boolean ?= false)
+GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String, mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", status: String, priority: String, tagFilter: String ?= "", onlySaved: Boolean = false)
 ###
 # tags: [ Review ]
 # summary: Retrieve a summary of meta-review coverage for reviewers

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -320,60 +320,61 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 # parameters:
 #  - name: taskId
 #    in: query
-#    description: Optional limit reviews to equivalent taskId.
+#    description: Reviews to equivalent taskId.
 #  - name: reviewStatus
 #    in: query
-#    description: Optional limit reviews to equivalent reviewStatus.
+#    description: Reviews to equivalent reviewStatus.
 #  - name: mapper
 #    in: query
-#    description: Optional limit reviews to equivalent mapper.
+#    description: Reviews to equivalent mapper.
 #  - name: challengeId
 #    in: query
-#    description: Optional limit reviews to equivalent challengeId.
+#    description: Reviews to equivalent challengeId.
 #  - name: projectIds
 #    in: query
-#    description: Optional limit reviews to equivalent projectIds.
+#    description: Reviews to equivalent projectIds.
+#    required: true
 #  - name: mappedOn
 #    in: query
-#    description: Optional limit reviews to equivalent mappedOn.
+#    description: Reviews to equivalent mappedOn.
 #  - name: reviewedBy
 #    in: query
-#    description: Optional limit reviews to equivalent reviewedBy.
+#    description: Reviews to equivalent reviewedBy.
 #  - name: reviewedAt
 #    in: query
-#    description: Optional limit reviews to equivalent reviewedAt.
+#    description: Reviews to equivalent reviewedAt.
 #  - name: metaReviewedBy
 #    in: query
-#    description: Optional limit reviews to equivalent metaReviewedBy.
+#    description: Reviews to equivalent metaReviewedBy.
 #  - name: metaReviewStatus
 #    in: query
-#    description: Optional limit reviews to equivalent metaReviewStatus.
+#    description: Reviews to equivalent metaReviewStatus.
 #  - name: status
 #    in: query
-#    description: Optional limit reviews to equivalent status.
+#    description: Reviews to equivalent status.
 #  - name: priority
 #    in: query
-#    description: Optional limit reviews to equivalent priority.
+#    description: Reviews to equivalent priority.
 #  - name: tagFilter
 #    in: query
-#    description: Optional limit reviews to equivalent tagFilter.
+#    description: Sort order direction. Either ASC or DESC.
 #  - name: sortBy
 #    in: query
-#    description: Optional limit reviews to equivalent sortBy.
+#    description: Reviews to equivalent sortBy.
 #  - name: direction
 #    in: query
-#    description: Optional limit reviews to equivalent direction.
+#    description: Reviews to equivalent direction.
 #  - name: displayedColumns
 #    in: query
-#    description: Optional limit reviews to equivalent displayedColumns.
+#    description: Reviews to equivalent displayedColumns.
 #  - name: invertedFilters
 #    in: query
-#    description: Optional limit reviews to equivalent invertedFilters.
+#    description: Reviews to equivalent invertedFilters.
 #  - name: onlySaved
 #    in: query
-#    description: Optional limit reviews to equivalent onlySaved.
+#    description: Reviews to equivalent onlySaved.
 ###
-GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "0,1,2,3,4,5,6,7,-1", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", metaReviewedBy: String ?= "", metaReviewStatus: String ?= "2,0,1,2,3,6", status: String ?= "0,1,2,3,4,5,6,9", priority: String ?= "0,1,2", tagFilter: String ?= "", sortBy: String ?= "mapped_on", direction: String ?= "ASC", displayedColumns: String ?= "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,View Comments,Tags,Additional Reviewers", invertedFilters: String ?= "", onlySaved: Boolean = false)
+GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "0,1,2,3,4,5,6,7,-1", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "1", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", metaReviewedBy: String ?= "", metaReviewStatus: String ?= "2,0,1,2,3,6", status: String ?= "0,1,2,3,4,5,6,9", priority: String ?= "0,1,2", tagFilter: String ?= "", sortBy: String ?= "mapped_on", direction: String ?= "ASC", displayedColumns: String ?= "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,View Comments,Tags,Additional Reviewers", invertedFilters: String ?= "", onlySaved: Boolean = false)
 ###
 # tags: [ Review ]
 # summary: Retrieve a summary of meta-review coverage for reviewers

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -352,7 +352,7 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 #     in: query 
 #     description: Optional limit reviews to equivalent priority
 ###
-GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", status: String ?= "", priority: String ?= "", tagFilter: String ?= "", sortBy: String ?= "", direction: String ?= "", invertedFilters: String ?= "", onlySaved: Boolean = false)
+GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", metaReviewedBy: String ?= "", metaReviewStatus: String ?= "", status: String ?= "", priority: String ?= "", tagFilter: String ?= "", sortBy: String ?= "", direction: String ?= "", displayedColumns: String ?= "", invertedFilters: String ?= "", onlySaved: Boolean = false)
 ###
 # tags: [ Review ]
 # summary: Retrieve a summary of meta-review coverage for reviewers

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -316,65 +316,67 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 # description: This will retrieve a summary of review coverage for each review related task and respond with a csv
 # response:
 #   '200':
-#     description: A CSV file containing the following data "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,View Comments,Tags,Additional Reviewers"
+#     description: A CSV file containing the following data "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,Additional Reviewers"
 # parameters:
 #  - name: taskId
 #    in: query
-#    description: Reviews to equivalent taskId.
+#    description: Reviews to equivalent taskId. Example (Int) - 14
 #  - name: reviewStatus
 #    in: query
-#    description: Reviews to equivalent reviewStatus.
+#    description: Reviews to equivalent reviewStatus. Available Values - 0,1,2,3,4,5,6,7,-1
 #  - name: mapper
 #    in: query
-#    description: Reviews to equivalent mapper.
+#    description: Reviews to equivalent mapper. Example (String) - Username123
 #  - name: challengeId
 #    in: query
-#    description: Reviews to equivalent challengeId.
+#    description: Reviews to equivalent challengeId. Example (Int)'s (no spaces) - 23,45,1,12
 #  - name: projectIds
 #    in: query
-#    description: Reviews to equivalent projectIds.
+#    description: Reviews to equivalent projectIds. Example (Int)'s (no spaces) - 1,12,3
 #    required: true
 #  - name: mappedOn
 #    in: query
-#    description: Reviews to equivalent mappedOn.
+#    description: Reviews to equivalent mappedOn. format - YYYY-MM-DD
 #  - name: reviewedBy
 #    in: query
-#    description: Reviews to equivalent reviewedBy.
+#    description: Reviews to equivalent reviewedBy. Example - Username567
 #  - name: reviewedAt
 #    in: query
-#    description: Reviews to equivalent reviewedAt.
+#    description: Reviews to equivalent reviewedAt. format - YYYY-MM-DD
 #  - name: metaReviewedBy
 #    in: query
-#    description: Reviews to equivalent metaReviewedBy.
+#    description: Reviews to equivalent metaReviewedBy. Example - Username987
 #  - name: metaReviewStatus
 #    in: query
-#    description: Reviews to equivalent metaReviewStatus.
+#    description: Reviews to equivalent metaReviewStatus. Available Values - 2,0,1,2,3,6
 #  - name: status
 #    in: query
-#    description: Reviews to equivalent status.
+#    description: Reviews to equivalent status. Available Values - 0,1,2,3,4,5,6,9
 #  - name: priority
 #    in: query
-#    description: Reviews to equivalent priority.
+#    description: Reviews to equivalent priority. Available Values - 0,1,2
 #  - name: tagFilter
 #    in: query
-#    description: Sort order direction. Either ASC or DESC.
+#    description: Reviews to equivalent tagFilter. Example - Geometries
 #  - name: sortBy
 #    in: query
-#    description: Reviews to equivalent sortBy.
+#    description: Reviews to equivalent sortBy. (You must pick only one) Available Values - Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,Additional Reviewers
+#    required: true
 #  - name: direction
 #    in: query
-#    description: Reviews to equivalent direction.
+#    description: Sort order direction. Either ASC or DESC.
+#    required: true
 #  - name: displayedColumns
 #    in: query
-#    description: Reviews to equivalent displayedColumns.
+#    description: Reviews to equivalent displayedColumns. Available Values - Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,Additional Reviewers
 #  - name: invertedFilters
 #    in: query
-#    description: Reviews to equivalent invertedFilters.
+#    description: Reviews to equivalent invertedFilters. Available Values - cid,priorities,pid,m,trStatus,r,tStatus
 #  - name: onlySaved
 #    in: query
 #    description: Reviews to equivalent onlySaved.
 ###
-GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "0,1,2,3,4,5,6,7,-1", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "1", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", metaReviewedBy: String ?= "", metaReviewStatus: String ?= "2,0,1,2,3,6", status: String ?= "0,1,2,3,4,5,6,9", priority: String ?= "0,1,2", tagFilter: String ?= "", sortBy: String ?= "mapped_on", direction: String ?= "ASC", displayedColumns: String ?= "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,View Comments,Tags,Additional Reviewers", invertedFilters: String ?= "", onlySaved: Boolean = false)
+GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "0,1,2,3,4,5,6,7,-1", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", metaReviewedBy: String ?= "", metaReviewStatus: String ?= "2,0,1,2,3,6", status: String ?= "0,1,2,3,4,5,6,9", priority: String ?= "0,1,2", tagFilter: String ?= "", sortBy: String ?= "mapped_on", direction: String ?= "ASC", displayedColumns: String ?= "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,Additional Reviewers", invertedFilters: String ?= "", onlySaved: Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieve a summary of meta-review coverage for reviewers

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -352,7 +352,7 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 #     in: query 
 #     description: Optional limit reviews to equivalent priority
 ###
-GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", status: String ?= "", priority: String ?= "", tagFilter: String ?= "", onlySaved: Boolean = false)
+GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", status: String ?= "", priority: String ?= "", tagFilter: String ?= "", sortBy: String ?= "", direction: String ?= "", invertedFilters: String ?= "", onlySaved: Boolean = false)
 ###
 # tags: [ Review ]
 # summary: Retrieve a summary of meta-review coverage for reviewers


### PR DESCRIPTION
Sets an endpoint to be used by the front end housing all the variables needed for the review table CSV.  Reused the getTaskWithReviewParser, and implementation of a new endpoint. Uses existing configuration for filtering, and sorting.