### PR TITLE
Use https in a few URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,4 +338,4 @@ Please fork the project and submit a pull request. See [Postman Docs](postman/RE
 
 Bug and feature requests are best left as an issue right here on Github. For other things, contact maproulette@maproulette.org
 
-MapRoulette now also has a channel #maproulette on the [OSM US Slack community](http://osmus.slack.com). Invite yourself [here](https://osmus-slack.herokuapp.com/)!
+MapRoulette now also has a channel #maproulette on the [OSM US Slack community](https://osmus.slack.com).

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -669,7 +669,7 @@ class ChallengeProvider @Inject() (
   }
 
   /**
-    * parse the query, replace various extended overpass query parameters see http://wiki.openstreetmap.org/wiki/Overpass_turbo/Extended_Overpass_Queries
+    * parse the query, replace various extended overpass query parameters see https://wiki.openstreetmap.org/wiki/Overpass_turbo/Extended_Overpass_Queries
     * Currently do not support {{bbox}} or {{center}}
     *
     * @param query The query to parse

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -312,7 +312,7 @@ include "keepright.conf"
 
 osm {
   ql {
-    provider="http://overpass-api.de/api/interpreter"
+    provider="https://overpass-api.de/api/interpreter"
     timeout=120
   }
   server="https://www.openstreetmap.org"
@@ -341,7 +341,7 @@ osm {
 
 # Logger
 # ~~~~~
-# You can also configure logback (http://logback.qos.ch/),
+# You can also configure logback (https://logback.qos.ch/),
 # by providing an application-logger.xml file in the conf directory.
 
 # Root logger:

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -7,7 +7,7 @@ info:
     name: "maproulette@maproulette.org"
   license:
     name: "Apache License version 2.0"
-    url: "http://www.apache.org/licenses/"
+    url: "https://www.apache.org/licenses/"
 servers:
   - url: /api/v2
 tags:

--- a/docs/challenge_api.md
+++ b/docs/challenge_api.md
@@ -183,7 +183,7 @@ The third option is to provide the GeoJSON directly through the API. This can be
 
 ##### GeoJSON Structure
 
-The GeoJSON provided in any of the above usages must conform to the GeoJSON standards found in [RFC 7946](https://tools.ietf.org/html/rfc7946), you can also find out further information at [geojson.org](http://geojson.org). There is one caveat to this, in that you can also provide LineByLine GeoJSON. That is GeoJSON that as a whole is not valid, as each line in a file contains valid GeoJSON, but each line is a separate GeoJSON entity. The LineByLine GeoJSON is only an option when using files, and cannot be used when supplying the GeoJSON in the body of a Challenge. You can however use the LineByLine GeoJSON when supplying it as the body of the API ```PUT /api/v2/challenge/{id}/addTasks```.
+The GeoJSON provided in any of the above usages must conform to the GeoJSON standards found in [RFC 7946](https://tools.ietf.org/html/rfc7946), you can also find out further information at [geojson.org](https://geojson.org). There is one caveat to this, in that you can also provide LineByLine GeoJSON. That is GeoJSON that as a whole is not valid, as each line in a file contains valid GeoJSON, but each line is a separate GeoJSON entity. The LineByLine GeoJSON is only an option when using files, and cannot be used when supplying the GeoJSON in the body of a Challenge. You can however use the LineByLine GeoJSON when supplying it as the body of the API ```PUT /api/v2/challenge/{id}/addTasks```.
 
 ## Examples
 


### PR DESCRIPTION
A few URLs were using 'http' instead of 'https'. The URLs would upgrade to TLS but it's a good habit to use HTTPS by default and not depend on the connection upgrade.