### PR TITLE
Add barrier against multiple project ids

### DIFF
--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -253,7 +253,7 @@ class TaskReviewController @Inject() (
     * @param reviewStatus Reviews to equivalent reviewStatus. Available Values - 0,1,2,3,4,5,6,7,-1
     * @param mapper Reviews to equivalent mapper. Example (String) - Username123
     * @param challengeId Reviews to equivalent challengeId. Example (Int)'s (no spaces) - 23,45,1,12
-    * @param projectIds Reviews to equivalent projectIds. Example (Int)'s (no spaces) - 1,12,3
+    * @param projectId Reviews to equivalent projectId. Example (Int) - 12
     * @param mappedOn Reviews to equivalent mappedOn. format - YYYY-MM-DD
     * @param reviewedBy Reviews to equivalent reviewedBy. Example - Username567
     * @param reviewedAt Reviews to equivalent reviewedAt. format - YYYY-MM-DD
@@ -274,7 +274,7 @@ class TaskReviewController @Inject() (
       reviewStatus: String,
       mapper: String,
       challengeId: String,
-      projectIds: String,
+      projectId: String,
       mappedOn: String,
       reviewedBy: String,
       reviewedAt: String,
@@ -291,12 +291,15 @@ class TaskReviewController @Inject() (
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
+        if (projectId.split(",").length != 1) {
+          throw new IllegalArgumentException("Exactly one project ID is required.")
+        }
         val invertFiltering        = parseParameterString(invertedFilters)
         val statusFilter           = parseParameterInt(status)
         val reviewStatusFilter     = parseParameterInt(reviewStatus)
         val priorityFilter         = parseParameterInt(priority)
         val metaReviewStatusFilter = parseParameterInt(metaReviewStatus)
-        val projectIdsFilter       = parseParameterLong(projectIds)
+        val projectIdFilter        = parseParameterLong(projectId)
         val challengeIdsFilter     = parseParameterLong(challengeId)
         val taskIdFilter           = parseParameterLong(taskId).map(_.head)
         val mappedOnFilter         = parseParameterString(mappedOn).map(_.head)
@@ -308,7 +311,7 @@ class TaskReviewController @Inject() (
         val metrics = this.service.getReviewTableData(
           User.userOrMocked(user),
           params.copy(
-            projectIds = projectIdsFilter,
+            projectIds = projectIdFilter,
             challengeParams = params.challengeParams.copy(
               challengeIds = challengeIdsFilter
             ),

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -330,9 +330,9 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 #  - name: challengeId
 #    in: query
 #    description: Reviews to equivalent challengeId. Example (Int)'s (no spaces) - 23,45,1,12
-#  - name: projectIds
+#  - name: projectId
 #    in: query
-#    description: Reviews to equivalent projectIds. Example (Int)'s (no spaces) - 1,12,3
+#    description: Reviews to equivalent projectId. Example (Int) - 12
 #    required: true
 #  - name: mappedOn
 #    in: query
@@ -376,7 +376,7 @@ GET     /tasks/review/mappers/export                          @org.maproulette.f
 #    in: query
 #    description: Reviews to equivalent onlySaved.
 ###
-GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "0,1,2,3,4,5,6,7,-1", mapper: String ?= "", challengeId: String ?= "", projectIds: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", metaReviewedBy: String ?= "", metaReviewStatus: String ?= "2,0,1,2,3,6", status: String ?= "0,1,2,3,4,5,6,9", priority: String ?= "0,1,2", tagFilter: String ?= "", sortBy: String ?= "mapped_on", direction: String ?= "ASC", displayedColumns: String ?= "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,Additional Reviewers", invertedFilters: String ?= "", onlySaved: Boolean ?= false)
+GET     /tasks/review/reviewTable/export              @org.maproulette.framework.controller.TaskReviewController.extractReviewTableData(taskId: String ?= "", reviewStatus: String ?= "0,1,2,3,4,5,6,7,-1", mapper: String ?= "", challengeId: String ?= "", projectId: String ?= "", mappedOn: String ?= "", reviewedBy: String ?= "", reviewedAt: String ?= "", metaReviewedBy: String ?= "", metaReviewStatus: String ?= "2,0,1,2,3,6", status: String ?= "0,1,2,3,4,5,6,9", priority: String ?= "0,1,2", tagFilter: String ?= "", sortBy: String ?= "mapped_on", direction: String ?= "ASC", displayedColumns: String ?= "Internal Id,Review Status,Mapper,Challenge,Project,Mapped On,Reviewer,Reviewed On,Status,Priority,Actions,Additional Reviewers", invertedFilters: String ?= "", onlySaved: Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieve a summary of meta-review coverage for reviewers


### PR DESCRIPTION
Implemented to prevent people from using the backend directly to request a CSV of the review table endpoint with multiple multiple project ids.