### PR TITLE
Fix deleted parent filter

### DIFF
--- a/app/org/maproulette/framework/mixins/TaskFilterMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskFilterMixin.scala
@@ -89,16 +89,18 @@ trait TaskFilterMixin {
     query.addFilterGroup(
       FilterGroup(
         List(
-          FilterParameter.conditional(
+          BaseParameter(
             Challenge.FIELD_DELETED,
             false,
-            Operator.BOOL,
+            Operator.EQ,
+            useValueDirectly = true,
             table = Some("c")
           ),
-          FilterParameter.conditional(
+          BaseParameter(
             Project.FIELD_DELETED,
             false,
-            Operator.BOOL,
+            Operator.EQ,
+            useValueDirectly = true,
             table = Some("p")
           )
         )

--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -76,8 +76,6 @@ class TaskClusterRepository @Inject() (override val db: Database, challengeDAL: 
       query: Query,
       numberOfPoints: Int
   ): (StringBuilder, List[NamedParameter]) = {
-    val whereClause = query.filter.sql() + " AND c.deleted = false AND p.deleted = false"
-
     val queryString = s"""FROM (
             SELECT tasks.*, tasks.id as taskId, tasks.status as taskStatus,
                    tasks.priority as taskPriority, tasks.geojson::TEXT as taskGeojson,
@@ -87,12 +85,12 @@ class TaskClusterRepository @Inject() (override val db: Database, challengeDAL: 
                           CASE WHEN COUNT(*) < $numberOfPoints THEN COUNT(*) ELSE $numberOfPoints END
                         FROM tasks
                         $joinClause
-                        WHERE ${whereClause}
+                        WHERE ${query.filter.sql()}
                       )::Integer
                     ) OVER () AS kmeans, tasks.location as taskLocation, tasks.parent_id as challengeIds
             FROM tasks
             $joinClause
-            WHERE ${whereClause}
+            WHERE ${query.filter.sql()}
           ) AS ksub
           WHERE location IS NOT NULL
       """

--- a/app/org/maproulette/framework/service/TaskClusterService.scala
+++ b/app/org/maproulette/framework/service/TaskClusterService.scala
@@ -96,21 +96,6 @@ class TaskClusterService @Inject() (repository: TaskClusterRepository)
         ignoreLocked
       )
 
-    if (params.projectEnabled.getOrElse(false))
-      query = query.addFilterGroup(
-        FilterGroup(
-          List(
-            BaseParameter(
-              Project.FIELD_ENABLED,
-              true,
-              Operator.BOOL,
-              useValueDirectly = true,
-              table = Some("p")
-            )
-          )
-        )
-      )
-
     query = params.taskParams.excludeTaskIds match {
       case Some(excludedIds) if !excludedIds.isEmpty =>
         //this.appendInWhereClause(whereClause, s"(tasks.id NOT IN (${excludedIds.mkString(",")}))")


### PR DESCRIPTION
 Both the  /taskCluster endpoint and the /tasks/box/:left/:bottom/:right/:top endpoint should return the same tasks (the format of the data should be different, but the tasks themselves should be the same and the amount of tasks should be the same).
 
Issue: The two endpoints, when passed the same filtering parameters, would pass back different results.

Solution: Fixed the filtering conditions of these two endpoints:
 `PUT     /taskCluster `
 `PUT     /tasks/box/:left/:bottom/:right/:top`
 
 More details on the solution: 
 - Remove a manually added filter on enabled challenges from the taskCluster endpoint and use the built in search parameter instead.
 - Fix the deleted challenges and projects filters to filter for challenges and projects that have a "false" deleted status. 
 - Remove manually added filter on deleted projects and challenges.
 
 related: https://github.com/maproulette/maproulette3/issues/2211
 
 /taskCluster endpoint WHERE statement in sql query with the manually added "deleted" related filters: 
```
WHERE (tasks.location && ST_MakeEnvelope (-111.91609382363669, 40.714313359738256, -111.86871528359762, 40.748394608673685, 4326)) AND 
(tasks.status IN (0,3,6)) AND ((c.status IN (3,4,0,-1) OR c.status IS NULL)) AND 
(NOT c.requires_local) AND (c.enabled) AND (c.is_archived = false) AND 
c.deleted = false AND p.deleted = false`
```

 /tasks/box endpoint WHERE statement in sql query where filters on deleted project and challenges should be present: 
``` 
WHERE (p.enabled) AND (tasks.location && ST_MakeEnvelope (-111.91609382363669, 40.714313359738256, -111.86871528359762, 40.748394608673685, 4326)) AND 
(tasks.status IN (0,3,6)) AND ((c.status IN (3,4,0,-1) OR c.status IS NULL)) AND 
(NOT c.requires_local) AND (c.enabled) AND (c.is_archived = false) 
ORDER BY RANDOM() DESC LIMIT 1001 OFFSET 0;
```

 /taskCluster endpoint WHERE statement in sql query after change: 
```
WHERE (c.deleted = false AND p.deleted = false) AND (tasks.location && ST_MakeEnvelope (-111.90092327097236, 40.72337196386074, -111.87723400095282, 40.740412450956256, 4326)) AND 
(tasks.status IN (0,3,6)) AND ((c.status IN (3,4,0,-1) OR c.status IS NULL)) AND 
(NOT c.requires_local) AND (c.enabled) AND (c.is_archived = false)
```

 /tasks/box endpoint WHERE statement in sql query after change: 
```
WHERE (c.deleted = false AND p.deleted = false) AND (tasks.location && ST_MakeEnvelope (-111.90092327097236, 40.72337196386074, -111.87723400095282, 40.740412450956256, 4326)) AND 
(tasks.status IN (0,3,6)) AND ((c.status IN (3,4,0,-1) OR c.status IS NULL)) AND 
(NOT c.requires_local) AND (c.enabled) AND (c.is_archived = false) 
ORDER BY RANDOM() DESC LIMIT 1001 OFFSET 0;
```

The reason why p.enabled is missing from the new  `PUT     /tasks/box/:left/:bottom/:right/:top` endpoint is because i removed the manually added condition that added it to that specific endpoint. The filter that is supposed to be used is blocked by a condition:
```
if (projectSearch) {
  filterList = this.filterProjects(params) :: this.filterProjectEnabled(params) :: filterList
}
```
projectSearch value is determined by this function:
```
  /**
    * Filters by p.display_name with a like %projectSearch%
    * @param params with inverting on 'ps'
    */
  def filterProjectSearch(params: SearchParameters): FilterGroup = {
    FilterGroup(
      List(
        FilterParameter.conditional(
          Project.FIELD_DISPLAY_NAME,
          s"'${SQLUtils.search(params.projectSearch.getOrElse(""))}'",
          Operator.ILIKE,
          params.invertFields.getOrElse(List()).contains("ps"),
          true,
          params.projectSearch != None,
          Some("p")
        )
      )
    )
  }
```
At the moment this change is necessary for the endpoints outputs to match, but further investigation of why that condition is needed.