### PR TITLE
Support adding/removing superuser role via API

### DIFF
--- a/app/org/maproulette/jobs/Bootstrap.scala
+++ b/app/org/maproulette/jobs/Bootstrap.scala
@@ -4,8 +4,9 @@
  */
 package org.maproulette.jobs
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.{Inject, Provider, Singleton}
 import org.maproulette.Config
+import org.maproulette.framework.service.UserService
 import org.slf4j.LoggerFactory
 import play.api.db.Database
 import play.api.inject.ApplicationLifecycle
@@ -16,7 +17,12 @@ import scala.concurrent.Future
   * @author mcuthbert
   */
 @Singleton
-class Bootstrap @Inject() (appLifeCycle: ApplicationLifecycle, db: Database, config: Config) {
+class Bootstrap @Inject() (
+    appLifeCycle: ApplicationLifecycle,
+    db: Database,
+    config: Config,
+    userService: Provider[UserService]
+) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -33,6 +39,8 @@ class Bootstrap @Inject() (appLifeCycle: ApplicationLifecycle, db: Database, con
         case _ => // do nothing
       }
     }
+
+    userService.get().promoteSuperUsersInConfig()
   }
 
   appLifeCycle.addStopHook { () =>

--- a/app/org/maproulette/permissions/Permission.scala
+++ b/app/org/maproulette/permissions/Permission.scala
@@ -229,18 +229,13 @@ class Permission @Inject() (
     * Determines if the given user has been configured as a superuser
     */
   def isSuperUser(user: User): Boolean = {
-    if (user.id == User.DEFAULT_SUPER_USER_ID) {
-      return true
-    }
-
-    config.superAccounts.headOption match {
-      case Some("*") => true
-      case Some("")  => false
-      case _ =>
-        config.superAccounts.exists { superId =>
-          superId.toInt == user.osmProfile.id
-        }
-    }
+    // Check if the user is the system super user (id=-999)
+    if (user.id == User.DEFAULT_SUPER_USER_ID) true
+    else
+      config.superAccounts match {
+        case List("*") if config.isDevMode => true
+        case _                             => serviceManager.user.isSuperUser(user.id)
+      }
   }
 
   private def getItem(

--- a/conf/v2_route/user.api
+++ b/conf/v2_route/user.api
@@ -596,3 +596,65 @@ DELETE  /user/:userId/project/:projectId/:role  @org.maproulette.framework.contr
 #           format: int64
 ###
 DELETE  /user/project/:projectId/:role         @org.maproulette.framework.controller.UserController.removeUsersFromProject(projectId:Long, role:Int, isOSMUserId:Boolean ?= false)
+###
+# tags: [ User ]
+# summary: Promote a standard user to a super user
+# description: Promote a standard user, a 'grantee', to a super user role; the requesting user is called a 'grantor'.
+#              This will add the superuser role to the grantee user, allowing the grantee to perform super user actions.
+#              The grantor must be a super user.
+# responses:
+#   '204':
+#     description: The user was promoted to a superuser or was already a superuser
+#   '401':
+#     description: The request lacks authentication
+#   '403':
+#     description: Use 403 Forbidden if the grantor is not authorized (not a superuser)
+#   '404':
+#     description: The grantee was not found
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The MapRoulette user id of the user (the grantee) to be promoted
+###
+PUT     /superuser/:userId                    @org.maproulette.framework.controller.UserController.promoteUserToSuperUser(userId:Long)
+###
+# tags: [ User ]
+# summary: Remove the superuser role from a super user
+# description: Demote a super user, a 'grantee', back to a standard user; the requesting user is called a 'grantor'.
+#              This will remove the superuser role from the grantee.
+#              The grantor must be a superuser.
+# responses:
+#   '204':
+#     description: The superuser role was removed from the user or the user was not a superuser
+#   '401':
+#     description: The request lacks authentication
+#   '403':
+#     description: Use 403 Forbidden if the grantor is not a superuser, or trying to demote themselves or the system superuser
+#   '404':
+#     description: The grantee was not found
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The MapRoulette user id of the user (the grantee) to be promoted
+###
+DELETE  /superuser/:userId                    @org.maproulette.framework.controller.UserController.demoteSuperUserToUser(userId:Long)
+###
+# tags: [ User ]
+# summary: Get all current superusers
+# description: Return a list of MapRoulette user ids who are superusers. The requesting user must be a super user.
+# responses:
+#   '200':
+#     description: The list was obtained and the response contains the list of superusers
+#     content:
+#       application/json:
+#         schema:
+#           type: array
+#           items:
+#             type: integer
+#             uniqueItems: true
+#   '401':
+#     description: The request lacks authentication
+#   '403':
+#     description: Use 403 Forbidden if the user is not authorized to make this request
+###
+GET     /superusers                           @org.maproulette.framework.controller.UserController.getSuperUserIds()

--- a/test/org/maproulette/utils/TestSpec.scala
+++ b/test/org/maproulette/utils/TestSpec.scala
@@ -237,6 +237,7 @@ trait TestSpec extends PlaySpec with MockitoSugar {
 
     // Mocks for users
     when(this.userService.retrieve(-999L)).thenReturn(Some(User.superUser))
+    when(this.userService.isSuperUser(-999L)).thenReturn(true)
     when(this.userService.retrieve(-998L)).thenReturn(Some(User.guestUser))
     doAnswer(_ => Some(User.superUser)).when(this.userService).retrieve(-999L)
     when(this.userService.retrieve(-1L)).thenReturn(Some(User.guestUser))


### PR DESCRIPTION
Create endpoints and service startup code to support adding/removing superuser roles via the API. Only existing superuser are authorized to make the calls.

Check user grants to determine if they're a superuser:

- Javascript
  - `const isSuperUser = data.grants.some(grant => grant.role === -1);`
- Curl
  - `curl -s -H "apiKey: $apiKey" -X GET 'http://localhost:9000/api/v2/user/whoami' | jq '{userId: .id, grants: [.grants[] | select(.role == -1)]}'`


Get the current superusers:

`curl -i -H "apiKey: $apiKey" -X GET 'http://localhost:9000/api/v2/superusers'`


Show that a super cannot demote themselves:

```sh
$ curl -s -i -H "apiKey: $apiKey" -X DELETE 'http://localhost:9000/api/v2/superuser/2'
HTTP/1.1 403 Forbidden
Vary: Origin
Date: Fri, 24 Nov 2023 19:40:06 GMT
Content-Type: application/json
Content-Length: 71

{"status":"Forbidden","message":"A superuser cannot demote themselves"}
```


A super cannot demote the system superuser:

```sh
$ curl -s -i -H "apiKey: $apiKey" -X DELETE 'http://localhost:9000/api/v2/superuser/-999'
HTTP/1.1 403 Forbidden
Vary: Origin
Date: Fri, 24 Nov 2023 19:40:52 GMT
Content-Type: application/json
Content-Length: 85

{"status":"Forbidden","message":"The system super user is not allowed to be removed"}
```


Example showing what it looks like when uid=2 promotes uid=3 to a superuser. The user is fetched before and after to show that the backend user cache is updated.

```sh
$ curl -s -H "apiKey: $apiKey" -X GET 'http://localhost:9000/api/v2/user/3' | jq '{userId: .id, grants: [.grants[] | select(.role == -1)]}'
{
  "userId": 3,
  "grants": []
}


$ curl -s -i -H "apiKey: $apiKey" -X PUT 'http://localhost:9000/api/v2/superuser/3'
HTTP/1.1 204 No Content
Vary: Origin
Date: Fri, 24 Nov 2023 19:41:58 GMT


$ curl -s -i -H "apiKey: $apiKey" -X GET 'http://localhost:9000/api/v2/superusers'
HTTP/1.1 200 OK
Vary: Origin
Date: Fri, 24 Nov 2023 19:42:30 GMT
Content-Type: application/json
Content-Length: 10

[2,3,-999]


$ curl -s -H "apiKey: $apiKey" -X GET 'http://localhost:9000/api/v2/user/3' | jq '{userId: .id, grants: [.grants[] | select(.role == -1)]}'
{
  "userId": 3,
  "grants": [
    {
      "id": 887,
      "name": "Grant superuser role on uid=3 (osm_id=18133), requested by uid=2",
      "grantee": {
        "granteeType": 5,
        "granteeId": 3
      },
      "role": -1,
      "target": {
        "objectType": 0,
        "objectId": 0
      }
    }
  ]
}
```



Example showing what it looks like when uid=3 removes the superuser role from uid=2. The user is fetched before and after to show that the backend user cache is updated.

```sh
$ curl -s -H "apiKey: $apiKey" -X GET 'http://localhost:9000/api/v2/user/2' | jq '{userId: .id, grants: [.grants[] | select(.role == -1)]}'
{
  "userId": 2,
  "grants": [
    {
      "id": 879,
      "name": "User 2 has Superuser",
      "grantee": {
        "granteeType": 5,
        "granteeId": 2
      },
      "role": -1,
      "target": {
        "objectType": 0,
        "objectId": 0
      }
    }
  ]
}



$ curl -s -i -H "apiKey: $apiKey" -X DELETE 'http://localhost:9000/api/v2/superuser/2'
HTTP/1.1 204 No Content
Vary: Origin
Date: Fri, 24 Nov 2023 19:57:29 GMT


$ curl -s -H "apiKey: $apiKey" -X GET 'http://localhost:9000/api/v2/user/2' | jq '{userId: .id, grants: [.grants[] | select(.role == -1)]}'
{
  "userId": 2,
  "grants": []
}


$ curl -s -i -H "apiKey: $apiKey" -X GET 'http://localhost:9000/api/v2/superusers'
HTTP/1.1 200 OK
Vary: Origin
Date: Fri, 24 Nov 2023 19:58:11 GMT
Content-Type: application/json
Content-Length: 8

[3,-999]
```