### PR TITLE
Migrate JTS package from vividsolutions to Eclipse Foundation

### DIFF
--- a/app/org/maproulette/framework/repository/UserRepository.scala
+++ b/app/org/maproulette/framework/repository/UserRepository.scala
@@ -5,22 +5,22 @@
 
 package org.maproulette.framework.repository
 
-import java.sql.Connection
-
 import anorm.SqlParser._
 import anorm._
-import com.vividsolutions.jts.geom.{Coordinate, GeometryFactory, Point}
-import com.vividsolutions.jts.io.WKTReader
-import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
+import org.locationtech.jts.geom.{Coordinate, GeometryFactory, Point}
+import org.locationtech.jts.io.WKTReader
 import org.maproulette.Config
 import org.maproulette.framework.model._
-import org.maproulette.framework.service.{ServiceManager, GrantService}
 import org.maproulette.framework.psql.filter._
 import org.maproulette.framework.psql.{Query, SQLUtils}
+import org.maproulette.framework.service.{GrantService, ServiceManager}
 import org.maproulette.models.dal.ChallengeDAL
 import play.api.db.Database
 import play.api.libs.json.{JsResultException, Json}
+
+import java.sql.Connection
+import javax.inject.{Inject, Singleton}
 
 /**
   * The User repository handles all the sql queries that are executed against the database for the

--- a/build.sbt
+++ b/build.sbt
@@ -100,10 +100,9 @@ libraryDependencies ++= Seq(
   // See https://www.slf4j.org/codes.html#ignoredBindings
   "net.postgis" % "postgis-jdbc" % "2023.1.0" exclude ("org.slf4j", "slf4j-api"), // https://github.com/postgis/postgis-java/releases
   "joda-time"   % "joda-time"    % "2.12.0",
-  // TODO(ljdelight): The vividsolutions package was moved to the Eclipse Foundation as LocationTech.
-  //                  See the upgrade guide https://github.com/locationtech/jts/blob/master/MIGRATION.md
-  "com.vividsolutions"   % "jts"                 % "1.13",
-  "org.wololo"           % "jts2geojson"         % "0.14.3",
+  // https://github.com/locationtech/jts/releases
+  "org.locationtech.jts" % "jts-core"            % "1.19.0",
+  "org.wololo"           % "jts2geojson"         % "0.18.1", // https://github.com/bjornharrtell/jts2geojson/releases
   "org.apache.commons"   % "commons-lang3"       % "3.12.0",
   "commons-codec"        % "commons-codec"       % "1.14",
   "com.typesafe.play"    %% "play-mailer"        % "8.0.1",


### PR DESCRIPTION
- Update the JTS (Java Topology Suite) dependency from `com.vividsolutions:jts:1.13` to `org.locationtech.jts:jts-core:1.19.0` due to the package's move to the Eclipse Foundation as LocationTech.
- Update`org.wololo:jts2geojson` to 0.18.1, which has a dependency on jts-core:1.18.1.

This resolves #1082 