### PR TITLE
MPExceptionUtil: Log http 403 Forbidden, 404 NotFound, at WARN level without stack

### DIFF
--- a/app/org/maproulette/exception/MPExceptionUtil.scala
+++ b/app/org/maproulette/exception/MPExceptionUtil.scala
@@ -79,10 +79,10 @@ object MPExceptionUtil {
         logger.debug(e.getMessage)
         Unauthorized(Json.toJson(StatusMessage("NotAuthorized", JsString(e.getMessage)))).withNewSession
       case e: IllegalAccessException =>
-        logger.error(e.getMessage, e)
+        logger.warn(e.getMessage)
         Forbidden(Json.toJson(StatusMessage("Forbidden", JsString(e.getMessage))))
       case e: NotFoundException =>
-        logger.error(e.getMessage, e)
+        logger.warn(e.getMessage)
         NotFound(Json.toJson(StatusMessage("NotFound", JsString(e.getMessage))))
       case e: ChangeConflictException =>
         logger.error(e.getMessage, e)


### PR DESCRIPTION
When a request results in an HTTP 403 Forbidden or 404 NotFound, it's logged at an Error level and emits a full stack trace. That's not necessary and this patch changes it to a warning without the full stack trace.