### PR TITLE
Handle taskWidgetLayout as JSON object in ChallengeController and MRS…

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -1167,7 +1167,7 @@ class ChallengeController @Inject() (
       Utils.insertIntoJson(jsonBody, "reviewSetting", Challenge.REVIEW_SETTING_NOT_REQUIRED)(
         IntWrites
       )
-    jsonBody = Utils.insertIntoJson(jsonBody, "taskWidgetLayout", "")(StringWrites)
+    jsonBody = Utils.insertIntoJson(jsonBody, "taskWidgetLayout", JsObject.empty)(jsValueWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "updateTasks", false)(BooleanWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "changesetUrl", false)(BooleanWrites)
     // if we can't find the parent ID, just use the user's default project instead

--- a/app/org/maproulette/framework/graphql/schemas/MRSchemaTypes.scala
+++ b/app/org/maproulette/framework/graphql/schemas/MRSchemaTypes.scala
@@ -5,6 +5,8 @@
 
 package org.maproulette.framework.graphql.schemas
 
+import play.api.libs.json._
+
 import org.joda.time.DateTime
 import org.maproulette.framework.model._
 import org.maproulette.framework.graphql.fetchers._
@@ -169,6 +171,7 @@ trait MRSchemaTypes {
     deriveObjectType[Unit, ChallengeCreation](ObjectTypeName("ChallengeCreation"))
   implicit val ChallengePriorityType: ObjectType[Unit, ChallengePriority] =
     deriveObjectType[Unit, ChallengePriority](ObjectTypeName("ChallengePriority"))
+
   implicit val ChallengeExtraType: ObjectType[Unit, ChallengeExtra] =
     deriveObjectType[Unit, ChallengeExtra](
       ObjectTypeName("ChallengeExtra"),
@@ -177,7 +180,11 @@ trait MRSchemaTypes {
         Field(
           "taskWidgetLayout",
           StringType,
-          resolve = _.value.taskWidgetLayout.getOrElse("").toString
+          resolve = ctx =>
+            ctx.value.taskWidgetLayout match {
+              case Some(jsValue) => Json.stringify(jsValue)
+              case None          => "{}"
+            }
         )
       )
     )


### PR DESCRIPTION
…chemaTypes

Modified the `ChallengeController` to store `taskWidgetLayout` as an empty JSON object instead of an empty string when the field is not provided in the request.

Updated `MRSchemaTypes` in the GraphQL schema to handle `taskWidgetLayout` as an optional JSON value, defaulting to an empty JSON object when not present.