### PR TITLE
update tasks_remaining column in challenge table

### DIFF
--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -173,11 +173,12 @@ class ChallengeRepository @Inject() (override val db: Database) extends Reposito
       SQL(
         s"""
            |UPDATE challenges
-           |SET completion_percentage = new_completion_percentage
+           |SET completion_percentage = new_completion_percentage, tasks_remaining = new_tasks_remaining
            |FROM (
            |    SELECT
            |        challenges.id AS challenge_id,
-           |        completed_task_counts.completed_tasks * 100 / total_task_counts.total_tasks AS new_completion_percentage
+           |        completed_task_counts.completed_tasks * 100 / total_task_counts.total_tasks AS new_completion_percentage,
+           |        total_task_counts.total_tasks - completed_task_counts.completed_tasks AS new_tasks_remaining
            |    FROM
            |        challenges
            |    JOIN (


### PR DESCRIPTION
The scheduled MapRoulette backend task 'updateCompletionMetricsOfActiveChallenges' does not update the `challenges.tasks_remaining` metric, which appears to be its original intent. This field is used in the UI to allow users to sort challenges by the "remaining tasks". 

This PR tweaks the scheduled task to update `challenges.tasks_remaining`, along with the `challenges.completion_progress`.

Resolves: https://github.com/maproulette/maproulette3/issues/2324