### PR TITLE
Move comments parameters into Request Body

### DIFF
--- a/app/org/maproulette/framework/controller/CommentController.scala
+++ b/app/org/maproulette/framework/controller/CommentController.scala
@@ -119,7 +119,7 @@ class CommentController @Inject() (
   def add(taskId: Long, actionId: Option[Long]): Action[JsValue] =
     Action.async(parse.json) { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        val commentResult = (request.body \ "comment").asOpt[String]
+        val commentResult = (request.body \ "comment").asOpt[String].map(_.trim)
         commentResult match {
           case Some(comment) =>
             Created(
@@ -141,7 +141,7 @@ class CommentController @Inject() (
   def addChallengeComment(challengeId: Long): Action[JsValue] =
     Action.async(parse.json) { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        val commentResult = (request.body \ "comment").asOpt[String]
+        val commentResult = (request.body \ "comment").asOpt[String].map(_.trim)
         commentResult match {
           case Some(comment) =>
             Created(
@@ -166,7 +166,7 @@ class CommentController @Inject() (
       actionId: Option[Long]
   ): Action[JsValue] = Action.async(parse.json) { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      val commentResult = (request.body \ "comment").asOpt[String]
+      val commentResult = (request.body \ "comment").asOpt[String].map(_.trim)
       commentResult match {
         case Some(comment) =>
           this.commentService.addToBundle(user, bundleId, comment, actionId)
@@ -183,7 +183,7 @@ class CommentController @Inject() (
     */
   def update(commentId: Long): Action[JsValue] = Action.async(parse.json) { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      val commentResult = (request.body \ "comment").asOpt[String]
+      val commentResult = (request.body \ "comment").asOpt[String].map(_.trim)
       commentResult match {
         case Some(comment) =>
           Ok(

--- a/app/org/maproulette/framework/controller/CommentController.scala
+++ b/app/org/maproulette/framework/controller/CommentController.scala
@@ -11,7 +11,7 @@ import javax.inject.Inject
 import org.maproulette.data.ActionManager
 import org.maproulette.framework.service.{CommentService, ServiceManager}
 import org.maproulette.session.SessionManager
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
 
 /**
@@ -115,18 +115,22 @@ class CommentController @Inject() (
     * Adds a comment for a specific task
     *
     * @param taskId   The id for a task
-    * @param comment  The comment the user is leaving
     * @param actionId The action if any associated with the comment
     * @return Ok if successful.
     */
-  def add(taskId: Long, comment: String, actionId: Option[Long]): Action[AnyContent] =
-    Action.async { implicit request =>
+  def add(taskId: Long, actionId: Option[Long]): Action[JsValue] =
+    Action.async(parse.json) { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        Created(
-          Json.toJson(
-            this.commentService.create(user, taskId, URLDecoder.decode(comment, "UTF-8"), actionId)
-          )
-        )
+        val commentResult = (request.body \ "comment").asOpt[String]
+        commentResult match {
+          case Some(comment) =>
+            Created(
+              Json.toJson(
+                this.commentService
+                  .create(user, taskId, URLDecoder.decode(comment, "UTF-8"), actionId)
+              )
+            )
+        }
       }
     }
 
@@ -134,18 +138,21 @@ class CommentController @Inject() (
     * Adds a comment for a specific challenge
     *
     * @param challengeId   The id for a challenge
-    * @param comment  The comment the user is leaving
     * @return Ok if successful.
     */
-  def addChallengeComment(challengeId: Long, comment: String): Action[AnyContent] =
-    Action.async { implicit request =>
+  def addChallengeComment(challengeId: Long): Action[JsValue] =
+    Action.async(parse.json) { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        Created(
-          Json.toJson(
-            this.commentService
-              .createChallengeComment(user, challengeId, URLDecoder.decode(comment, "UTF-8"))
-          )
-        )
+        val commentResult = (request.body \ "comment").asOpt[String]
+        commentResult match {
+          case Some(comment) =>
+            Created(
+              Json.toJson(
+                this.commentService
+                  .createChallengeComment(user, challengeId, URLDecoder.decode(comment, "UTF-8"))
+              )
+            )
+        }
       }
     }
 
@@ -153,18 +160,19 @@ class CommentController @Inject() (
     * Adds a comment for tasks in a bundle
     *
     * @param bundleId   The id for the bundle
-    * @param comment  The comment the user is leaving
     * @param actionId The action if any associated with the comment
     * @return Ok if successful.
     */
   def addToBundleTasks(
       bundleId: Long,
-      comment: String,
       actionId: Option[Long]
-  ): Action[AnyContent] = Action.async { implicit request =>
+  ): Action[JsValue] = Action.async(parse.json) { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      this.commentService.addToBundle(user, bundleId, comment, actionId)
-
+      val commentResult = (request.body \ "comment").asOpt[String]
+      commentResult match {
+        case Some(comment) =>
+          this.commentService.addToBundle(user, bundleId, comment, actionId)
+      }
       Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, bundleId)))
     }
   }

--- a/app/org/maproulette/framework/controller/CommentController.scala
+++ b/app/org/maproulette/framework/controller/CommentController.scala
@@ -179,18 +179,21 @@ class CommentController @Inject() (
     * Updates the original comment
     *
     * @param commentId The ID of the comment to update
-    * @param comment   The comment to update
     * @return
     */
-  def update(commentId: Long, comment: String): Action[AnyContent] = Action.async {
-    implicit request =>
-      this.sessionManager.authenticatedRequest { implicit user =>
-        Ok(
-          Json.toJson(
-            this.commentService.update(commentId, comment, user)
+  def update(commentId: Long): Action[JsValue] = Action.async(parse.json) { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      val commentResult = (request.body \ "comment").asOpt[String]
+      commentResult match {
+        case Some(comment) =>
+          Ok(
+            Json.toJson(
+              this.commentService
+                .update(commentId, comment, user)
+            )
           )
-        )
       }
+    }
   }
 
   /**

--- a/app/org/maproulette/framework/controller/CommentController.scala
+++ b/app/org/maproulette/framework/controller/CommentController.scala
@@ -127,7 +127,7 @@ class CommentController @Inject() (
             Created(
               Json.toJson(
                 this.commentService
-                  .create(user, taskId, URLDecoder.decode(comment, "UTF-8"), actionId)
+                  .create(user, taskId, comment, actionId)
               )
             )
         }
@@ -149,7 +149,7 @@ class CommentController @Inject() (
             Created(
               Json.toJson(
                 this.commentService
-                  .createChallengeComment(user, challengeId, URLDecoder.decode(comment, "UTF-8"))
+                  .createChallengeComment(user, challengeId, comment)
               )
             )
         }
@@ -189,7 +189,7 @@ class CommentController @Inject() (
       this.sessionManager.authenticatedRequest { implicit user =>
         Ok(
           Json.toJson(
-            this.commentService.update(commentId, URLDecoder.decode(comment, "UTF-8"), user)
+            this.commentService.update(commentId, comment, user)
           )
         )
       }

--- a/app/org/maproulette/framework/controller/CommentController.scala
+++ b/app/org/maproulette/framework/controller/CommentController.scala
@@ -5,8 +5,6 @@
 
 package org.maproulette.framework.controller
 
-import java.net.URLDecoder
-
 import javax.inject.Inject
 import org.maproulette.data.ActionManager
 import org.maproulette.framework.service.{CommentService, ServiceManager}

--- a/app/org/maproulette/framework/service/CommentService.scala
+++ b/app/org/maproulette/framework/service/CommentService.scala
@@ -5,8 +5,6 @@
 
 package org.maproulette.framework.service
 
-import java.net.URLDecoder
-
 import javax.inject.{Inject, Singleton}
 import org.apache.commons.lang3.StringUtils
 import org.maproulette.exception.{InvalidException, NotFoundException}

--- a/app/org/maproulette/framework/service/CommentService.scala
+++ b/app/org/maproulette/framework/service/CommentService.scala
@@ -117,7 +117,7 @@ class CommentService @Inject() (
 
     var notify = true
     for (task <- tasks) {
-      this.create(user, task.id, URLDecoder.decode(comment, "UTF-8"), actionId, notify)
+      this.create(user, task.id, comment, actionId, notify)
       notify = false
     }
     bundle

--- a/conf/v2_route/comment.api
+++ b/conf/v2_route/comment.api
@@ -97,14 +97,18 @@ GET     /challengeComments/user/:id                          @org.maproulette.fr
 #   - name: id
 #     in: path
 #     description: The ID for the Task
-#   - name: comment
-#     in: query
-#     description: A URLEncoded comment for the Task
 #   - name: actionId
 #     in: query
 #     description: An optional action ID that may be associated with the comment
+# requestBody:
+#   description: The JSON structure for the Comments body, include the key "comment" to create or update Task comment objects.
+#   required: true
+#   content:
+#     application/json:
+#       schema:
+#         $ref: '#/components/schemas/org.maproulette.framework.model.Comment'
 ###
-POST    /task/:id/comment                           @org.maproulette.framework.controller.CommentController.add(id:Long, comment:String, actionId:Option[Long])
+POST    /task/:id/comment                           @org.maproulette.framework.controller.CommentController.add(id:Long, actionId:Option[Long])
 ###
 # tags: [ Comment ]
 # summary: Adds comment to each Task in a Task Bundle
@@ -122,14 +126,18 @@ POST    /task/:id/comment                           @org.maproulette.framework.c
 #   - name: id
 #     in: path
 #     description: The ID for the bundle
-#   - name: comment
-#     in: query
-#     description: A URLEncoded comment for the Task
 #   - name: actionId
 #     in: query
 #     description: An optional action ID that may be associated with the comment
+# requestBody:
+#   description: The JSON structure for the Comments body, include the key "comment" to create or update Task comment objects.
+#   required: true
+#   content:
+#     application/json:
+#       schema:
+#         $ref: '#/components/schemas/org.maproulette.framework.model.Comment'
 ###
-POST    /taskBundle/:id/comment                     @org.maproulette.framework.controller.CommentController.addToBundleTasks(id:Long, comment:String, actionId:Option[Long])
+POST    /taskBundle/:id/comment                     @org.maproulette.framework.controller.CommentController.addToBundleTasks(id:Long, actionId:Option[Long])
 ###
 # tags: [ Comment ]
 # summary: Update comment on Task
@@ -189,11 +197,15 @@ DELETE  /task/:id/comment/:commentId                @org.maproulette.framework.c
 #   - name: id
 #     in: path
 #     description: The ID for the Challenge
-#   - name: comment
-#     in: query
-#     description: A URLEncoded comment for the Challenge
+# requestBody:
+#   description: The JSON structure for the Comments body, include the key "comment" to create or update Task comment objects.
+#   required: true
+#   content:
+#     application/json:
+#       schema:
+#         $ref: '#/components/schemas/org.maproulette.framework.model.Comment'
 ###
-POST    /challenge/:id/comment                           @org.maproulette.framework.controller.CommentController.addChallengeComment(id:Long, comment:String)
+POST    /challenge/:id/comment                           @org.maproulette.framework.controller.CommentController.addChallengeComment(id:Long)
 ###
 # tags: [ Comment ]
 # summary: Retrieves comments for a Challenge

--- a/conf/v2_route/comment.api
+++ b/conf/v2_route/comment.api
@@ -101,12 +101,19 @@ GET     /challengeComments/user/:id                          @org.maproulette.fr
 #     in: query
 #     description: An optional action ID that may be associated with the comment
 # requestBody:
-#   description: The JSON structure for the Comments body, include the key "comment" to create or update Task comment objects.
+#   description: The JSON structure for the Comments body
 #   required: true
 #   content:
 #     application/json:
 #       schema:
-#         $ref: '#/components/schemas/org.maproulette.framework.model.Comment'
+#         type: object
+#         properties:
+#           comment:
+#             type: string
+#             description: User's comment.
+#             example: "This is an example comment."
+#         required:
+#           - comment
 ###
 POST    /task/:id/comment                           @org.maproulette.framework.controller.CommentController.add(id:Long, actionId:Option[Long])
 ###
@@ -130,12 +137,19 @@ POST    /task/:id/comment                           @org.maproulette.framework.c
 #     in: query
 #     description: An optional action ID that may be associated with the comment
 # requestBody:
-#   description: The JSON structure for the Comments body, include the key "comment" to create or update Task comment objects.
+#   description: The JSON structure for the Comments body
 #   required: true
 #   content:
 #     application/json:
 #       schema:
-#         $ref: '#/components/schemas/org.maproulette.framework.model.Comment'
+#         type: object
+#         properties:
+#           comment:
+#             type: string
+#             description: User's comment.
+#             example: "This is an example comment."
+#         required:
+#           - comment
 ###
 POST    /taskBundle/:id/comment                     @org.maproulette.framework.controller.CommentController.addToBundleTasks(id:Long, actionId:Option[Long])
 ###
@@ -157,11 +171,22 @@ POST    /taskBundle/:id/comment                     @org.maproulette.framework.c
 #   - name: commentId
 #     in: path
 #     description: The ID of the original comment
-#   - name: comment
-#     in: query
-#     description: A URLEncoded comment for the Task
+# requestBody:
+#   description: The JSON structure for the Comments body
+#   required: true
+#   content:
+#     application/json:
+#       schema:
+#         type: object
+#         properties:
+#           comment:
+#             type: string
+#             description: User's comment.
+#             example: "This is an example comment."
+#         required:
+#           - comment
 ###
-PUT    /comment/:commentId                          @org.maproulette.framework.controller.CommentController.update(commentId:Long, comment:String)
+PUT    /comment/:commentId                          @org.maproulette.framework.controller.CommentController.update(commentId:Long)
 ###
 # tags: [ Comment ]
 # summary: Deletes comment from Task
@@ -198,12 +223,19 @@ DELETE  /task/:id/comment/:commentId                @org.maproulette.framework.c
 #     in: path
 #     description: The ID for the Challenge
 # requestBody:
-#   description: The JSON structure for the Comments body, include the key "comment" to create or update Task comment objects.
+#   description: The JSON structure for the Comments body
 #   required: true
 #   content:
 #     application/json:
 #       schema:
-#         $ref: '#/components/schemas/org.maproulette.framework.model.Comment'
+#         type: object
+#         properties:
+#           comment:
+#             type: string
+#             description: User's comment.
+#             example: "This is an example comment."
+#         required:
+#           - comment
 ###
 POST    /challenge/:id/comment                           @org.maproulette.framework.controller.CommentController.addChallengeComment(id:Long)
 ###


### PR DESCRIPTION
Frontend: https://github.com/maproulette/maproulette3/pull/2199
Issue fixed: 
When a user submitted a url with an attached comment including many spaces, using the majority of the character limit of the comment box, the URL encoder would replace every space with “%20”. This would enable there to be more characters in the url than what was displayed in the comment input box. The issue with this is that there is a 2048 character limit to urls, so those extra characters added over every space would often surpass this limit causing the comment to not be saved.

Changes:
Old route to add a comment to Task
`POST    /task/:id/comment/?comment=Example%20Comment&actionId=2 `
New route
`POST    /task/:id/comment/?actionId=2`

Old route to add comment to each Task in Bundle
`POST    /taskBundle/:id/comment?comment=Example%20Comment&actionId=2`
New route
`POST    /taskBundle/:id/comment?actionId=2`

Old route to add a comment to challenge
`POST    /challenge/:id/comment?comment=Example%20Comment`
New route
`POST    /challenge/:id/comment`

Old route to add a comment to challenge
`PUT    /comment/:commentId?comment=Example%20Comment`
New route
`PUT    /comment/:commentId`



The comments are now sent through the request body to eliminate the threat of a url character limit being hit.
```
{
  "comment": "This is an example comment."
}
```