### PR TITLE
fix nearby task looping too hard tasks issue

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -1144,7 +1144,7 @@ class TaskDAL @Inject() (
           s"""NOT (tasks.status != ${Task.STATUS_CREATED} AND tasks.id IN (
              |SELECT task_id FROM status_actions
              |WHERE osm_user_id IN (${user.osmProfile.id})
-             |  AND created >= NOW() - '1 hour'::INTERVAL))""".stripMargin
+             |  AND modified >= NOW() - '1 hour'::INTERVAL))""".stripMargin
         )
 
         priority match {
@@ -1273,7 +1273,7 @@ class TaskDAL @Inject() (
             tasks.status IN (0, 3, 6) AND
             NOT tasks.id IN (
                 SELECT task_id FROM status_actions
-                WHERE osm_user_id = ${user.osmProfile.id} AND created >= NOW() - '1 hour'::INTERVAL)
+                WHERE osm_user_id = ${user.osmProfile.id} AND modified >= NOW() - '1 hour'::INTERVAL)
       ORDER BY ST_Distance(tasks.location, (SELECT location FROM tasks WHERE id = $proximityId)), tasks.status, RANDOM()
       LIMIT ${this.sqlLimit(limit)}"""
 

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -1161,7 +1161,7 @@ class TaskDAL @Inject() (
           case Some(p) =>
             appendInWhereClause(
               whereClause,
-              s"tasks.priority = $p AND tasks.status != ${Task.STATUS_SKIPPED} AND tasks.status != ${Task.STATUS_TOO_HARD} AND (tasks.completed_by != ${user.id} OR tasks.completed_by IS NULL)"
+              s"tasks.priority = $p AND (tasks.completed_by != ${user.id} OR tasks.completed_by IS NULL)"
             )
           case None => // Ignore
         }


### PR DESCRIPTION
Tickets resolved by this pr: https://github.com/maproulette/maproulette3/issues/2292, https://github.com/maproulette/maproulette3/issues/2018

The reason why users where running into a looping issue with tasks marked as too hard was because the time interval that made it so that tasks marked with mappable status were invisible was based on the value of the "create" column in the task table, which was reset after as a task was set to created or skipped but not too hard since the too hard status is passed through the completion steps instead of the "reset to mappable" steps. To resolve this issue i made the 1 hour interval based on the mapped_on date. I also added some order sorting so that if a user marked a task as too_hard or skipped it that those tasks would be the last option to be selected.