### PR TITLE
Introduce Java 17 to MapRoulette-backend CI tests

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: sbt
       - name: Create sbt dependencyTree
@@ -48,7 +48,7 @@ jobs:
           POSTGRES_PASSWORD: osm
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -81,7 +81,7 @@ jobs:
           POSTGRES_PASSWORD: osm
     strategy:
       matrix:
-        java: [11]
+        java: [17]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/checkout@v4
@@ -91,6 +91,7 @@ jobs:
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
+        # https://github.com/actions/setup-java?tab=readme-ov-file#install-multiple-jdks
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
         cache: sbt


### PR DESCRIPTION
This is a testing only change -- MapRoulette runtime will remain at Java 11.

With Play framework 3.x planning to stop supporting Java 11, we're adding Java 17 support to MapRoulette-backend. The recent upgrade to Play 2.9 has helped us overcome earlier issues with Java 17. However, Java 21 is not supported yet (the compile fails).

This update keeps Java 11 support while adding Java 17, ensuring our code works with both versions.