### PR TITLE
add cooperative task bundling rules

### DIFF
--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -57,12 +57,12 @@ class TaskBundleService @Inject() (
         // 1. Must belong to same challenge
         // 2. Cooperative tasks not allowed
         for (task <- tasks) {
-          if (cooperativeWork == true && task.cooperativeWork.isDefined != cooperativeWork) {
+          if (cooperativeWork && task.cooperativeWork.isDefined != cooperativeWork) {
             throw new InvalidException(
               "The main task type is Cooperative. All selected tasks must be Cooperative."
             )
           }
-          if (cooperativeWork == false && task.cooperativeWork.isDefined != cooperativeWork) {
+          if (!cooperativeWork && task.cooperativeWork.isDefined != cooperativeWork) {
             throw new InvalidException(
               "The main task type is not Cooperative. All selected tasks must not be Cooperative."
             )

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -50,18 +50,22 @@ class TaskBundleService @Inject() (
           throw new InvalidException("Must be at least one task to bundle.")
         }
 
-        val challengeId = tasks.head.parent
+        val challengeId     = tasks.head.parent
         val cooperativeWork = tasks.head.cooperativeWork.isDefined
-        
+
         // Verify tasks
         // 1. Must belong to same challenge
         // 2. Cooperative tasks not allowed
         for (task <- tasks) {
           if (cooperativeWork == true && task.cooperativeWork.isDefined != cooperativeWork) {
-            throw new InvalidException("The main task type is Cooperative. All selected tasks must be Cooperative.")
+            throw new InvalidException(
+              "The main task type is Cooperative. All selected tasks must be Cooperative."
+            )
           }
-           if (cooperativeWork == false && task.cooperativeWork.isDefined != cooperativeWork) {
-            throw new InvalidException("The main task type is not Cooperative. All selected tasks must not be Cooperative.")
+          if (cooperativeWork == false && task.cooperativeWork.isDefined != cooperativeWork) {
+            throw new InvalidException(
+              "The main task type is not Cooperative. All selected tasks must not be Cooperative."
+            )
           }
           if (task.parent != challengeId) {
             throw new InvalidException(

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -55,7 +55,7 @@ class TaskBundleService @Inject() (
 
         // Verify tasks
         // 1. Must belong to same challenge
-        // 2. Cooperative tasks not allowed
+        // 2. Must be same task type as main task
         for (task <- tasks) {
           if (cooperativeWork && task.cooperativeWork.isDefined != cooperativeWork) {
             throw new InvalidException(

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -51,13 +51,17 @@ class TaskBundleService @Inject() (
         }
 
         val challengeId = tasks.head.parent
-
+        val cooperativeWork = tasks.head.cooperativeWork.isDefined
+        
         // Verify tasks
         // 1. Must belong to same challenge
         // 2. Cooperative tasks not allowed
         for (task <- tasks) {
-          if (task.cooperativeWork.isDefined) {
-            throw new InvalidException("Cooperative tasks cannot be bundled.")
+          if (cooperativeWork == true && task.cooperativeWork.isDefined != cooperativeWork) {
+            throw new InvalidException("The main task type is Cooperative. All selected tasks must be Cooperative.")
+          }
+           if (cooperativeWork == false && task.cooperativeWork.isDefined != cooperativeWork) {
+            throw new InvalidException("The main task type is not Cooperative. All selected tasks must not be Cooperative.")
           }
           if (task.parent != challengeId) {
             throw new InvalidException(

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -554,7 +554,6 @@ class TaskDAL @Inject() (
     var bundleUpdate = ""
 
     // Find primary task in bundle if we are using a bundle
-    // Also check to make sure they aren't cooperative tasks
     bundleId match {
       case Some(b) =>
         bundleUpdate = ", bundle_id = " + b

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -562,12 +562,6 @@ class TaskDAL @Inject() (
           primaryTaskId match {
             case Some(p) =>
               if (task.id == p) primaryTask = task
-              if (task.cooperativeWork != None) {
-                throw new InvalidException(
-                  "Cannot set task status as part of a bundle on task: " +
-                    task.id + " as it contains cooperative work."
-                )
-              }
             case _ => // do nothing
           }
         }

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -97,21 +97,6 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
       }
     }
 
-    "not create a task Bundle with cooperative tasks" taggedAs (TaskTag) in {
-      val task1 = taskDAL
-        .insert(
-          getTestTask(UUID.randomUUID().toString, challenge.id).copy(
-            cooperativeWork = Some("{\"meta\": {\"version\": 1} }")
-          ),
-          User.superUser
-        )
-
-      // Cannot create a bundle with cooperative tasks
-      intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "bad bundle again", List(task1.id))
-      }
-    }
-
     "get a task Bundle" taggedAs (TaskTag) in {
       val task1 = taskDAL
         .insert(


### PR DESCRIPTION
Resolves issue: https://github.com/maproulette/maproulette3/issues/2062
Backend support for: https://github.com/maproulette/maproulette3/pull/2090

Makes it so a user can now bundle cooperative tasks, but also makes it so that they cant bundle cooperative tasks with other   task types like tag fix or other non cooperative tasks.