### PR TITLE
Perf: Remove 'connectionTestQuery' from application.conf

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -41,7 +41,6 @@ db {
     password=${?MR_DATABASE_PASSWORD}
 
     hikaricp {
-      connectionTestQuery="SELECT 1"
       # The database connection pool size can be tweaked based on available system resources and needed throughput.
       # Increasing this value causes parallel database transactions at the cost of more RAM, more CPU.
       # Note:


### PR DESCRIPTION
Remove application.conf 'db.default.hikaricp.connectionTestQuery' to allow the driver to use the Connection.isValid() API, which improves performance.

[The HikariCP documentation](https://github.com/brettwooldridge/HikariCP) strongly recommends that we do not set `connectionTestQuery`:

> If your driver supports JDBC4 we strongly recommend not setting this property. This is for "legacy" drivers that do not support the JDBC4 Connection.isValid() API. This is the query that will be executed just before a connection is given to you from the pool to validate that the connection to the database is still alive. Again, try running the pool without this property, HikariCP will log an error if your driver is not JDBC4 compliant to let you know. Default: none