### PR TITLE
Eliminate use of 'null' in TaskReviewRepository query and improve readability

### DIFF
--- a/app/org/maproulette/framework/mixins/TaskParserMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskParserMixin.scala
@@ -114,6 +114,7 @@ trait TaskParserMixin {
           Option[String]
       )
   ): RowParser[TaskWithReview] = {
+    // tasks fields
     get[Long]("tasks.id") ~
       get[String]("tasks.name") ~
       get[DateTime]("tasks.created") ~
@@ -127,6 +128,12 @@ trait TaskParserMixin {
       get[Option[DateTime]]("tasks.mapped_on") ~
       get[Option[Long]]("tasks.completed_time_spent") ~
       get[Option[Long]]("tasks.completed_by") ~
+      get[Int]("tasks.priority") ~
+      get[Option[Long]]("tasks.changeset_id") ~
+      get[Option[Long]]("tasks.bundle_id") ~
+      get[Option[Boolean]]("tasks.is_bundle_primary") ~
+      get[Option[String]]("responses") ~
+      // task_review fields
       get[Option[Int]]("task_review.review_status") ~
       get[Option[Long]]("task_review.review_requested_by") ~
       get[Option[Long]]("task_review.reviewed_by") ~
@@ -139,21 +146,20 @@ trait TaskParserMixin {
       get[Option[DateTime]]("task_review.review_claimed_at") ~
       get[Option[List[Long]]]("task_review.additional_reviewers") ~
       get[Option[String]]("task_review.error_tags") ~
-      get[Int]("tasks.priority") ~
-      get[Option[Long]]("tasks.changeset_id") ~
-      get[Option[Long]]("tasks.bundle_id") ~
-      get[Option[Boolean]]("tasks.is_bundle_primary") ~
+      // challenges and projects fields
       get[Option[String]]("challenge_name") ~
       get[Option[String]]("project_name") ~
+      // users fields
       get[Option[String]]("review_requested_by_username") ~
-      get[Option[String]]("reviewed_by_username") ~
-      get[Option[String]]("responses") map {
+      get[Option[String]]("reviewed_by_username") map {
       case id ~ name ~ created ~ modified ~ parent_id ~ instruction ~ location ~ status ~ geojson ~
-            cooperativeWork ~ mappedOn ~ completedTimeSpent ~ completedBy ~ reviewStatus ~ reviewRequestedBy ~
+            cooperativeWork ~ mappedOn ~ completedTimeSpent ~ completedBy ~
+            priority ~ changesetId ~ bundleId ~ isBundlePrimary ~ responses ~
+            reviewStatus ~ reviewRequestedBy ~
             reviewedBy ~ reviewedAt ~ metaReviewedBy ~ metaReviewStatus ~ metaReviewedAt ~ reviewStartedAt ~
             reviewClaimedBy ~ reviewClaimedAt ~ additionalReviewers ~ errorTags ~
-            priority ~ changesetId ~ bundleId ~ isBundlePrimary ~ challengeName ~ projectName ~
-            reviewRequestedByUsername ~ reviewedByUsername ~ responses =>
+            challengeName ~ projectName ~
+            reviewRequestedByUsername ~ reviewedByUsername =>
         val values = updateAndRetrieve(id, geojson, location, cooperativeWork)
         TaskWithReview(
           Task(


### PR DESCRIPTION
This resolves NULLs getting introduced into the database by fetching the values. A sample request and its generated sql query are below:
```sql
[debug] [application-akka.actor.default-dispatcher-21] o.m.f.HttpLoggingFilter.$anonfun$apply$1(HttpLoggingFilter.scala:39) - id=118 org.maproulette.framework.controller.TaskReviewController.extractReviewTableData: 'GET /api/v2/tasks/review/reviewTable/export?&reviewStatus=0,1,2,3,4,5,6,7,-1&challengeId=1&projectIds=2&metaReviewStatus=-2,0,1,2,3,6&&status=0,1,2,3,4,5,6,9&&priority=0,1,2&&sortBy=mapped_on&direction=ASC&displayedColumns=Internal%20Id,Review%20Status,Mapper,Challenge,Project,Mapped%20On,Reviewer,Reviewed%20On,Status,Priority,Actions,Additional%20Reviewers&invertedFilters=' took 13ms and returned 200

[info] [scala-execution-context-global-161624] o.j.StatementLogger.info(StatementLogger.java:10) - SELECT
              -- tasks fields
              tasks.id,
              tasks.name,
              tasks.created,
              tasks.modified,
              tasks.parent_id,
              tasks.instruction,
              ST_AsGeoJSON(tasks.location) AS geo_location,
              tasks.status,
              tasks.geojson::TEXT AS geo_json,
              tasks.cooperative_work_json::TEXT AS cooperative_work,
              tasks.mapped_on,
              tasks.completed_time_spent,
              tasks.completed_by,
              tasks.priority,
              tasks.changeset_id,
              tasks.bundle_id,
              tasks.is_bundle_primary,
              tasks.completion_responses::TEXT AS responses,

              -- task_review fields
              task_review.review_status,
              task_review.review_requested_by,
              task_review.reviewed_by,
              task_review.reviewed_at,
              task_review.meta_reviewed_by,
              task_review.meta_review_status,
              task_review.meta_reviewed_at,
              task_review.review_started_at,
              task_review.review_claimed_by,
              task_review.review_claimed_at,
              task_review.additional_reviewers,
              task_review.error_tags,

              -- challenges and projects fields
              c.name AS challenge_name,
              p.display_name AS project_name,

              -- users fields
              mappers.name AS review_requested_by_username,
              reviewers.name AS reviewed_by_username

            FROM tasks
            -- Joining with task_review
            INNER JOIN task_review ON task_review.task_id = tasks.id

            -- Joining with challenges and projects
            INNER JOIN challenges c ON c.id = tasks.parent_id
            INNER JOIN projects p ON p.id = c.parent_id

            -- Joining with users
            LEFT OUTER JOIN users mappers ON task_review.review_requested_by = mappers.id
            LEFT OUTER JOIN users reviewers ON task_review.reviewed_by = reviewers.id
       WHERE (tasks.priority IN (0,1,2)) AND (task_review.review_requested_by IS NOT NULL) AND ((task_review.meta_review_status IN (-2,0,1,2,3,6) OR task_review.meta_review_status IS NULL)) AND (tasks.status IN (0,1,2,3,4,5,6,9)) AND (c.id IN (1)) AND (p.id IN (2)) AND (task_review.review_status IN (0,1,2,3,4,5,6,7,-1)) AND (task_review.review_status <> 5) AND ((tasks.bundle_id IS NULL OR tasks.is_bundle_primary)) AND (((p.enabled AND c.enabled) OR (p.id IN (2)) OR (task_review.review_requested_by = 2) OR (task_review.reviewed_by = 2))) ORDER BY mapped_on ASC;
```