### PR TITLE
Migrate to io.github.play-swagger and update swagger-ui

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ libraryDependencies ++= Seq(
   // NOTE: The swagger-ui package is used to obtain the static distribution of swagger-ui, the files included at runtime
   // and are served by the webserver at route '/assets/lib/swagger-ui/'. We have a few customized swagger files in dir
   // 'public/swagger'.
-  "org.webjars"             % "swagger-ui"      % "4.14.3",
+  "org.webjars"             % "swagger-ui"      % "5.10.3",
   "org.playframework.anorm" %% "anorm"          % "2.6.10",
   "org.playframework.anorm" %% "anorm-postgres" % "2.6.10",
   "org.postgresql"          % "postgresql"      % "42.5.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
 addSbtPlugin("com.beautiful-scala" %% "sbt-scalastyle" % "1.5.1")
 
-addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.11.0")
+addSbtPlugin("io.github.play-swagger" % "sbt-play-swagger" % "1.6.2")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 


### PR DESCRIPTION
Project `com.iheart:sbt-play-swagger` has been migrated to a new repository, so update to use the new name `io.github.play-swagger:sbt-play-swagger:1.6.2`. Also update org.webjars:swagger-ui from 4.14.3 to 5.10.3.