### PR TITLE
Support configurable OSM OAuth2 scope

### DIFF
--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -146,7 +146,7 @@ class AuthController @Inject() (
         "client_id"     -> clientId,
         "response_type" -> "code",
         "redirect_uri"  -> config.getMRFrontend,
-        "scope"         -> "read_prefs write_prefs write_api",
+        "scope"         -> config.getOSMOauth.scope,
         "state"         -> state
       )
 

--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -18,7 +18,8 @@ case class OSMOAuth(
     requestTokenURL: String,
     accessTokenURL: String,
     authorizationURL: String,
-    consumerKey: ConsumerKey
+    consumerKey: ConsumerKey,
+    scope: String
 )
 
 case class OSMQLProvider(providerURL: String, requestTimeout: Duration)
@@ -156,7 +157,8 @@ class Config @Inject() (implicit val configuration: Configuration) {
       ConsumerKey(
         this.config.getOptional[String](Config.KEY_OSM_CONSUMER_KEY).get,
         this.config.getOptional[String](Config.KEY_OSM_CONSUMER_SECRET).get
-      )
+      ),
+      this.config.getOptional[String](Config.KEY_OSM_OAUTH2_SCOPE).get
     )
   }
   lazy val getOSMQLProvider: OSMQLProvider = OSMQLProvider(
@@ -357,6 +359,7 @@ object Config {
   val KEY_OSM_AUTHORIZATION_URL         = s"$GROUP_OSM.authorizationURL"
   val KEY_OSM_CONSUMER_KEY              = s"$GROUP_OSM.consumerKey"
   val KEY_OSM_CONSUMER_SECRET           = s"$GROUP_OSM.consumerSecret"
+  val KEY_OSM_OAUTH2_SCOPE              = s"$GROUP_OSM.oauth2Scope"
   val KEY_SKIP_OSM_CHANGESET_SUBMISSION = s"$GROUP_OSM.skipOSMChangesetSubmission"
 
   val GROUP_CHALLENGES                 = "challenges"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -328,6 +328,10 @@ osm {
   consumerKey=${?MR_OAUTH_CONSUMER_KEY}
   consumerSecret="CHANGE_ME"
   consumerSecret=${?MR_OAUTH_CONSUMER_SECRET}
+  # By default, maproulette needs to edit the OSM map and to read/write the user's preferences (write is needed to store the user's api key to OSM).
+  # At times the oauth2 scope needs reduced, for example a local dev or staging environment, to avoid accidentally publishing test data to OSM.
+  oauth2Scope = "read_prefs write_prefs write_api"
+  oauth2Scope = ${?MR_OSM_OAUTH2SCOPE}
 }
 
 # Evolutions


### PR DESCRIPTION
This allows for customization of the OSM OAuth2 scope via the conf (osm.oauth2Scope) or an environment variable (MR_OSM_OAUTH2SCOPE). At times the oauth2 scope needs reduced, for example a local dev or staging environment, to avoid accidentally publishing test data to OSM.