### PR TITLE
fix changeset submission bug for tag fix tasks with relations

### DIFF
--- a/app/org/maproulette/provider/osm/objects/VersionedObjects.scala
+++ b/app/org/maproulette/provider/osm/objects/VersionedObjects.scala
@@ -164,7 +164,7 @@ case class VersionedRelation(
 ) extends VersionedObject {
 
   override def toChangeElement(changesetId: Int): Elem = {
-    <way>
+    <relation>
       {
       for (member <- members)
         yield <member/> % Attribute(
@@ -176,7 +176,7 @@ case class VersionedRelation(
       for (tagKV <- tags)
         yield <tag/> % Attribute("k", Text(tagKV._1), Attribute("v", Text(tagKV._2), Null))
     }
-    </way> % Attribute(
+    </relation> % Attribute(
       "visible",
       Text(visible.toString),
       Attribute(


### PR DESCRIPTION
Issue Resolved: https://github.com/maproulette/maproulette3/issues/2344

In our changeset provider, we utilize a custom versioned object for constructing changesets for nodes, ways, and relations. However, the versioned object for relations previously employed a way wrapper, as illustrated below:

```xml
<way>{content}</way>
```

This resulted in OpenStreetMap searching for a way with the relation ID, leading to the error message:

`
https://www.openstreetmap.org/api/0.6/changeset/{changesetId}/upload failed with status code 412 (Precondition failed: Way {wayId} must have at least one node)
`

Relations necessitate a structure like so:

```xml
<relation>{content}</relation>
```

This pull request addresses this issue by implementing the required change.