### PR TITLE
Remove quotes around HOCON substitutions

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -182,7 +182,7 @@ maproulette {
   # Do not use the default value in production, generate a new key and set it via conf or 'MAPROULETTE_SECRET_KEY' env.
   # A secure way to get a distinct key is to run 'openssl rand -base64 32' and set the output as the secret key.
   secret.key = "%APPLICATION_SECRET%"
-  secret.key = "${?MAPROULETTE_SECRET_KEY}"
+  secret.key = ${?MAPROULETTE_SECRET_KEY}
 
   # redirect for OSM
   frontend="http://127.0.0.1:3000"

--- a/conf/dev.conf.example
+++ b/conf/dev.conf.example
@@ -4,7 +4,7 @@ include "application.conf"
 # A secure way to get a distinct key is to run 'openssl rand -base64 32' and set the output as the secret key.
 # Play 2.9 requires a key of at least 32 characters https://github.com/maproulette/maproulette-backend/issues/1117
 play.http.secret.key = "DEVLOCAL_1z8rvducX6AaMTXQl4olw71YHj3MCFpRXXTB73TNnTc="
-play.http.secret.key = "${?APPLICATION_SECRET}"
+play.http.secret.key = ${?APPLICATION_SECRET}
 
 db.default {
   url="jdbc:postgresql://localhost:5432/mp_dev"
@@ -26,7 +26,7 @@ maproulette {
   # Do not use the default value in production, generate a new key and set it via conf or 'MAPROULETTE_SECRET_KEY' env.
   # A secure way to get a distinct key is to run 'openssl rand -base64 32' and set the output as the secret key.
   secret.key = "DEVLOCAL_Jw8W2PMl434eL85+IRvoT7DA+eNR9a9N3ZK2Gfx4ecs="
-  secret.key = "${?MAPROULETTE_SECRET_KEY}"
+  secret.key = ${?MAPROULETTE_SECRET_KEY}
 
   scheduler {
     startTimeJitterForMinuteTasks = "15 seconds"


### PR DESCRIPTION
In HOCON, variable substitutions are not performed if the replacement part is in quotes.

From the manual:

Substitutions are not parsed inside quoted strings. To get a string containing a substitution, you must use value concatenation with the substitution in the unquoted portion:

key : ${animal.favorite} is my favorite animal