### PR TITLE
Update to Play 2.9

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -5,6 +5,15 @@ on:
   pull_request:
 
 jobs:
+  generate_app_secret:
+    runs-on: ubuntu-latest
+    outputs:
+      application_secret: ${{ steps.generate_app_secret.outputs.application_app_secret }}
+    steps:
+      - name: Generate Playframework APPLICATION_SECRET
+        id: generate_app_secret
+        run: echo "application_app_secret=$(openssl rand -base64 32)" >> "$GITHUB_OUTPUT"
+
   sbt_formatChecks_dependencyTree:
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +36,7 @@ jobs:
 
   sbt_tests_jacoco:
     runs-on: ubuntu-latest
+    needs: generate_app_secret
     services:
       postgis11:
         image: postgis/postgis:13-3.3
@@ -48,6 +58,7 @@ jobs:
           distribution: 'temurin'
       - name: Run sbt tests with jacoco analysis
         env:
+          APPLICATION_SECRET: ${{ needs.generate_app_secret.outputs.application_secret }}
           CI: true
           MR_TEST_DB_NAME: "mr_test"
           MR_TEST_DB_USER: "osm"
@@ -57,6 +68,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    needs: generate_app_secret
     services:
       postgis11:
         image: postgis/postgis:13-3.3
@@ -95,6 +107,7 @@ jobs:
     - name: Run maproulette and the maproulette-java-client integration tests
       env:
         # maproulette overrides
+        APPLICATION_SECRET: ${{ needs.generate_app_secret.outputs.application_secret }}
         CI: true
         SBT_OPTS: "-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M"
         MR_SUPER_KEY: 1234

--- a/build.sbt
+++ b/build.sbt
@@ -82,12 +82,12 @@ libraryDependencies ++= Seq(
   guice,
   // NOTE: Be careful upgrading sangria and play-json as binary incompatibilities can break graphql and the entire UI.
   //       See the compatibility matrix here https://github.com/sangria-graphql/sangria-play-json
-  "org.sangria-graphql"    %% "sangria-play-json"  % "2.0.1",
-  "org.sangria-graphql"    %% "sangria"            % "2.0.1",
-  "com.typesafe.play"      %% "play-json-joda"     % "2.8.2",
-  "com.typesafe.play"      %% "play-json"          % "2.8.2",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
-  "org.scalatestplus"      %% "mockito-4-5"        % "3.2.12.0" % Test,
+  "org.sangria-graphql"    %% "sangria-play-json-play29" % "2.0.3",
+  "org.sangria-graphql"    %% "sangria"                  % "4.0.2",
+  "com.typesafe.play"      %% "play-json-joda"           % "2.10.5",
+  "com.typesafe.play"      %% "play-json"                % "2.10.5",
+  "org.scalatestplus.play" %% "scalatestplus-play"       % "5.1.0" % Test,
+  "org.scalatestplus"      %% "mockito-4-5"              % "3.2.12.0" % Test,
   // NOTE: The swagger-ui package is used to obtain the static distribution of swagger-ui, the files included at runtime
   // and are served by the webserver at route '/assets/lib/swagger-ui/'. We have a few customized swagger files in dir
   // 'public/swagger'.
@@ -99,14 +99,14 @@ libraryDependencies ++= Seq(
   // At some point other libraries will need to be updated to use the ServiceLoader mechanism and we can remove this.
   // See https://www.slf4j.org/codes.html#ignoredBindings
   "net.postgis" % "postgis-jdbc" % "2023.1.0" exclude ("org.slf4j", "slf4j-api"), // https://github.com/postgis/postgis-java/releases
-  "joda-time"   % "joda-time"    % "2.12.0",
+  "joda-time"   % "joda-time"    % "2.12.7",
   // https://github.com/locationtech/jts/releases
   "org.locationtech.jts" % "jts-core"            % "1.19.0",
   "org.wololo"           % "jts2geojson"         % "0.18.1", // https://github.com/bjornharrtell/jts2geojson/releases
   "org.apache.commons"   % "commons-lang3"       % "3.12.0",
   "commons-codec"        % "commons-codec"       % "1.14",
-  "com.typesafe.play"    %% "play-mailer"        % "8.0.1",
-  "com.typesafe.play"    %% "play-mailer-guice"  % "8.0.1",
+  "com.typesafe.play"    %% "play-mailer"        % "9.0.0",
+  "com.typesafe.play"    %% "play-mailer-guice"  % "9.0.0",
   "com.typesafe.akka"    %% "akka-cluster-tools" % "2.6.21",
   "com.typesafe.akka"    %% "akka-cluster-typed" % "2.6.21",
   "com.typesafe.akka"    %% "akka-slf4j"         % "2.6.21",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # https://github.com/sbt/sbt/releases
-sbt.version=1.7.2
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 addDependencyTreePlugin
 
 // https://github.com/playframework/playframework/releases
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.21")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
@@ -20,3 +20,8 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
+
+// https://github.com/sbt/sbt/issues/6997
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)


### PR DESCRIPTION
Update sbt, plugins, and other dependencies to support running with Play 2.9 because Play 2.8 is out of support at the end of May 2024.

Folks that run MapRoulette locally or in some environment will need to update the APPLICATION_SECRET if it's not at least 32 bytes. This is detailed in issue <https://github.com/maproulette/maproulette-backend/issues/1117> and also <https://www.playframework.com/documentation/3.0.x/ApplicationSecret>

For more information about Play 2.9, see here <https://www.playframework.com/documentation/2.9.x/Highlights29>.

Specifically the updates are:

- `build.properties` sbt version is updated from `1.7.2` to `1.9.9`
- `project/plugins.sbt` Play sbt plugin is updated from `2.8.21` to `2.9.3`.
- `build.sbt` supporting dependencies
  - `sangria-play-json` 2.0.1 -> `sangria-play-json-play29` 2.0.3
  - `sangria`: 2.0.1 -> 4.0.2
  - `play-json-joda`: 2.8.2 -> 2.10.5
  - `play-json`: 2.8.2 -> 2.10.5
  - `play-mailer`: 8.0.1 -> 9.0.0
  - `play-mailer-guice`: 8.0.1 -> 9.0.0
  - `joda-time`: 2.12.0 -> 2.12.7