### PR TITLE
update task caching for task bundling endpoints

### DIFF
--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -6,10 +6,10 @@
 package org.maproulette.framework.repository
 
 import org.slf4j.LoggerFactory
+
 import anorm.ToParameterValue
 import anorm.SqlParser.scalar
-import anorm._
-import postgresql._
+import anorm._, postgresql._
 
 import javax.inject.{Inject, Singleton}
 import org.maproulette.exception.InvalidException

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -294,8 +294,8 @@ class TaskBundleRepository @Inject() (
                   task.copy(
                     bundleId = Option.empty[Long],
                     status = Some(STATUS_CREATED),
-                    review = TaskReviewFields(),
-                  ),
+                    review = TaskReviewFields()
+                  )
                 )
               }
 

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -10,14 +10,13 @@ import org.slf4j.LoggerFactory
 import anorm.ToParameterValue
 import anorm.SqlParser.scalar
 import anorm._, postgresql._
-
 import javax.inject.{Inject, Singleton}
 import org.maproulette.exception.InvalidException
 import org.maproulette.Config
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.BaseParameter
-import org.maproulette.framework.mixins.{Locking, TaskParserMixin}
 import org.maproulette.framework.model.{Task, TaskBundle, User}
+import org.maproulette.framework.mixins.{TaskParserMixin, Locking}
 import org.maproulette.framework.model.Task.STATUS_CREATED
 import org.maproulette.data.TaskType
 import play.api.db.Database


### PR DESCRIPTION
Issue: Sometimes tasks removed from a bundle still redirect to the bundle they use to be a part of.
Reason: The backend caches task data, and in order to fully associate or disassociate a task with a bundle, the cache must be updated.
Solution: This PR adds those cache updates to all the bundle-related endpoints.