### PR TITLE
add support for relations in overpass queries

### DIFF
--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -553,7 +553,7 @@ class ChallengeProvider @Inject() (
 
                                   case Some("relation") =>
                                     // If it's another relation, recursively extract geometries from it
-                                    val geometries = (element \ "members").as[List[JsValue]].map {
+                                    val geometries = (member \ "members").as[List[JsValue]].map {
                                       member =>
                                         extractGeometries(member)
                                     }

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -530,10 +530,18 @@ class ChallengeProvider @Inject() (
                               }
                               Some(Json.obj("type" -> "LineString", "coordinates" -> points))
                             case Some("relation") =>
-                              // Relations can contain multiple geometries. Here, we're handling them similarly to ways.
-                              val geometries = (element \ "members").as[List[JsValue]].flatMap {
-                                member =>
-                                  (member \ "geometry").asOpt[List[JsValue]]
+                              // Relations can contain a list of both nodes and ways.
+                             val geometries = (element \ "members").as[List[JsValue]].flatMap { member =>
+                                (member \ "type").asOpt[String] match {
+                                  case Some("way") =>
+                                    (member \ "geometry").asOpt[List[JsValue]]
+
+                                  case Some("node") =>
+                                    Some(List(member)) // Wrap single node in a list
+
+                                  case _ =>
+                                    None 
+                                }
                               }
                               val points = geometries.flatMap { geom =>
                                 geom.map { point =>

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -531,17 +531,18 @@ class ChallengeProvider @Inject() (
                               Some(Json.obj("type" -> "LineString", "coordinates" -> points))
                             case Some("relation") =>
                               // Relations can contain a list of both nodes and ways.
-                             val geometries = (element \ "members").as[List[JsValue]].flatMap { member =>
-                                (member \ "type").asOpt[String] match {
-                                  case Some("way") =>
-                                    (member \ "geometry").asOpt[List[JsValue]]
+                              val geometries = (element \ "members").as[List[JsValue]].flatMap {
+                                member =>
+                                  (member \ "type").asOpt[String] match {
+                                    case Some("way") =>
+                                      (member \ "geometry").asOpt[List[JsValue]]
 
-                                  case Some("node") =>
-                                    Some(List(member)) // Wrap single node in a list
+                                    case Some("node") =>
+                                      Some(List(member)) // Wrap single node in a list
 
-                                  case _ =>
-                                    None 
-                                }
+                                    case _ =>
+                                      None
+                                  }
                               }
                               val points = geometries.flatMap { geom =>
                                 geom.map { point =>

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -545,7 +545,7 @@ class ChallengeProvider @Inject() (
                                       }
                                     }
 
-                                  case Some("node") =>\
+                                  case Some("node") =>
                                     Some(
                                       List(
                                         for {

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -534,35 +534,35 @@ class ChallengeProvider @Inject() (
                               def extractGeometries(member: JsValue): Option[JsObject] = {
                                 (member \ "type").asOpt[String] match {
                                   case Some("way") =>
-                                       val points = (member \ "geometry").as[List[JsValue]].map { geom =>
-                                List((geom \ "lon").as[Double], (geom \ "lat").as[Double])
-                              }
-                              Some(Json.obj("type" -> "LineString", "coordinates" -> points))
+                                    val points = (member \ "geometry").as[List[JsValue]].map {
+                                      geom =>
+                                        List((geom \ "lon").as[Double], (geom \ "lat").as[Double])
+                                    }
+                                    Some(Json.obj("type" -> "LineString", "coordinates" -> points))
 
                                   case Some("node") =>
                                     Some(
-                                Json.obj(
-                                  "type" -> "Point",
-                                  "coordinates" -> List(
-                                    (member \ "lon").as[Double],
-                                    (member \ "lat").as[Double]
-                                  )
-                                )
-                              
+                                      Json.obj(
+                                        "type" -> "Point",
+                                        "coordinates" -> List(
+                                          (member \ "lon").as[Double],
+                                          (member \ "lat").as[Double]
+                                        )
+                                      )
                                     )
 
                                   case Some("relation") =>
                                     // If it's another relation, recursively extract geometries from it
                                     val geometries = (element \ "members").as[List[JsValue]].map {
-                                member =>
-                                  extractGeometries(member)
-                              }
-                                 val geometryCollection = Json.obj(
-                                "type"       -> "GeometryCollection",
-                                "geometries" -> geometries
-                              )
+                                      member =>
+                                        extractGeometries(member)
+                                    }
+                                    val geometryCollection = Json.obj(
+                                      "type"       -> "GeometryCollection",
+                                      "geometries" -> geometries
+                                    )
 
-                              Some(geometryCollection)
+                                    Some(geometryCollection)
 
                                   case _ =>
                                     None


### PR DESCRIPTION
When using overpass queries, there are 3 object types: relation, ways, and nodes. Relations are not yet supported, so this PR adds support for relations in overpass queries. Relations are a list of nodes and/or ways and/or relations in one object.