### PR TITLE
add endpoint for fetching task markers specifically

### DIFF
--- a/app/org/maproulette/framework/controller/TaskController.scala
+++ b/app/org/maproulette/framework/controller/TaskController.scala
@@ -139,25 +139,22 @@ class TaskController @Inject() (
       top: Double,
       limit: Int,
       excludeLocked: Boolean,
-      includeGeometries: Boolean
+      includeGeometries: Boolean,
+      includeTags: Boolean
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { p =>
         val params = p.copy(location = Some(SearchLocation(left, bottom, right, top)))
-        val (count, result) = this.taskClusterService.getTaskMarkerDataInBoundingBox(
+        val result = this.taskClusterService.getTaskMarkerDataInBoundingBox(
           User.userOrMocked(user),
           params,
           limit,
           excludeLocked
         )
 
-        result match {
-          case Some(points) =>
-            val resultJson = this.insertExtraTaskJSON(points)
-            Ok(Json.obj("total" -> count, "tasks" -> resultJson))
-          case None =>
-            Ok(Json.obj("total" -> count))
-        }
+        val resultJson = this.insertExtraTaskJSON(result, includeGeometries, includeTags)
+
+        Ok(resultJson)
       }
     }
   }

--- a/app/org/maproulette/framework/controller/TaskController.scala
+++ b/app/org/maproulette/framework/controller/TaskController.scala
@@ -77,10 +77,10 @@ class TaskController @Inject() (
   /**
     * Gets all the tasks within a bounding box
     *
-    * @param left   The minimum latitude for the bounding box
-    * @param bottom The minimum longitude for the bounding box
-    * @param right  The maximum latitude for the bounding box
-    * @param top    The maximum longitude for the bounding box
+    * @param left   The minimum longitude for the bounding box
+    * @param bottom The minimum latitude for the bounding box
+    * @param right  The maximum longitude for the bounding box
+    * @param top    The maximum latitude for the bounding box
     * @param limit  Limit for the number of returned tasks
     * @param offset The offset used for paging
     * @return
@@ -125,10 +125,10 @@ class TaskController @Inject() (
   /**
     * Gets all the task markers within a bounding box
     *
-    * @param left   The minimum latitude for the bounding box
-    * @param bottom The minimum longitude for the bounding box
-    * @param right  The maximum latitude for the bounding box
-    * @param top    The maximum longitude for the bounding box
+    * @param left   The minimum longitude for the bounding box
+    * @param bottom The minimum latitude for the bounding box
+    * @param right  The maximum longitude for the bounding box
+    * @param top    The maximum latitude for the bounding box
     * @param limit  Limit for the number of returned tasks
     * @return
     */

--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -27,7 +27,6 @@ class TaskClusterRepository @Inject() (override val db: Database, challengeDAL: 
   val DEFAULT_NUMBER_OF_POINTS = 100
 
   val pointParser  = this.challengeDAL.pointParser
-  val markerParser = this.challengeDAL.markerParser
 
   private val joinClause =
     new StringBuilder(

--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -175,7 +175,7 @@ class TaskClusterRepository @Inject() (override val db: Database, challengeDAL: 
     *
     * @param query         Query to execute
     * @param c             An available connection
-    * @return The list of Tasks found within the bounding box and the total count of tasks if not bounding
+    * @return The list of Tasks found within the bounding box
     */
   def queryTaskMarkerDataInBoundingBox(
       query: Query,

--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -26,7 +26,8 @@ class TaskClusterRepository @Inject() (override val db: Database, challengeDAL: 
 
   val DEFAULT_NUMBER_OF_POINTS = 100
 
-  val pointParser = this.challengeDAL.pointParser
+  val pointParser  = this.challengeDAL.pointParser
+  val markerParser = this.challengeDAL.markerParser
 
   private val joinClause =
     new StringBuilder(
@@ -193,22 +194,15 @@ class TaskClusterRepository @Inject() (override val db: Database, challengeDAL: 
           query
             .build(
               s"""
-                      SELECT tasks.id, tasks.name, tasks.parent_id, c.name, tasks.instruction, tasks.status, tasks.mapped_on,
-                            tasks.completed_time_spent, tasks.completed_by,
-                            tasks.bundle_id, tasks.is_bundle_primary, tasks.cooperative_work_json::TEXT as cooperative_work,
-                            task_review.review_status, task_review.review_requested_by, task_review.reviewed_by, task_review.reviewed_at,
-                            task_review.review_started_at, task_review.meta_review_status, task_review.meta_reviewed_by,
-                            task_review.meta_reviewed_at, task_review.additional_reviewers,
-                            ST_AsGeoJSON(tasks.location) AS location, priority,
-                            CASE WHEN task_review.review_started_at IS NULL
-                                  THEN 0
-                                  ELSE EXTRACT(epoch FROM (task_review.reviewed_at - task_review.review_started_at)) END
-                            AS reviewDuration
-                      FROM tasks
-                      ${joinClause.toString()}
-                      """
+                SELECT tasks.id, tasks.name, tasks.parent_id, c.name, tasks.status, 
+                      tasks.bundle_id, tasks.is_bundle_primary, 
+                      task_review.review_status, task_review.meta_review_status, 
+                      ST_AsGeoJSON(tasks.location) AS location, priority
+                FROM tasks
+                ${joinClause.toString()}
+                """
             )
-            .as(this.pointParser.*)
+            .as(this.markerParser.*)
 
         (count, Some(results))
       } else {

--- a/app/org/maproulette/framework/service/TaskClusterService.scala
+++ b/app/org/maproulette/framework/service/TaskClusterService.scala
@@ -136,7 +136,7 @@ class TaskClusterService @Inject() (repository: TaskClusterRepository)
       params: SearchParameters,
       limit: Int,
       ignoreLocked: Boolean = false
-  ): (Int, Option[List[ClusteredPoint]]) = {
+  ): (List[ClusteredPoint]) = {
     params.location match {
       case Some(sl) => // params has location
       case None =>

--- a/app/org/maproulette/framework/service/TaskClusterService.scala
+++ b/app/org/maproulette/framework/service/TaskClusterService.scala
@@ -129,7 +129,7 @@ class TaskClusterService @Inject() (repository: TaskClusterRepository)
     *
     * @param params        The search parameters from the cookie or the query string parameters.
     * @param ignoreLocked  Whether to include locked tasks (by other users) or not
-    * @return The list of Tasks found within the bounding box and the total count of tasks if not bounding
+    * @return The list of Tasks found within the bounding box
     */
   def getTaskMarkerDataInBoundingBox(
       user: User,

--- a/app/org/maproulette/framework/service/TaskClusterService.scala
+++ b/app/org/maproulette/framework/service/TaskClusterService.scala
@@ -156,21 +156,6 @@ class TaskClusterService @Inject() (repository: TaskClusterRepository)
         ignoreLocked
       )
 
-    if (params.projectEnabled.getOrElse(false))
-      query = query.addFilterGroup(
-        FilterGroup(
-          List(
-            BaseParameter(
-              Project.FIELD_ENABLED,
-              true,
-              Operator.BOOL,
-              useValueDirectly = true,
-              table = Some("p")
-            )
-          )
-        )
-      )
-
     query = params.taskParams.excludeTaskIds match {
       case Some(excludedIds) if !excludedIds.isEmpty =>
         //this.appendInWhereClause(whereClause, s"(tasks.id NOT IN (${excludedIds.mkString(",")}))")

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -418,64 +418,6 @@ class ChallengeDAL @Inject() (
     }
   }
 
-  val markerParser: RowParser[ClusteredPoint] = {
-    get[Long]("tasks.id") ~
-      get[String]("tasks.name") ~
-      get[Long]("tasks.parent_id") ~
-      get[String]("challenges.name").? ~
-      get[String]("challengeName").? ~
-      get[String]("location") ~
-      get[Int]("tasks.status") ~
-      get[Int]("tasks.priority") ~
-      get[Option[Long]]("tasks.bundle_id") ~
-      get[Option[Boolean]]("tasks.is_bundle_primary") ~
-      get[Option[Int]]("task_review.review_status") ~
-      get[Option[Int]]("task_review.meta_review_status") map {
-      case id ~ name ~ parentId ~ parentName ~ orParentName ~ location ~ status ~
-            priority ~ bundleId ~
-            isBundlePrimary ~ reviewStatus ~
-            metaReviewStatus =>
-        val locationJSON = Json.parse(location)
-        val coordinates  = (locationJSON \ "coordinates").as[List[Double]]
-        val point        = Point(coordinates(1), coordinates.head)
-        val pointReview =
-          PointReview(
-            reviewStatus,
-            None,
-            None,
-            None,
-            metaReviewStatus,
-            None,
-            None,
-            None,
-            None
-          )
-        ClusteredPoint(
-          id,
-          -1,
-          "",
-          name,
-          parentId,
-          parentName.getOrElse(orParentName.get),
-          point,
-          JsString(""),
-          "",
-          DateTime.now(),
-          -1,
-          Actions.ITEM_TYPE_TASK,
-          status,
-          None,
-          None,
-          None,
-          None,
-          pointReview,
-          priority,
-          bundleId,
-          isBundlePrimary
-        )
-    }
-  }
-
   private val DEFAULT_NUM_CHILDREN_LIST = 1000
 
   /**

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -418,6 +418,64 @@ class ChallengeDAL @Inject() (
     }
   }
 
+  val markerParser: RowParser[ClusteredPoint] = {
+    get[Long]("tasks.id") ~
+      get[String]("tasks.name") ~
+      get[Long]("tasks.parent_id") ~
+      get[String]("challenges.name").? ~
+      get[String]("challengeName").? ~
+      get[String]("location") ~
+      get[Int]("tasks.status") ~
+      get[Int]("tasks.priority") ~
+      get[Option[Long]]("tasks.bundle_id") ~
+      get[Option[Boolean]]("tasks.is_bundle_primary") ~
+      get[Option[Int]]("task_review.review_status") ~
+      get[Option[Int]]("task_review.meta_review_status") map {
+      case id ~ name ~ parentId ~ parentName ~ orParentName ~ location ~ status ~
+            priority ~ bundleId ~
+            isBundlePrimary ~ reviewStatus ~
+            metaReviewStatus =>
+        val locationJSON = Json.parse(location)
+        val coordinates  = (locationJSON \ "coordinates").as[List[Double]]
+        val point        = Point(coordinates(1), coordinates.head)
+        val pointReview =
+          PointReview(
+            reviewStatus,
+            None,
+            None,
+            None,
+            metaReviewStatus,
+            None,
+            None,
+            None,
+            None
+          )
+        ClusteredPoint(
+          id,
+          -1,
+          "",
+          name,
+          parentId,
+          parentName.getOrElse(orParentName.get),
+          point,
+          JsString(""),
+          "",
+          DateTime.now(),
+          -1,
+          Actions.ITEM_TYPE_TASK,
+          status,
+          None,
+          None,
+          None,
+          None,
+          pointReview,
+          priority,
+          bundleId,
+          isBundlePrimary
+        )
+    }
+  }
+
   private val DEFAULT_NUM_CHILDREN_LIST = 1000
 
   /**

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -571,7 +571,7 @@ PUT     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.framework.c
 #     in: query
 #     description: Optional flag to have geometries data returned for each task.
 ###
-PUT     /markers/box/:left/:bottom/:right/:top        @org.maproulette.framework.controller.TaskController.getTaskMarkerDataInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 500, excludeLocked:Boolean ?= false, includeGeometries:Boolean ?= false)
+PUT     /markers/box/:left/:bottom/:right/:top        @org.maproulette.framework.controller.TaskController.getTaskMarkerDataInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 500, excludeLocked:Boolean ?= false, includeGeometries:Boolean ?= false, includeTags:Boolean ?= false)
 ###
 # tags: [ Task ]
 # summary: Update Task Changeset

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -537,6 +537,43 @@ GET     /tasks/random                               @org.maproulette.controllers
 PUT     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.framework.controller.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", includeTotal:Boolean ?= false, includeGeometries:Boolean ?=false, includeTags:Boolean ?= false)
 ###
 # tags: [ Task ]
+# summary: Retrieves Task Marker Data within a bounding box
+# description: Retrieves task marker data within a given bounding box.
+# responses:
+#   '200':
+#     description: The list of markers representing Tasks that match the search criteria within the bounding box.
+#     content:
+#       application/json:
+#         schema:
+#           type: array
+#           items:
+#             $ref: '#/components/schemas/org.maproulette.framework.model.ClusteredPoint'
+# parameters:
+#   - name: left
+#     in: path
+#     description: The minimum latitude for the bounding box.
+#   - name: bottom
+#     in: path
+#     description: The minimum longitude for the bounding box.
+#   - name: right
+#     in: path
+#     description: The maximum latitude for the bounding box.
+#   - name: top
+#     in: path
+#     description: The maximum longitude for the bounding box.
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 1.
+#   - name: excludeLocked
+#     in: query
+#     description: Ignore the lock status of the task. So true will include all tasks, including ones locked by another user.
+#   - name: includeGeometries
+#     in: query
+#     description: Optional flag to have geometries data returned for each task.
+###
+PUT     /markers/box/:left/:bottom/:right/:top        @org.maproulette.framework.controller.TaskController.getTaskMarkerDataInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 500, excludeLocked:Boolean ?= false, includeGeometries:Boolean ?= false)
+###
+# tags: [ Task ]
 # summary: Update Task Changeset
 # description: Will update the changeset of the task. It will do this by attempting to match the OSM changeset to the Task based on the geometry and the time that the changeset was executed.
 # responses:

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -508,16 +508,16 @@ GET     /tasks/random                               @org.maproulette.controllers
 # parameters:
 #   - name: left
 #     in: path
-#     description: The minimum latitude for the bounding box.
+#     description: The minimum longitude for the bounding box.
 #   - name: bottom
 #     in: path
-#     description: The minimum longitude for the bounding box.
+#     description: The minimum latitude for the bounding box.
 #   - name: right
 #     in: path
-#     description: The maximum latitude for the bounding box.
+#     description: The maximum longitude for the bounding box.
 #   - name: top
 #     in: path
-#     description: The maximum longitude for the bounding box.
+#     description: The maximum latitude for the bounding box.
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 1.
@@ -551,16 +551,16 @@ PUT     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.framework.c
 # parameters:
 #   - name: left
 #     in: path
-#     description: The minimum latitude for the bounding box.
+#     description: The minimum longitude for the bounding box.
 #   - name: bottom
 #     in: path
-#     description: The minimum longitude for the bounding box.
+#     description: The minimum latitude for the bounding box.
 #   - name: right
 #     in: path
-#     description: The maximum latitude for the bounding box.
+#     description: The maximum longitude for the bounding box.
 #   - name: top
 #     in: path
-#     description: The maximum longitude for the bounding box.
+#     description: The maximum latitude for the bounding box.
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 1.


### PR DESCRIPTION
The ` PUT     /tasks/box/:left/:bottom/:right/:top ` endpoint has some unneeded complexity when fetching for task markers. The reason why that endpoint was so complex is because it is also used to fetch task table data. This led to slower performance when fetching markers because paging, ordering, and sorting was applied.

Because that structure is needed for the tables but not for fetching tasks markers, I have created a new endpoint to reduce complexity: `PUT     /tasks/markers/:left/:bottom/:right/:top `.

This new endpoint exports the same task data as the previous endpoint, but doesn't query for the total task count, and also doesn't do any ordering or paging.

21771 task in view with 1001 task limit:
Old endpoint (Time to complete: ~ 1.1s-1.9s ):
<img width="1453" alt="Screenshot 2024-07-19 at 4 36 15 PM" src="https://github.com/user-attachments/assets/9ec9f0d2-25a5-4e6e-a14a-f2b7631616d6">

New endpoint  (Time to complete: ~ 400ms-600ms):
<img width="1453" alt="Screenshot 2024-07-19 at 4 36 33 PM" src="https://github.com/user-attachments/assets/df1354b6-ee05-44fd-bfae-e5f92f5a3eb8">

977 task in view with 1001 task limit:
Old endpoint  (Time to complete: ~ 450ms-700ms):
<img width="1455" alt="Screenshot 2024-07-19 at 4 37 34 PM" src="https://github.com/user-attachments/assets/42dd79db-e536-4afd-a346-3ae69e3bfe95">

New endpoint  (Time to complete: ~300ms-550ms):
<img width="1454" alt="Screenshot 2024-07-19 at 4 37 59 PM" src="https://github.com/user-attachments/assets/10ae372d-c40c-4b32-9579-e7f3002e3ef1">


Times were recorded on the same device at a similar time, and ran multiple times to get an average. There is a small performance increase with the new endpoint when the number of tasks in view is below the limit. A bigger performance increase is noticeable whenever there are significantly more than 1001 tasks(or the limit) as the endpoint no longer needs to query for all the tasks the meet the filter requirements to get the total tssk count.