### PR TITLE
Update to the latest Play 2.8.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,9 +107,9 @@ libraryDependencies ++= Seq(
   "commons-codec"        % "commons-codec"       % "1.14",
   "com.typesafe.play"    %% "play-mailer"        % "8.0.1",
   "com.typesafe.play"    %% "play-mailer-guice"  % "8.0.1",
-  "com.typesafe.akka"    %% "akka-cluster-tools" % "2.6.20",
-  "com.typesafe.akka"    %% "akka-cluster-typed" % "2.6.20",
-  "com.typesafe.akka"    %% "akka-slf4j"         % "2.6.20",
+  "com.typesafe.akka"    %% "akka-cluster-tools" % "2.6.21",
+  "com.typesafe.akka"    %% "akka-cluster-typed" % "2.6.21",
+  "com.typesafe.akka"    %% "akka-slf4j"         % "2.6.21",
   "net.debasishg"        %% "redisclient"        % "3.42",
   "com.github.blemale"   %% "scaffeine"          % "5.2.1",
   "com.github.tototoshi" %% "scala-csv"          % "1.3.10"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
+# https://github.com/sbt/sbt/releases
 sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,8 @@ logLevel := Level.Warn
 
 addDependencyTreePlugin
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
+// https://github.com/playframework/playframework/releases
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.21")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 


### PR DESCRIPTION
The play 2.8 branch is EOL by May 31 2024. MapRoulette need to use a newer version and the first step is to update to the latest 2.8 and then step to 2.9.

See here for more details <https://www.playframework.com/documentation/3.0.x/Migration29>. This is a step in concluding #1079.