### PR TITLE
add unlocked tasks only restriction to bundling and lock tasks on bundle

### DIFF
--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -42,52 +42,53 @@ class TaskBundleRepository @Inject() (
     * @param name    The name of the task bundle
     * @param lockedTasks The tasks to be added to the bundle
     */
-def insert(
-  user: User,
-  name: String,
-  taskIds: List[Long],
-  verifyTasks: (List[Task]) => Unit
-): TaskBundle = {
-  this.withMRTransaction { implicit c =>
-    val lockedTasks = this.withListLocking(user, Some(TaskType())) { () =>
-      this.taskDAL.retrieveListById(-1, 0)(taskIds)
-    }
+  def insert(
+      user: User,
+      name: String,
+      taskIds: List[Long],
+      verifyTasks: (List[Task]) => Unit
+  ): TaskBundle = {
+    this.withMRTransaction { implicit c =>
+      val lockedTasks = this.withListLocking(user, Some(TaskType())) { () =>
+        this.taskDAL.retrieveListById(-1, 0)(taskIds)
+      }
 
- 
-    val failedTaskIds = taskIds.diff(lockedTasks.map(_.id))
-    if (failedTaskIds.nonEmpty) {
-      throw new InvalidException(s"Bundle creation failed because the following task IDs were locked: ${failedTaskIds.mkString(", ")}")
-    }
+      val failedTaskIds = taskIds.diff(lockedTasks.map(_.id))
+      if (failedTaskIds.nonEmpty) {
+        throw new InvalidException(
+          s"Bundle creation failed because the following task IDs were locked: ${failedTaskIds.mkString(", ")}"
+        )
+      }
 
-    verifyTasks(lockedTasks)
+      verifyTasks(lockedTasks)
 
-    for (task <- lockedTasks) {
-      try {
-        this.lockItem(user, task)
-      } catch {
-        case e: Exception => this.logger.warn(e.getMessage)
+      for (task <- lockedTasks) {
+        try {
+          this.lockItem(user, task)
+        } catch {
+          case e: Exception => this.logger.warn(e.getMessage)
+        }
+      }
+
+      val rowId =
+        SQL"""INSERT INTO bundles (owner_id, name) VALUES (${user.id}, ${name})""".executeInsert()
+      rowId match {
+        case Some(bundleId) =>
+          val sqlQuery =
+            s"""INSERT INTO task_bundles (task_id, bundle_id) VALUES ({taskId}, $bundleId)"""
+          val parameters = lockedTasks.map(task => {
+            Seq[NamedParameter]("taskId" -> task.id)
+          })
+          BatchSql(sqlQuery, parameters.head, parameters.tail: _*).execute()
+          TaskBundle(bundleId, user.id, lockedTasks.map(task => {
+            task.id
+          }), Some(lockedTasks))
+
+        case None =>
+          throw new Exception("Bundle creation failed")
       }
     }
-
-    val rowId =
-      SQL"""INSERT INTO bundles (owner_id, name) VALUES (${user.id}, ${name})""".executeInsert()
-    rowId match {
-      case Some(bundleId) =>
-        val sqlQuery =
-          s"""INSERT INTO task_bundles (task_id, bundle_id) VALUES ({taskId}, $bundleId)"""
-        val parameters = lockedTasks.map(task => {
-          Seq[NamedParameter]("taskId" -> task.id)
-        })
-        BatchSql(sqlQuery, parameters.head, parameters.tail: _*).execute()
-        TaskBundle(bundleId, user.id, lockedTasks.map(task => {
-          task.id
-        }), Some(lockedTasks))
-
-      case None =>
-        throw new Exception("Bundle creation failed")
-    }
   }
-}
 
   /**
     * Removes tasks from a bundle.

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory
 import anorm.ToParameterValue
 import anorm._, postgresql._
 import javax.inject.{Inject, Singleton}
-import org.maproulette.exception.{InvalidException, NotFoundException}
+import org.maproulette.exception.InvalidException
 import org.maproulette.Config
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.BaseParameter


### PR DESCRIPTION
There was an issue where multiple users could add the same task into their bundle, and this would cause problems on submission. The first user to submit their bundle had no issue but any other user that had bundled the same task would would get a "Bundle Failed"  due to that task being officially in a bundle because of that first users submission. To prevent this issue, in this commit we made it so tasks were locked on bundle, and bundles would fail to create if they try to bundle with that now locked task, or any other locked task.