### PR TITLE
Require user for `leaderboard` and `topChallenges`

### DIFF
--- a/conf/v2_route/leaderboard.api
+++ b/conf/v2_route/leaderboard.api
@@ -73,9 +73,15 @@ GET     /data/user/leaderboard                      @org.maproulette.framework.c
 # responses:
 #   '200':
 #     description: List of leaderboard stats
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/org.maproulette.framework.model.LeaderboardUser'
+#   '404':
+#     description: User not found
 # parameters:
 #   - name: userId
-#     in: query
+#     in: path
 #     description: User id to fetch ranking for.
 #     schema:
 #       type: integer
@@ -134,9 +140,15 @@ GET     /data/user/:userId/leaderboard              @org.maproulette.framework.c
 # responses:
 #   '200':
 #     description: Brief list of challenges
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/org.maproulette.framework.model.LeaderboardChallenge'
+#   '404':
+#     description: User not found
 # parameters:
 #   - name: userId
-#     in: query
+#     in: path
 #     description: User id to fetch challenges for.
 #     schema:
 #       type: integer


### PR DESCRIPTION
The below routes were updated to raise an http 404 when the :id does not exist, and corrections were made to the api docs.

- /data/user/:id/leaderboard
- /data/user/:id/topChallenges

In a local dev environment this call should work:
```sh
$ curl -i 'http://localhost:9000/api/v2/data/user/1/leaderboard'
HTTP/1.1 200 OK
Vary: Origin
maproulette-request-id: e5e13630-b1f7-4be8-8b5d-710ec347b5ff
Date: Mon, 08 Jan 2024 23:05:03 GMT
Content-Type: application/json
Content-Length: 2

[]
```

and this call should fail:
```sh
$ curl -i 'http://localhost:9000/api/v2/data/user/999/leaderboard'
HTTP/1.1 404 Not Found
Vary: Origin
maproulette-request-id: 532717d3-bac5-474d-8689-0395d6bbcfda
Date: Mon, 08 Jan 2024 23:04:20 GMT
Content-Type: application/json
Content-Length: 59

{"status":"NotFound","message":"No user found with id 999"}
```