### PR TITLE
prioritize tasks by challenge id in nextTaskReview endpoint

### DIFF
--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -117,6 +117,7 @@ class TaskReviewController @Inject() (
       order: String,
       lastChallengeId: Long = -1,
       lastTaskId: Long = -1,
+      reviewedTaskIds: String = "",
       excludeOtherReviewers: Boolean = false,
       asMetaReview: Boolean = false
   ): Action[AnyContent] = Action.async { implicit request =>
@@ -134,6 +135,8 @@ class TaskReviewController @Inject() (
           case _: Throwable => // do nothing, it's okay if the user didn't lock the prior task
         }
 
+        val reviewedTaskIdsList: List[Long] = reviewedTaskIds.split(",").map(_.toLong).toList
+
         val result = this.service.nextTaskReview(
           user,
           params,
@@ -142,6 +145,7 @@ class TaskReviewController @Inject() (
           order,
           (if (lastChallengeId == -1) None else Some(lastChallengeId)),
           (if (lastTaskId == -1) None else Some(lastTaskId)),
+          reviewedTaskIdsList,
           excludeOtherReviewers,
           asMetaReview
         )

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -115,6 +115,7 @@ class TaskReviewController @Inject() (
       onlySaved: Boolean = false,
       sort: String,
       order: String,
+      lastChallengeId: Long = -1,
       lastTaskId: Long = -1,
       excludeOtherReviewers: Boolean = false,
       asMetaReview: Boolean = false
@@ -139,10 +140,12 @@ class TaskReviewController @Inject() (
           onlySaved,
           sort,
           order,
+          (if (lastChallengeId == -1) None else Some(lastChallengeId)),
           (if (lastTaskId == -1) None else Some(lastTaskId)),
           excludeOtherReviewers,
           asMetaReview
         )
+
         val nextTask = result match {
           case Some(task) =>
             Ok(Json.toJson(this.service.startTaskReview(user, task)))

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -7,14 +7,12 @@ package org.maproulette.framework.repository
 
 import java.sql.Connection
 import scala.concurrent.duration.FiniteDuration
-import scala.collection.mutable
 
-import anorm.SqlParser.get
-import anorm.{ToParameterValue, SimpleSql, Row, SqlParser, RowParser, ~, SQL}
+import anorm.{ToParameterValue, SimpleSql, Row, SqlParser, SQL}
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.maproulette.framework.model.{Task, TaskReview, TaskWithReview, User}
-import org.maproulette.framework.psql.{Query, Grouping, OrderField, Order, Paging}
+import org.maproulette.framework.psql.{Query, OrderField, Order, Paging}
 import org.maproulette.framework.mixins.{Locking, TaskParserMixin}
 import org.maproulette.framework.service.UserService
 import org.maproulette.session.SearchParameters

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -8,7 +8,6 @@ package org.maproulette.framework.service
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration.FiniteDuration
 import org.joda.time.DateTime
-import scala.util.Random
 import org.maproulette.framework.model._
 import org.maproulette.framework.psql.{Query, _}
 import org.maproulette.framework.psql.filter.{BaseParameter, _}
@@ -181,7 +180,7 @@ class TaskReviewService @Inject() (
         )
       )
 
-    Random.shuffle(tasks).headOption
+    tasks.headOption
   }
 
   /**

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -160,6 +160,12 @@ GET     /tasks/reviewed                          @org.maproulette.framework.cont
 #   - name: lastTaskId
 #     in: query
 #     description: Fetch the next task after the lastTaskId. (so if you want to 'skip' a task you can get the next one)
+#   - name: lastChallengeId
+#     in: query
+#     description: Fetch a task within the current challenge lastChallengeId.
+#   - name: reviewedTaskIds
+#     in: query
+#     description: A comma-separated list of reviewed task IDs. Example format: "14859,25084". Use this parameter to exclude tasks that have been reviewed. Tasks listed here will not appear in the results of the request.
 #   - name: asMetaReview
 #     in: query
 #     description: Fetch the next task for a meta review.
@@ -173,7 +179,7 @@ GET     /tasks/reviewed                          @org.maproulette.framework.cont
 #     in: query
 #     description: The search string used to match the Reviewer names. (reviewed_by)
 ###
-GET     /tasks/review/next                       @org.maproulette.framework.controller.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastChallengeId:Long ?= -1, lastTaskId:Long ?= -1, excludeOtherReviewers:Boolean ?= false, asMetaReview: Boolean ?= false)
+GET     /tasks/review/next                       @org.maproulette.framework.controller.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastChallengeId:Long ?= -1, lastTaskId:Long ?= -1, reviewedTaskIds:String ?= "", excludeOtherReviewers:Boolean ?= false, asMetaReview: Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieves nearby Tasks

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -173,7 +173,7 @@ GET     /tasks/reviewed                          @org.maproulette.framework.cont
 #     in: query
 #     description: The search string used to match the Reviewer names. (reviewed_by)
 ###
-GET     /tasks/review/next                       @org.maproulette.framework.controller.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastTaskId:Long ?= -1, excludeOtherReviewers:Boolean ?= false, asMetaReview: Boolean ?= false)
+GET     /tasks/review/next                       @org.maproulette.framework.controller.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastChallengeId:Long ?= -1, lastTaskId:Long ?= -1, excludeOtherReviewers:Boolean ?= false, asMetaReview: Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieves nearby Tasks

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -165,7 +165,7 @@ GET     /tasks/reviewed                          @org.maproulette.framework.cont
 #     description: Fetch a task within the current challenge lastChallengeId.
 #   - name: reviewedTaskIds
 #     in: query
-#     description: A comma-separated list of reviewed task IDs. Example format: "14859,25084". Use this parameter to exclude tasks that have been reviewed. Tasks listed here will not appear in the results of the request.
+#     description: A comma-separated list of reviewed task IDs. Example format "14859,25084". Use this parameter to exclude tasks that have been reviewed. Tasks listed here will not appear in the results of the request.
 #   - name: asMetaReview
 #     in: query
 #     description: Fetch the next task for a meta review.

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -63,7 +63,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
         SearchParameters(),
         lastChallengeId = Some(result.get.parent),
         lastTaskId = Some(result.get.id),
-        reviewedTaskIdsList = List(Some(result.get.id)),
+        reviewedTaskIdsList = List(result.get.id),
         sort = "id",
         order = ""
       )
@@ -80,7 +80,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
         SearchParameters(),
         lastChallengeId = Some(result2.get.parent),
         lastTaskId = Some(result2.get.id),
-        reviewedTaskIdsList = List(Some(result.get.id), Some(result2.get.id)),
+        reviewedTaskIdsList = List(result.get.id, result2.get.id),
         sort = "id",
         order = ""
       )

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -107,6 +107,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
         SearchParameters(),
         lastChallengeId = Some(reviewTask.parent),
         lastTaskId = Some(reviewTask.id),
+        reviewedTaskIdsList = List(reviewTask.id),
         sort = "id",
         order = "ASC"
       )

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -52,6 +52,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
       // Get a task to review
       var result =
         this.service.nextTaskReview(reviewUser, SearchParameters(), sort = "id", order = "")
+      println(s"Task 1: $result")
       result = this.service.startTaskReview(reviewUser, result.get)
       result.get.review.reviewClaimedBy.get mustEqual reviewUser.id
       result.get.id mustEqual reviewTask.id
@@ -66,6 +67,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
         sort = "id",
         order = ""
       )
+      println(s"Task 2: $result2")
       result2 = this.service.startTaskReview(reviewUser, result2.get)
       result2.get.review.reviewClaimedBy.get mustEqual reviewUser.id
 
@@ -82,6 +84,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
         sort = "id",
         order = ""
       )
+      println(s"Task 3: $result3")
       result3 mustEqual None
     }
 

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -61,6 +61,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
       var result2 = this.service.nextTaskReview(
         reviewUser,
         SearchParameters(),
+        lastChallengeId = Some(result.get.parent),
         lastTaskId = Some(result.get.id),
         sort = "id",
         order = ""
@@ -76,6 +77,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
       var result3 = this.service.nextTaskReview(
         reviewUser,
         SearchParameters(),
+        lastChallengeId = Some(result2.get.parent),
         lastTaskId = Some(result2.get.id),
         sort = "id",
         order = ""

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -100,6 +100,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
       var result2 = this.service.nextTaskReview(
         reviewUser,
         SearchParameters(),
+        lastChallengeId = Some(result.get.parent),
         lastTaskId = Some(result.get.id),
         sort = "id",
         order = "DESC"
@@ -144,6 +145,7 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
       var task = this.service.nextTaskReview(
         reviewUser,
         SearchParameters(),
+        lastChallengeId = Some(reviewTask.parent),
         lastTaskId = Some(reviewTask.id),
         sort = "id",
         order = "ASC"

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -87,45 +87,6 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
       result3 mustEqual None
     }
 
-    "next task review should honor sort direction" taggedAs (TaskReviewTag) in {
-      // Get a task to review
-      var result =
-        this.service.nextTaskReview(reviewUser, SearchParameters(), sort = "id", order = "DESC")
-      result = this.service.startTaskReview(reviewUser, result.get)
-      result.get.review.reviewClaimedBy.get mustEqual reviewUser.id
-      this.service.cancelTaskReview(reviewUser, result.get)
-
-      // Get a second task to review
-      var result2 = this.service.nextTaskReview(
-        reviewUser,
-        SearchParameters(),
-        lastChallengeId = Some(result.get.parent),
-        lastTaskId = Some(result.get.id),
-        sort = "id",
-        order = "DESC"
-      )
-      result2 = this.service.startTaskReview(reviewUser, result2.get)
-      result2.get.review.reviewClaimedBy.get mustEqual reviewUser.id
-      result2.get.id mustEqual reviewTask.id
-      this.service.cancelTaskReview(reviewUser, result2.get)
-
-      // Exercise sorting
-      var result3 = this.service.nextTaskReview(
-        reviewUser,
-        SearchParameters(),
-        sort = "review_requested_by",
-        order = "ASC"
-      )
-      (result3 != None) mustEqual true
-      var result4 = this.service.nextTaskReview(
-        reviewUser,
-        SearchParameters(),
-        sort = "mapped_on",
-        order = "ASC"
-      )
-      (result4 != None) mustEqual true
-    }
-
     "get Review Requested tasks" taggedAs (TaskReviewTag) in {
       var (count, result) =
         this.service.getReviewRequestedTasks(reviewUser, SearchParameters(), sort = "", order = "")

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -52,7 +52,6 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
       // Get a task to review
       var result =
         this.service.nextTaskReview(reviewUser, SearchParameters(), sort = "id", order = "")
-      println(s"Task 1: $result")
       result = this.service.startTaskReview(reviewUser, result.get)
       result.get.review.reviewClaimedBy.get mustEqual reviewUser.id
       result.get.id mustEqual reviewTask.id
@@ -64,10 +63,10 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
         SearchParameters(),
         lastChallengeId = Some(result.get.parent),
         lastTaskId = Some(result.get.id),
+        reviewedTaskIdsList = List(Some(result.get.id)),
         sort = "id",
         order = ""
       )
-      println(s"Task 2: $result2")
       result2 = this.service.startTaskReview(reviewUser, result2.get)
       result2.get.review.reviewClaimedBy.get mustEqual reviewUser.id
 
@@ -81,10 +80,10 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
         SearchParameters(),
         lastChallengeId = Some(result2.get.parent),
         lastTaskId = Some(result2.get.id),
+        reviewedTaskIdsList = List(Some(result.get.id), Some(result2.get.id)),
         sort = "id",
         order = ""
       )
-      println(s"Task 3: $result3")
       result3 mustEqual None
     }
 


### PR DESCRIPTION
Frontend: https://github.com/maproulette/maproulette3/pull/2319

This PR introduces enhancements to the `GET /tasks/review/next` endpoint, incorporating two additional parameters.

The first parameter, `lastChallengeId`, filters for tasks that have the same challenge id as the parameter. This was implemented so that users do not keep going back and forth between challenges. (If there are no other tasks with matching challenge ids, a random task will be found)

The second parameter, `reviewedTaskIds`, enables the exclusion of specified task IDs from the selection pool. This was implemented to prevent reviewers from encountering the same tasks repeatedly.

### Old:
All parameters:
```
GET /tasks/review/next @org.maproulette.framework.controller.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastTaskId:Long ?= -1, excludeOtherReviewers:Boolean ?= false, asMetaReview: Boolean ?= false)
```
request:
```
/api/v2/tasks/review/next
```

### New:
All parameters:
```
GET /tasks/review/next @org.maproulette.framework.controller.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastChallengeId:Long ?= -1, lastTaskId:Long ?= -1, reviewedTaskIds:String ?= "", excludeOtherReviewers:Boolean ?= false, asMetaReview: Boolean ?= false)
```
request:
```
/api/v2/tasks/review/next?lastChallengeId=90878&reviewedTaskIds=90899%2C90880
```
