### PR TITLE
Update GH Action versions and test against PostGIS 13-3.3 and 16-3.4

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,4 +1,4 @@
-name: Scala CI
+name: MapRoulette Backend CI
 
 on:
   push:
@@ -17,18 +17,18 @@ jobs:
   sbt_formatChecks_dependencyTree:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: 'temurin'
+          cache: sbt
       - name: Create sbt dependencyTree
         env:
           CI: true
         run: |
-          sbt -Dsbt.log.format=false 'set asciiGraphWidth := 10000' 'dependencyTree'
-      - name: Verify scalafix passes
+          sbt -Dsbt.log.format=false 'set asciiGraphWidth := 10000' 'dependencyTree' 'evicted'
+      - name: Verify code format checks pass
         env:
           CI: true
         run: |
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate_app_secret
     services:
-      postgis11:
-        image: postgis/postgis:13-3.3
+      postgis:
+        image: postgis/postgis:16-3.4
         ports:
           - 5432:5432
         env:
@@ -50,12 +50,13 @@ jobs:
       matrix:
         java: [ 11 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: sbt
       - name: Run sbt tests with jacoco analysis
         env:
           APPLICATION_SECRET: ${{ needs.generate_app_secret.outputs.application_secret }}
@@ -70,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate_app_secret
     services:
-      postgis11:
+      postgis:
         image: postgis/postgis:13-3.3
         ports:
           - 5432:5432
@@ -82,16 +83,17 @@ jobs:
       matrix:
         java: [11]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
       with:
         repository: 'osmlab/maproulette-java-client'
         path: 'java-client'
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
+        cache: sbt
     - name: Run sbt compile
       env:
         CI: true


### PR DESCRIPTION
The main changes here are to use the setup-java sbt cache and to create PostGRES databases of versions 13-3.3 and 16-3.4.