### PR TITLE
fix stale review_started_at column

### DIFF
--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -86,7 +86,7 @@ class TaskReviewRepository @Inject() (
         Query
           .simple(List())
           .build(
-             """UPDATE task_review SET review_claimed_by = {userId}, review_claimed_at = NOW(), review_started_at = NOW()
+            """UPDATE task_review SET review_claimed_by = {userId}, review_claimed_at = NOW(), review_started_at = NOW()
                     WHERE task_id = {taskId} AND review_claimed_at IS NULL"""
           )
           .on(Symbol("taskId") -> task.id, Symbol("userId") -> user.id)

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -83,21 +83,11 @@ class TaskReviewRepository @Inject() (
         .executeUpdate()
 
       for (task <- taskList) {
-        var querystring =
-          """UPDATE task_review SET review_claimed_by = {userId}, review_claimed_at = NOW(), review_started_at = NOW()
-                    WHERE task_id = {taskId} AND review_claimed_at IS NULL"""
-
-        //don't reset review_started_at if task has already been reviewed
-        if (!task.review.reviewedAt.isEmpty) {
-          querystring =
-            """UPDATE task_review SET review_claimed_by = {userId}, review_claimed_at = NOW()
-                    WHERE task_id = {taskId} AND review_claimed_at IS NULL"""
-        }
-
         Query
           .simple(List())
           .build(
-            querystring
+             """UPDATE task_review SET review_claimed_by = {userId}, review_claimed_at = NOW(), review_started_at = NOW()
+                    WHERE task_id = {taskId} AND review_claimed_at IS NULL"""
           )
           .on(Symbol("taskId") -> task.id, Symbol("userId") -> user.id)
           .executeUpdate()


### PR DESCRIPTION
Issue: Upon a second attempt to review a task, the review session has the first review session’s start time recorded under the field review_started_at. This results in incorrect, resulting high review time being calculated.

Solution: this pr removes the condition that prevent the column from being updated when a review session is started.