### PR TITLE
add resetTaskBundle endpoint

### DIFF
--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -270,11 +270,10 @@ class TaskBundleController @Inject() (
     */
   def resetTaskBundle(
       id: Long,
-      primaryTaskId: Long,
       taskIds: List[Long]
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      this.serviceManager.taskBundle.resetTaskBundle(user, id, primaryTaskId, taskIds)
+      this.serviceManager.taskBundle.resetTaskBundle(user, id, taskIds)
       Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
     }
   }
@@ -301,12 +300,11 @@ class TaskBundleController @Inject() (
     * Delete bundle.
     *
     * @param id        The id for the bundle
-    * @param primaryId optional task id to no unlock after deleting this bundle
     */
-  def deleteTaskBundle(id: Long, primaryId: Option[Long] = None): Action[AnyContent] =
+  def deleteTaskBundle(id: Long): Action[AnyContent] =
     Action.async { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        this.serviceManager.taskBundle.deleteTaskBundle(user, id, primaryId)
+        this.serviceManager.taskBundle.deleteTaskBundle(user, id)
         Ok
       }
     }

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -298,21 +298,6 @@ class TaskBundleController @Inject() (
   }
 
   /**
-    * Adds tasks to a bundle.
-    *
-    * @param id      The id for the bundle
-    * @param taskIds List of task ids to remove
-    * @return Task Bundle
-    */
-  def bundleTasks(id: Long, taskIds: List[Long]): Action[AnyContent] = Action.async {
-    implicit request =>
-      this.sessionManager.authenticatedRequest { implicit user =>
-        this.serviceManager.taskBundle.bundleTasks(user, id, taskIds)
-        Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
-      }
-  }
-
-  /**
     * Delete bundle.
     *
     * @param id        The id for the bundle

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -254,10 +254,11 @@ class TaskBundleController @Inject() (
     * @param id The id for the bundle
     * @return Task Bundle
     */
-  def getTaskBundle(id: Long): Action[AnyContent] = Action.async { implicit request =>
-    this.sessionManager.authenticatedRequest { implicit user =>
-      Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
-    }
+  def getTaskBundle(id: Long, lockTasks: Boolean): Action[AnyContent] = Action.async {
+    implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id, lockTasks)))
+      }
   }
 
   /**

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -260,18 +260,39 @@ class TaskBundleController @Inject() (
   }
 
   /**
+    *  Resets the bundle to the tasks provided, and unlock all tasks removed from current bundle
+    *
+    * @param bundleId The id of the bundle
+    * @param taskIds The task ids the bundle will reset to
+    * @param primaryTaskId The primary task id of the bundle
+    */
+  def resetTaskBundle(
+      id: Long,
+      primaryTaskId: Long,
+      taskIds: List[Long]
+  ): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      this.serviceManager.taskBundle.resetTaskBundle(user, id, primaryTaskId, taskIds)
+      Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
+    }
+  }
+
+  /**
     * Remove tasks from a bundle.
     *
     * @param id      The id for the bundle
     * @param taskIds List of task ids to remove
     * @return Task Bundle
     */
-  def unbundleTasks(id: Long, taskIds: List[Long]): Action[AnyContent] = Action.async {
-    implicit request =>
-      this.sessionManager.authenticatedRequest { implicit user =>
-        this.serviceManager.taskBundle.unbundleTasks(user, id, taskIds)
-        Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
-      }
+  def unbundleTasks(
+      id: Long,
+      taskIds: List[Long],
+      preventTaskIdUnlocks: List[Long]
+  ): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      this.serviceManager.taskBundle.unbundleTasks(user, id, taskIds, preventTaskIdUnlocks)
+      Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
+    }
   }
 
   /**

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -266,7 +266,6 @@ class TaskBundleController @Inject() (
     *
     * @param bundleId The id of the bundle
     * @param taskIds The task ids the bundle will reset to
-    * @param primaryTaskId The primary task id of the bundle
     */
   def resetTaskBundle(
       id: Long,

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -254,10 +254,10 @@ class TaskBundleController @Inject() (
     * @param id The id for the bundle
     * @return Task Bundle
     */
-  def getTaskBundle(id: Long, lockTasks: Boolean): Action[AnyContent] = Action.async {
+  def getTaskBundle(id: Long): Action[AnyContent] = Action.async {
     implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id, lockTasks)))
+        Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
       }
   }
 

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -254,11 +254,10 @@ class TaskBundleController @Inject() (
     * @param id The id for the bundle
     * @return Task Bundle
     */
-  def getTaskBundle(id: Long): Action[AnyContent] = Action.async {
-    implicit request =>
-      this.sessionManager.authenticatedRequest { implicit user =>
-        Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
-      }
+  def getTaskBundle(id: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
+    }
   }
 
   /**

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -334,7 +334,7 @@ trait SearchParametersMixin {
       case Some(bid) =>
         FilterGroup(
           List(
-            CustomParameter(s"CAST(${Task.TABLE}.${Task.FIELD_BUNDLE_ID} AS TEXT) LIKE '${bid}%'")
+            CustomParameter(s"${Task.TABLE}.${Task.FIELD_BUNDLE_ID} = $bid")
           )
         )
       case _ => FilterGroup(List())

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -40,6 +40,7 @@ trait SearchParametersMixin {
       this.filterChallengeStatus(params),
       this.filterChallengeRequiresLocal(params),
       this.filterBoundingGeometries(params),
+      this.filterBundleId(params),
       // For efficiency can only query on task properties with a parent challenge id
       this.filterTaskProps(params),
       this.filterChallenges(params),
@@ -321,6 +322,22 @@ trait SearchParametersMixin {
           )
         )
       case None => FilterGroup(List())
+    }
+  }
+
+  /**
+    * Filters by bundle id
+    * @param params with inverting on 'bid'
+    */
+  def filterBundleId(params: SearchParameters): FilterGroup = {
+    params.taskParams.bundleId match {
+      case Some(bid) =>
+        FilterGroup(
+          List(
+            CustomParameter(s"CAST(${Task.TABLE}.${Task.FIELD_BUNDLE_ID} AS TEXT) LIKE '${bid}%'")
+          )
+        )
+      case _ => FilterGroup(List())
     }
   }
 

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -127,7 +127,6 @@ class TaskBundleRepository @Inject() (
     *
     * @param bundleId The id of the bundle
     * @param taskIds The task ids the bundle will reset to
-    * @param primaryTaskId The primary task id of the bundle
     */
   def resetTaskBundle(
       user: User,

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -8,7 +8,6 @@ package org.maproulette.framework.repository
 import org.slf4j.LoggerFactory
 
 import anorm.ToParameterValue
-import anorm._
 import anorm.SqlParser.scalar
 
 import org.maproulette.cache.CacheManager

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -297,7 +297,7 @@ class TaskBundleRepository @Inject() (
   def deleteTaskBundle(user: User, bundleId: Long): Unit = {
     this.withMRConnection { implicit c =>
       val primaryTaskId = SQL(
-        """SELECT task_id FROM tasks WHERE bundle_id = {bundleId} AND is_bundle_primary = true"""
+        """SELECT id FROM tasks WHERE bundle_id = {bundleId} AND is_bundle_primary = true"""
       ).on("bundleId" -> bundleId)
         .as(scalar[Long].singleOpt)
         .getOrElse(0L)

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -418,4 +418,21 @@ class TaskBundleRepository @Inject() (
          """).as(this.getTaskParser(this.taskRepository.updateAndRetrieve).*)
     }
   }
+
+  /**
+    * Locks tasks on bundle fetch if task is in an editable status
+    *
+    * @param bundleId The id of the bundle
+    */
+  def lockBundledTasks(user: User, tasks: List[Task]) = {
+    this.withMRConnection { implicit c =>
+      for (task <- tasks) {
+        try {
+          this.lockItem(user, task)
+        } catch {
+          case e: Exception => this.logger.warn(e.getMessage)
+        }
+      }
+    }
+  }
 }

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -418,21 +418,4 @@ class TaskBundleRepository @Inject() (
          """).as(this.getTaskParser(this.taskRepository.updateAndRetrieve).*)
     }
   }
-
-  /**
-    * Fetches a list of tasks associated with the given bundle id.
-    *
-    * @param bundleId The id of the bundle
-    */
-  def lockBundledTasks(user: User, tasks: List[Task]) = {
-    this.withMRConnection { implicit c =>
-      for (task <- tasks) {
-        try {
-          this.lockItem(user, task)
-        } catch {
-          case e: Exception => this.logger.warn(e.getMessage)
-        }
-      }
-    }
-  }
 }

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -94,7 +94,6 @@ class TaskBundleService @Inject() (
     *
     * @param bundleId The id of the bundle
     * @param taskIds The task ids the bundle will reset to
-    * @param primaryTaskId The primary task id of the bundle
     */
   def resetTaskBundle(
       user: User,

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -100,6 +100,14 @@ class TaskBundleService @Inject() (
       bundleId: Long,
       taskIds: List[Long]
   ): TaskBundle = {
+    val bundle = this.getTaskBundle(user, bundleId)
+
+    if (!permission.isSuperUser(user) && bundle.ownerId != user.id) {
+      throw new IllegalAccessException(
+        "Only a super user or the original user can reset this bundle."
+      )
+    }
+
     this.repository.resetTaskBundle(user, bundleId, taskIds)
     this.getTaskBundle(user, bundleId)
   }
@@ -116,6 +124,13 @@ class TaskBundleService @Inject() (
       preventTaskIdUnlocks: List[Long]
   )(): TaskBundle = {
     val bundle = this.getTaskBundle(user, bundleId)
+
+    // Verify permissions to modify this bundle
+    if (!permission.isSuperUser(user) && bundle.ownerId != user.id) {
+      throw new IllegalAccessException(
+        "Only a super user or the original user can delete this bundle."
+      )
+    }
 
     this.repository.unbundleTasks(user, bundleId, taskIds, preventTaskIdUnlocks)
     this.getTaskBundle(user, bundleId)

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -146,7 +146,7 @@ class TaskBundleService @Inject() (
     *
     * @param bundleId The id of the bundle
     */
-  def getTaskBundle(user: User, bundleId: Long, lockTasks: Boolean = false): TaskBundle = {
+  def getTaskBundle(user: User, bundleId: Long): TaskBundle = {
     val filterQuery =
       Query.simple(
         List(
@@ -157,13 +157,12 @@ class TaskBundleService @Inject() (
     val ownerId = this.repository.retrieveOwner(filterQuery)
     val tasks   = this.repository.retrieveTasks(filterQuery)
 
-    if (ownerId.isEmpty) {
-      throw new NotFoundException(s"Task Bundle not found with id $bundleId.")
-    }
-    if (lockTasks) {
-      this.repository.lockBundledTasks(user, tasks)
+    if (ownerId == None) {
+      throw new NotFoundException(s"Task Bundle not found with id ${bundleId}.")
     }
 
-    TaskBundle(bundleId, ownerId.get, tasks.map(_.id), Some(tasks))
+     TaskBundle(bundleId, ownerId.get, tasks.map(task => {
+      task.id
+    }), Some(tasks))
   }
 }

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -84,11 +84,33 @@ class TaskBundleService @Inject() (
   }
 
   /**
+    *  Resets the bundle to the tasks provided, and unlock all tasks removed from current bundle
+    *
+    * @param bundleId The id of the bundle
+    * @param taskIds The task ids the bundle will reset to
+    * @param primaryTaskId The primary task id of the bundle
+    */
+  def resetTaskBundle(
+      user: User,
+      bundleId: Long,
+      primaryTaskId: Long,
+      taskIds: List[Long]
+  ): TaskBundle = {
+    this.repository.resetTaskBundle(user, bundleId, primaryTaskId, taskIds)
+    this.getTaskBundle(user, bundleId)
+  }
+
+  /**
     * Removes tasks from a bundle.
     *
     * @param bundleId The id of the bundle
     */
-  def unbundleTasks(user: User, bundleId: Long, taskIds: List[Long])(): TaskBundle = {
+  def unbundleTasks(
+      user: User,
+      bundleId: Long,
+      taskIds: List[Long],
+      preventTaskIdUnlocks: List[Long]
+  )(): TaskBundle = {
     val bundle = this.getTaskBundle(user, bundleId)
 
     // Verify permissions to modify this bundle
@@ -98,7 +120,7 @@ class TaskBundleService @Inject() (
       )
     }
 
-    this.repository.unbundleTasks(user, bundleId, taskIds)
+    this.repository.unbundleTasks(user, bundleId, taskIds, preventTaskIdUnlocks)
     this.getTaskBundle(user, bundleId)
   }
 

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -161,7 +161,7 @@ class TaskBundleService @Inject() (
       throw new NotFoundException(s"Task Bundle not found with id ${bundleId}.")
     }
 
-     TaskBundle(bundleId, ownerId.get, tasks.map(task => {
+    TaskBundle(bundleId, ownerId.get, tasks.map(task => {
       task.id
     }), Some(tasks))
   }

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -99,10 +99,9 @@ class TaskBundleService @Inject() (
   def resetTaskBundle(
       user: User,
       bundleId: Long,
-      primaryTaskId: Long,
       taskIds: List[Long]
   ): TaskBundle = {
-    this.repository.resetTaskBundle(user, bundleId, primaryTaskId, taskIds)
+    this.repository.resetTaskBundle(user, bundleId, taskIds)
     this.getTaskBundle(user, bundleId)
   }
 
@@ -128,7 +127,7 @@ class TaskBundleService @Inject() (
     *
     * @param bundleId The id of the bundle
     */
-  def deleteTaskBundle(user: User, bundleId: Long, primaryTaskId: Option[Long] = None): Unit = {
+  def deleteTaskBundle(user: User, bundleId: Long): Unit = {
     val bundle = this.getTaskBundle(user, bundleId)
 
     // Verify permissions to delete this bundle
@@ -138,7 +137,7 @@ class TaskBundleService @Inject() (
       this.permission.hasObjectWriteAccess(challenge.get, user)
     }
 
-    this.repository.deleteTaskBundle(user, bundle, primaryTaskId)
+    this.repository.deleteTaskBundle(user, bundle.bundleId)
   }
 
   /**

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -111,18 +111,6 @@ class TaskBundleService @Inject() (
     *
     * @param bundleId The id of the bundle
     */
-  def bundleTasks(user: User, bundleId: Long, taskIds: List[Long])(): TaskBundle = {
-    val bundle = this.getTaskBundle(user, bundleId)
-
-    this.repository.bundleTasks(user, bundleId, taskIds)
-    this.getTaskBundle(user, bundleId)
-  }
-
-  /**
-    * Removes tasks from a bundle.
-    *
-    * @param bundleId The id of the bundle
-    */
   def unbundleTasks(
       user: User,
       bundleId: Long,

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -50,6 +50,7 @@ case class SearchTaskParameters(
     taskStatus: Option[List[Int]] = None,
     taskId: Option[Long] = None,
     taskFeatureId: Option[String] = None,
+    bundleId: Option[Long] = None,
     taskReviewStatus: Option[List[Int]] = None,
     taskProperties: Option[Map[String, String]] = None,
     taskPropertySearchType: Option[String] = None,
@@ -248,6 +249,10 @@ object SearchParameters {
       }
       updated = o.taskParams.taskFeatureId match {
         case Some(c) => Utils.insertIntoJson(updated, "taskFeatureId", c, true)
+        case None    => updated
+      }
+      updated = o.taskParams.bundleId match {
+        case Some(c) => Utils.insertIntoJson(updated, "bundleId", c, true)
         case None    => updated
       }
       updated = o.taskParams.taskReviewStatus match {
@@ -455,6 +460,8 @@ object SearchParameters {
         this.getLongParameter(request.getQueryString("tid"), params.taskParams.taskId),
         //taskFeatureId
         this.getStringParameter(request.getQueryString("fid"), params.taskParams.taskFeatureId),
+        //bundleId
+        this.getLongParameter(request.getQueryString("bid"), params.taskParams.bundleId),
         //taskReviewStatus
         request.getQueryString("trStatus") match {
           case Some(v) => Utils.toIntList(v)

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -44,6 +44,29 @@ POST    /taskBundle                                 @org.maproulette.framework.c
 GET     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long)
 ###
 # tags: [ Bundle ]
+# summary: Resets a Task Bundle
+# description: Resets the bundle to the tasks provided, and unlock all tasks removed from current bundle
+# responses:
+#   '200':
+#     description: Ok with empty body
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Task Bundle
+#     required: true
+#   - name: primaryId
+#     in: query
+#     description: The task ids the bundle will reset to
+#   - name: taskIds
+#     in: query
+#     description: The primary task id of the bundle
+
+###
+POST     /taskBundle/:id/reset                          @org.maproulette.framework.controller.TaskBundleController.resetTaskBundle(id: Long, primaryId: Long, taskIds: List[Long])
+###
+# tags: [ Bundle ]
 # summary: Deletes a Task Bundle
 # description: Deletes a task bundle based on the supplied id
 # responses:
@@ -84,5 +107,9 @@ DELETE     /taskBundle/:id                          @org.maproulette.framework.c
 #     in: query
 #     description: The list of task ids to remove from the bundle
 #     required: true
+#   - name: preventTaskIdUnlocks
+#     in: query
+#     description: The list of task ids to keep locked when removed from bundle
+#     required: true
 ###
-POST       /taskBundle/:id/unbundle                 @org.maproulette.framework.controller.TaskBundleController.unbundleTasks(id:Long, taskIds:List[Long])
+POST       /taskBundle/:id/unbundle                 @org.maproulette.framework.controller.TaskBundleController.unbundleTasks(id:Long, taskIds:List[Long], preventTaskIdUnlocks:List[Long])

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -40,8 +40,11 @@ POST    /taskBundle                                 @org.maproulette.framework.c
 #     in: path
 #     description: The id of the Task Bundle
 #     required: true
+#   - name: lockTasks
+#     in: query
+#     description: The tasks in the bundle will be locked by the user.
 ###
-GET     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long)
+GET     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long, lockTasks:Boolean ?= false)
 ###
 # tags: [ Bundle ]
 # summary: Resets a Task Bundle
@@ -113,3 +116,29 @@ DELETE     /taskBundle/:id                          @org.maproulette.framework.c
 #     required: true
 ###
 POST       /taskBundle/:id/unbundle                 @org.maproulette.framework.controller.TaskBundleController.unbundleTasks(id:Long, taskIds:List[Long], preventTaskIdUnlocks:List[Long])
+###
+# tags: [ Bundle ]
+# summary: Bundles extra tasks to Task Bundle
+# description: Adds a list of tasks to a bundle of tasks
+# responses:
+#   '200':
+#     description: The task bundle with the new increased set of tasks
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/TaskBundle'
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: No Task Bundle with provided ID found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Task Bundle
+#     required: true
+#   - name: taskIds
+#     in: query
+#     description: The list of task ids to add from to bundle
+#     required: true
+###
+POST       /taskBundle/:id/bundle                 @org.maproulette.framework.controller.TaskBundleController.bundleTasks(id:Long, taskIds:List[Long])

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -40,11 +40,8 @@ POST    /taskBundle                                 @org.maproulette.framework.c
 #     in: path
 #     description: The id of the Task Bundle
 #     required: true
-#   - name: lockTasks
-#     in: query
-#     description: The tasks in the bundle will be locked by the user.
 ###
-GET     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long, lockTasks:Boolean ?= false)
+GET     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long)
 ###
 # tags: [ Bundle ]
 # summary: Resets a Task Bundle

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -44,7 +44,7 @@ POST    /taskBundle                                 @org.maproulette.framework.c
 #     in: query
 #     description: The tasks in the bundle will be locked by the user.
 ###
-GET     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long, lockTasks:Boolean ?= false)
+POST     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long, lockTasks:Boolean ?= false)
 ###
 # tags: [ Bundle ]
 # summary: Resets a Task Bundle

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -40,8 +40,11 @@ POST    /taskBundle                                 @org.maproulette.framework.c
 #     in: path
 #     description: The id of the Task Bundle
 #     required: true
+#   - name: lockTasks
+#     in: query
+#     description: The tasks in the bundle will be locked by the user.
 ###
-GET     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long)
+GET     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long, lockTasks:Boolean ?= false)
 ###
 # tags: [ Bundle ]
 # summary: Resets a Task Bundle

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -61,11 +61,10 @@ POST     /taskBundle/:id                             @org.maproulette.framework.
 #     required: true
 #   - name: primaryId
 #     in: query
-#     description: The task ids the bundle will reset to
+#     description: The primary task id of the bundle
 #   - name: taskIds
 #     in: query
-#     description: The primary task id of the bundle
-
+#     description: The task ids the bundle will reset to
 ###
 POST     /taskBundle/:id/reset                          @org.maproulette.framework.controller.TaskBundleController.resetTaskBundle(id: Long, primaryId: Long, taskIds: List[Long])
 ###

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -59,14 +59,11 @@ POST     /taskBundle/:id                             @org.maproulette.framework.
 #     in: path
 #     description: The id of the Task Bundle
 #     required: true
-#   - name: primaryId
-#     in: query
-#     description: The primary task id of the bundle
 #   - name: taskIds
 #     in: query
 #     description: The task ids the bundle will reset to
 ###
-POST     /taskBundle/:id/reset                          @org.maproulette.framework.controller.TaskBundleController.resetTaskBundle(id: Long, primaryId: Long, taskIds: List[Long])
+POST     /taskBundle/:id/reset                          @org.maproulette.framework.controller.TaskBundleController.resetTaskBundle(id: Long, taskIds: List[Long])
 ###
 # tags: [ Bundle ]
 # summary: Deletes a Task Bundle
@@ -81,10 +78,8 @@ POST     /taskBundle/:id/reset                          @org.maproulette.framewo
 #     in: path
 #     description: The id of the Task Bundle
 #     required: true
-#   - name: primaryId
-#     in: query
 ###
-DELETE     /taskBundle/:id                          @org.maproulette.framework.controller.TaskBundleController.deleteTaskBundle(id:Long, primaryId:Option[Long])
+DELETE     /taskBundle/:id                          @org.maproulette.framework.controller.TaskBundleController.deleteTaskBundle(id:Long)
 ###
 # tags: [ Bundle ]
 # summary: Unbundles tasks from Task Bundle

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -116,29 +116,3 @@ DELETE     /taskBundle/:id                          @org.maproulette.framework.c
 #     required: true
 ###
 POST       /taskBundle/:id/unbundle                 @org.maproulette.framework.controller.TaskBundleController.unbundleTasks(id:Long, taskIds:List[Long], preventTaskIdUnlocks:List[Long])
-###
-# tags: [ Bundle ]
-# summary: Bundles extra tasks to Task Bundle
-# description: Adds a list of tasks to a bundle of tasks
-# responses:
-#   '200':
-#     description: The task bundle with the new increased set of tasks
-#     content:
-#       application/json:
-#         schema:
-#           $ref: '#/components/schemas/TaskBundle'
-#   '401':
-#     description: The user is not authorized to make this request
-#   '404':
-#     description: No Task Bundle with provided ID found
-# parameters:
-#   - name: id
-#     in: path
-#     description: The id of the Task Bundle
-#     required: true
-#   - name: taskIds
-#     in: query
-#     description: The list of task ids to add from to bundle
-#     required: true
-###
-POST       /taskBundle/:id/bundle                 @org.maproulette.framework.controller.TaskBundleController.bundleTasks(id:Long, taskIds:List[Long])

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -281,7 +281,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Random user is not allowed to delete this bundle
       an[IllegalAccessException] should be thrownBy
-        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id))()
+        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id), List())()
     }
 
   }

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -210,40 +210,6 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
       response.taskIds.head mustEqual task1.id
     }
 
-    "unbundle a task with permission check" taggedAs (TaskTag) in {
-      val task1 = taskDAL
-        .insert(
-          getTestTask(UUID.randomUUID().toString, challenge.id),
-          User.superUser
-        )
-      var task2 = taskDAL
-        .insert(
-          getTestTask(UUID.randomUUID().toString, challenge.id),
-          User.superUser
-        )
-
-      val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for unbundle", Some(task1.id), List(task1.id, task2.id))
-
-      // tasks.bundle_id is NOT set until setTaskStatus is called
-      taskDAL.setTaskStatus(
-        List(task1, task2),
-        Task.STATUS_FIXED,
-        User.superUser,
-        bundleId = Some(bundle.bundleId),
-        primaryTaskId = Some(task1.id)
-      )
-
-      val randomUser = serviceManager.user.create(
-        this.getTestUser(1022345, "RandomOUser2"),
-        User.superUser
-      )
-
-      // Random user is not allowed to delete this bundle
-      an[IllegalAccessException] should be thrownBy
-        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id), List(task1.id))()
-    }
-
   }
 
   override implicit val projectTestName: String = "TaskBundleSpecProject"

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -35,7 +35,12 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val response =
-        this.service.createTaskBundle(User.superUser, "my bundle", Some(task1.id), List(task1.id, task2.id))
+        this.service.createTaskBundle(
+          User.superUser,
+          "my bundle",
+          Some(task1.id),
+          List(task1.id, task2.id)
+        )
       response.taskIds.length mustEqual 2
 
       // tasks.bundle_id is NOT set until setTaskStatus is called!!!
@@ -51,7 +56,12 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Cannot create a bundle with tasks already assigned
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "my bundle again", Some(task1.id), List(task1.id, task2.id))
+        this.service.createTaskBundle(
+          User.superUser,
+          "my bundle again",
+          Some(task1.id),
+          List(task1.id, task2.id)
+        )
       }
     }
 
@@ -93,7 +103,12 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Cannot create a bundle with tasks from different challenges
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "bad bundle", Some(task1.id), List(task1.id, task2.id))
+        this.service.createTaskBundle(
+          User.superUser,
+          "bad bundle",
+          Some(task1.id),
+          List(task1.id, task2.id)
+        )
       }
     }
 
@@ -110,7 +125,12 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle =
-        this.service.createTaskBundle(User.superUser, "my bundle for get", Some(task1.id), List(task1.id, task2.id))
+        this.service.createTaskBundle(
+          User.superUser,
+          "my bundle for get",
+          Some(task1.id),
+          List(task1.id, task2.id)
+        )
 
       val response = this.service.getTaskBundle(User.superUser, bundle.bundleId)
       response.bundleId mustEqual bundle.bundleId
@@ -130,7 +150,12 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for delete", Some(task1.id), List(task1.id, task2.id))
+        .createTaskBundle(
+          User.superUser,
+          "my bundle for delete",
+          Some(task1.id),
+          List(task1.id, task2.id)
+        )
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -159,7 +184,12 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for delete", Some(task1.id), List(task1.id, task2.id))
+        .createTaskBundle(
+          User.superUser,
+          "my bundle for delete",
+          Some(task1.id),
+          List(task1.id, task2.id)
+        )
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -193,7 +223,12 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for unbundle", Some(task1.id), List(task1.id, task2.id))
+        .createTaskBundle(
+          User.superUser,
+          "my bundle for unbundle",
+          Some(task1.id),
+          List(task1.id, task2.id)
+        )
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -38,6 +38,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         this.service.createTaskBundle(
           User.superUser,
           "my bundle",
+          Some(task1.id),
           List(task1.id, task2.id)
         )
       response.taskIds.length mustEqual 2
@@ -58,6 +59,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         this.service.createTaskBundle(
           User.superUser,
           "my bundle again",
+          Some(task1.id),
           List(task1.id, task2.id)
         )
       }
@@ -66,7 +68,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
     "not create a task Bundle with no tasks" taggedAs (TaskTag) in {
       // Cannot create a bundle with no tasks
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "my bundle again", List())
+        this.service.createTaskBundle(User.superUser, "my bundle again", Some(0), List())
       }
     }
 
@@ -104,6 +106,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         this.service.createTaskBundle(
           User.superUser,
           "bad bundle",
+          Some(task1.id),
           List(task1.id, task2.id)
         )
       }
@@ -125,6 +128,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         this.service.createTaskBundle(
           User.superUser,
           "my bundle for get",
+          Some(task1.id),
           List(task1.id, task2.id)
         )
 
@@ -149,6 +153,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         .createTaskBundle(
           User.superUser,
           "my bundle for delete",
+          Some(task1.id),
           List(task1.id, task2.id)
         )
 
@@ -182,6 +187,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         .createTaskBundle(
           User.superUser,
           "my bundle for delete",
+          Some(task1.id),
           List(task1.id, task2.id)
         )
 
@@ -220,6 +226,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         .createTaskBundle(
           User.superUser,
           "my bundle for unbundle",
+          Some(task1.id),
           List(task1.id, task2.id)
         )
 

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -245,6 +245,45 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
       response.taskIds.head mustEqual task1.id
     }
 
+    "unbundle a task with permission check" taggedAs (TaskTag) in {
+      val task1 = taskDAL
+        .insert(
+          getTestTask(UUID.randomUUID().toString, challenge.id),
+          User.superUser
+        )
+      var task2 = taskDAL
+        .insert(
+          getTestTask(UUID.randomUUID().toString, challenge.id),
+          User.superUser
+        )
+
+      val bundle = this.service
+        .createTaskBundle(
+          User.superUser,
+          "my bundle for unbundle",
+          Some(task1.id),
+          List(task1.id, task2.id)
+        )
+
+      // tasks.bundle_id is NOT set until setTaskStatus is called
+      taskDAL.setTaskStatus(
+        List(task1, task2),
+        Task.STATUS_FIXED,
+        User.superUser,
+        bundleId = Some(bundle.bundleId),
+        primaryTaskId = Some(task1.id)
+      )
+
+      val randomUser = serviceManager.user.create(
+        this.getTestUser(1022345, "RandomOUser2"),
+        User.superUser
+      )
+
+      // Random user is not allowed to delete this bundle
+      an[IllegalAccessException] should be thrownBy
+        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id))()
+    }
+
   }
 
   override implicit val projectTestName: String = "TaskBundleSpecProject"

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -35,7 +35,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val response =
-        this.service.createTaskBundle(User.superUser, "my bundle", List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "my bundle",Some(0),  List(task1.id, task2.id))
       response.taskIds.length mustEqual 2
 
       // tasks.bundle_id is NOT set until setTaskStatus is called!!!
@@ -51,14 +51,14 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Cannot create a bundle with tasks already assigned
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "my bundle again", List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "my bundle again", Some(0), List(task1.id, task2.id))
       }
     }
 
     "not create a task Bundle with no tasks" taggedAs (TaskTag) in {
       // Cannot create a bundle with no tasks
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "my bundle again", List())
+        this.service.createTaskBundle(User.superUser, "my bundle again",Some(0),  List())
       }
     }
 
@@ -93,7 +93,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Cannot create a bundle with tasks from different challenges
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "bad bundle", List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "bad bundle", Some(0), List(task1.id, task2.id))
       }
     }
 
@@ -110,7 +110,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle =
-        this.service.createTaskBundle(User.superUser, "my bundle for get", List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "my bundle for get",Some(0),  List(task1.id, task2.id))
 
       val response = this.service.getTaskBundle(User.superUser, bundle.bundleId)
       response.bundleId mustEqual bundle.bundleId
@@ -130,7 +130,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for delete", List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for delete",Some(0),  List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -159,7 +159,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for delete", List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for delete",Some(0),  List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -193,7 +193,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for unbundle", List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for unbundle",Some(0),  List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -204,7 +204,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         primaryTaskId = Some(task1.id)
       )
 
-      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task2.id))()
+      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task2.id), List(task2.id))()
       val response = this.service.getTaskBundle(User.superUser, bundle.bundleId)
       response.taskIds.length mustEqual 1
       response.taskIds.head mustEqual task1.id
@@ -223,7 +223,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for unbundle", List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for unbundle", Some(0), List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -241,7 +241,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Random user is not allowed to delete this bundle
       an[IllegalAccessException] should be thrownBy
-        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id))()
+        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id), List(task2.id))()
     }
 
   }

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -35,7 +35,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val response =
-        this.service.createTaskBundle(User.superUser, "my bundle",Some(0),  List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "my bundle", Some(0),  List(task1.id, task2.id))
       response.taskIds.length mustEqual 2
 
       // tasks.bundle_id is NOT set until setTaskStatus is called!!!
@@ -58,7 +58,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
     "not create a task Bundle with no tasks" taggedAs (TaskTag) in {
       // Cannot create a bundle with no tasks
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "my bundle again",Some(0),  List())
+        this.service.createTaskBundle(User.superUser, "my bundle again", Some(0),  List())
       }
     }
 
@@ -110,7 +110,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle =
-        this.service.createTaskBundle(User.superUser, "my bundle for get",Some(0),  List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "my bundle for get", Some(0),  List(task1.id, task2.id))
 
       val response = this.service.getTaskBundle(User.superUser, bundle.bundleId)
       response.bundleId mustEqual bundle.bundleId
@@ -130,7 +130,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for delete",Some(0),  List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for delete", Some(0),  List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -159,7 +159,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for delete",Some(0),  List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for delete", Some(0),  List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -193,7 +193,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for unbundle",Some(0),  List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for unbundle", Some(0),  List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -204,7 +204,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         primaryTaskId = Some(task1.id)
       )
 
-      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task2.id), List(task2.id))()
+      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task1.id), List(task2.id))()
       val response = this.service.getTaskBundle(User.superUser, bundle.bundleId)
       response.taskIds.length mustEqual 1
       response.taskIds.head mustEqual task1.id
@@ -241,7 +241,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Random user is not allowed to delete this bundle
       an[IllegalAccessException] should be thrownBy
-        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id), List(task2.id))()
+        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task1.id), List(task2.id))()
     }
 
   }

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -38,7 +38,6 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         this.service.createTaskBundle(
           User.superUser,
           "my bundle",
-          Some(task1.id),
           List(task1.id, task2.id)
         )
       response.taskIds.length mustEqual 2
@@ -59,7 +58,6 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         this.service.createTaskBundle(
           User.superUser,
           "my bundle again",
-          Some(task1.id),
           List(task1.id, task2.id)
         )
       }
@@ -68,7 +66,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
     "not create a task Bundle with no tasks" taggedAs (TaskTag) in {
       // Cannot create a bundle with no tasks
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "my bundle again", Some(0), List())
+        this.service.createTaskBundle(User.superUser, "my bundle again", List())
       }
     }
 
@@ -106,7 +104,6 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         this.service.createTaskBundle(
           User.superUser,
           "bad bundle",
-          Some(task1.id),
           List(task1.id, task2.id)
         )
       }
@@ -128,7 +125,6 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         this.service.createTaskBundle(
           User.superUser,
           "my bundle for get",
-          Some(task1.id),
           List(task1.id, task2.id)
         )
 
@@ -153,7 +149,6 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         .createTaskBundle(
           User.superUser,
           "my bundle for delete",
-          Some(task1.id),
           List(task1.id, task2.id)
         )
 
@@ -187,7 +182,6 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         .createTaskBundle(
           User.superUser,
           "my bundle for delete",
-          Some(task1.id),
           List(task1.id, task2.id)
         )
 
@@ -226,7 +220,6 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         .createTaskBundle(
           User.superUser,
           "my bundle for unbundle",
-          Some(task1.id),
           List(task1.id, task2.id)
         )
 

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -35,7 +35,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val response =
-        this.service.createTaskBundle(User.superUser, "my bundle", Some(0),  List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "my bundle", Some(task1.id), List(task1.id, task2.id))
       response.taskIds.length mustEqual 2
 
       // tasks.bundle_id is NOT set until setTaskStatus is called!!!
@@ -51,14 +51,14 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Cannot create a bundle with tasks already assigned
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "my bundle again", Some(0), List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "my bundle again", Some(task1.id), List(task1.id, task2.id))
       }
     }
 
     "not create a task Bundle with no tasks" taggedAs (TaskTag) in {
       // Cannot create a bundle with no tasks
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "my bundle again", Some(0),  List())
+        this.service.createTaskBundle(User.superUser, "my bundle again", Some(0), List())
       }
     }
 
@@ -93,7 +93,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Cannot create a bundle with tasks from different challenges
       intercept[InvalidException] {
-        this.service.createTaskBundle(User.superUser, "bad bundle", Some(0), List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "bad bundle", Some(task1.id), List(task1.id, task2.id))
       }
     }
 
@@ -110,7 +110,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle =
-        this.service.createTaskBundle(User.superUser, "my bundle for get", Some(0),  List(task1.id, task2.id))
+        this.service.createTaskBundle(User.superUser, "my bundle for get", Some(task1.id), List(task1.id, task2.id))
 
       val response = this.service.getTaskBundle(User.superUser, bundle.bundleId)
       response.bundleId mustEqual bundle.bundleId
@@ -130,7 +130,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for delete", Some(0),  List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for delete", Some(task1.id), List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -159,7 +159,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for delete", Some(0),  List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for delete", Some(task1.id), List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -193,7 +193,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for unbundle", Some(0),  List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for unbundle", Some(task1.id), List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -204,7 +204,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         primaryTaskId = Some(task1.id)
       )
 
-      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task1.id), List(task2.id))()
+      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task2.id), List(task1.id))()
       val response = this.service.getTaskBundle(User.superUser, bundle.bundleId)
       response.taskIds.length mustEqual 1
       response.taskIds.head mustEqual task1.id
@@ -223,7 +223,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         )
 
       val bundle = this.service
-        .createTaskBundle(User.superUser, "my bundle for unbundle", Some(0), List(task1.id, task2.id))
+        .createTaskBundle(User.superUser, "my bundle for unbundle", Some(task1.id), List(task1.id, task2.id))
 
       // tasks.bundle_id is NOT set until setTaskStatus is called
       taskDAL.setTaskStatus(
@@ -241,7 +241,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Random user is not allowed to delete this bundle
       an[IllegalAccessException] should be thrownBy
-        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task1.id), List(task2.id))()
+        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id), List(task1.id))()
     }
 
   }


### PR DESCRIPTION
Frontend: https://github.com/maproulette/maproulette3/pull/2291

Changes:
-----------------------------------------------------------------------------------------
This was implemented to lock all tasks in the bundle in certain contexts. For example, when a user goes to review a bundle, lockedTasks will be set to true so that all the tasks in the bundle the reviewer is reviewing will be locked.

Old route to to fetch a task bundle
`GET     /taskBundle/:id`
New route
`GET     /taskBundle/:id?lockedTasks=boolean`

This new route was implemented to reset bundles if a user redirects away from the bundle after making changes and no submission. From a backend percpective, this endpoint sets the bundle to include only the provided taskIds in the taskIds param, and set those tasks status and review status to that of the primary task.
New route
`POST     /taskBundle/:id/reset?primaryId=Long&taskIds=List[Long])`