### PR TITLE
Include project version from git in /api/v2/service/info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,15 +9,14 @@ import scala.io.Source
 import scala.util.Using
 
 name := "MapRouletteAPI"
-
-version := "4.0.0"
-
 scalaVersion := "2.13.10"
-
 Universal / packageName := "MapRouletteAPI"
 
 // Developers can run 'sbt format' to easily format their source; this is required to pass a PR build.
 addCommandAlias("format", "scalafmtAll; scalafmtSbt; scalafixAll")
+
+enablePlugins(GitVersioning)
+git.useGitDescribe := true
 
 // Setup BuildInfo plugin to write important build-time values to a generated file (org.maproulette.models.service.info.BuildInfo)
 enablePlugins(BuildInfoPlugin)
@@ -32,6 +31,14 @@ buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion)
 buildInfoKeys += BuildInfoKey.action("buildDate")(LocalDate.now(ZoneOffset.UTC).toString)
 buildInfoKeys += BuildInfoKey.action("javaVersion")(sys.props("java.version"))
 buildInfoKeys += BuildInfoKey.action("javaVendor")(sys.props("java.vendor"))
+buildInfoKeys += BuildInfoKey.action("gitDescribe")(git.gitDescribedVersion.value)
+buildInfoKeys += BuildInfoKey.action("gitHasUncommitedChanges")(git.gitUncommittedChanges.value)
+buildInfoKeys += BuildInfoKey.action("gitHeadCommit")(git.gitHeadCommit.value)
+buildInfoKeys += BuildInfoKey.action("gitHeadCommitUrl")(
+  // The URL will not work if the commit is not pushed to the remote repository.
+  s"https://github.com/maproulette/maproulette-backend/commit/${git.gitHeadCommit.value.get}"
+)
+buildInfoKeys += BuildInfoKey.action("gitHeadCommitDate")(git.gitHeadCommitDate.value)
 
 // Configure scalastyle. This does not run during compile, run it with 'sbt scalastyle' or 'sbt test:scalastyle'.
 Compile / scalastyleConfig := baseDirectory.value / "conf/scalastyle-config.xml"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,3 +17,5 @@ addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.4.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")


### PR DESCRIPTION
Git tags are used to identify releases of the MapRoulette backend. This commit adds a few useful git and version settings in the response of route /api/v2/service/info.

The algorithm to determine the version is described by [sbt-git in their manual](https://github.com/sbt/sbt-git#versioning-with-git), and we use git describe. Here is the snippet from the readme:

    The git plugin will now autogenerate your version using the following rules, in order:

    1. Looks at version-property setting (default to `project.version`), and checks the `sys.props` to see if this has a value.  If so, use it.
    2. Otherwise, looks at the project tags. The first to match the `gitTagToVersionNumberSetting` is used to assign the version.  The default is to look for tags that begin with `v` and a number, and use the number as the version. If there are multiple version tags, it will pick the highest.
    3. If no tags are found either, look at the head commit. We attach this to the `git.baseVersion` setting: "&lt;base-version&gt;.&lt;git commit sha&gt;"
    4. If no head commit is present either (which means this is a brand-new repository with no commits yet), we append the current timestamp to the base version: "&lt;base-version&gt;.&lt;timestamp&gt;".

    This way the version is derived by passing the result of `git describe` to the `gitTagToVersionNumber` function. The `describe` version is built from the last tag + number of commits since tag + short hash.  We recommend adopting the git describe approach.

Example response json:
```json
{
  "compiletime": {
    "name": "MapRouletteAPI",
    "version": "4.4.4-test1",
    "scalaVersion": "2.13.10",
    "sbtVersion": "1.7.2",
    "buildDate": "2023-08-23",
    "javaVersion": "11.0.20",
    "javaVendor": "Eclipse Adoptium",
    "gitDescribe": "4.4.4-test1",
    "gitHasUncommitedChanges": false,
    "gitHeadCommit": "ed5fcead860265a6522da2e80d18ce9b102ab8ca",
    "gitHeadCommitUrl": "https://github.com/maproulette/maproulette-backend/commit/ed5fcead860265a6522da2e80d18ce9b102ab8ca",
    "gitHeadCommitDate": "2023-08-23T00:40:42-0500"
  },
  "runtime": {
    "javaVersion": "11.0.20",
    "javaVendor": "Eclipse Adoptium",
    "startDateTime": "2023-08-23T05:43:08.317823"
  }
}
```