### PR TITLE
add `Retrieve a Users Locked Tasks` endpoint

### DIFF
--- a/app/org/maproulette/framework/controller/UserController.scala
+++ b/app/org/maproulette/framework/controller/UserController.scala
@@ -251,6 +251,16 @@ class UserController @Inject() (
     }
   }
 
+  def getLockedTasks(
+      userId: Long,
+      limit: Long
+  ): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      val tasks = this.serviceManager.user.getLockedTasks(userId, user, limit)
+      Ok(Json.toJson(tasks))
+    }
+  }
+
   def saveTask(userId: Long, taskId: Long): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       this.serviceManager.user.saveTask(userId, taskId, user)

--- a/app/org/maproulette/framework/model/LockedTask.scala
+++ b/app/org/maproulette/framework/model/LockedTask.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+package org.maproulette.framework.model
+
+import org.joda.time.DateTime
+import org.maproulette.cache.CacheObject
+import org.maproulette.framework.psql.CommonField
+import play.api.libs.json.{Json, Format}
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
+
+// Define the LockedTask case class
+case class LockedTask(
+    override val id: Long,
+    challengeName: Option[String],
+    startedAt: DateTime
+) extends CacheObject[Long] {
+  // Implement the abstract member 'name'
+  override def name: String = "LockedTask"
+}
+
+/**
+  * Mapping between Task and Challenge and Lock
+  */
+case class LockedTaskData(
+    id: Long,
+    challengeName: Option[String],
+    startedAt: DateTime
+)
+
+object LockedTask extends CommonField {
+  // Use Json.format to automatically derive both Reads and Writes
+  implicit val lockedTaskFormat: Format[LockedTask] = Json.format[LockedTask]
+}
+
+// Define implicit Formats for LockedTaskData
+object LockedTaskData {
+  implicit val lockedTaskDataFormat: Format[LockedTaskData] = Json.format[LockedTaskData]
+}

--- a/app/org/maproulette/framework/model/LockedTask.scala
+++ b/app/org/maproulette/framework/model/LockedTask.scala
@@ -5,35 +5,18 @@
 package org.maproulette.framework.model
 
 import org.joda.time.DateTime
-import org.maproulette.cache.CacheObject
-import org.maproulette.framework.psql.CommonField
 import play.api.libs.json.{Json, Format}
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
 
-// Define the LockedTask case class
-case class LockedTask(
-    override val id: Long,
-    challengeName: Option[String],
-    startedAt: DateTime
-) extends CacheObject[Long] {
-  // Implement the abstract member 'name'
-  override def name: String = "LockedTask"
-}
-
 /**
-  * Mapping between Task and Challenge and Lock
+  * Mapping of object structure for fetching task lock data
   */
 case class LockedTaskData(
     id: Long,
     challengeName: Option[String],
     startedAt: DateTime
 )
-
-object LockedTask extends CommonField {
-  // Use Json.format to automatically derive both Reads and Writes
-  implicit val lockedTaskFormat: Format[LockedTask] = Json.format[LockedTask]
-}
 
 // Define implicit Formats for LockedTaskData
 object LockedTaskData {

--- a/app/org/maproulette/framework/model/LockedTask.scala
+++ b/app/org/maproulette/framework/model/LockedTask.scala
@@ -11,16 +11,14 @@ import play.api.libs.json.JodaReads._
 
 /**
   * Mapping of object structure for fetching task lock data
-  *
-  * id - A database assigned id for the Task
-  * parent - The id of the challenge of the locked task
-  * parentName - The name of the challenge of the locked task
-  * startedAt - The time that the task was locked
   */
 case class LockedTaskData(
     id: Long,
     parent: Long,
     parentName: String,
+    /**
+      * The time that the task was locked
+      */
     startedAt: DateTime
 )
 

--- a/app/org/maproulette/framework/model/LockedTask.scala
+++ b/app/org/maproulette/framework/model/LockedTask.scala
@@ -14,7 +14,7 @@ import play.api.libs.json.JodaReads._
   */
 case class LockedTaskData(
     id: Long,
-    parent: Option[Long],
+    parent: Long,
     parentName: Option[String],
     startedAt: DateTime
 )

--- a/app/org/maproulette/framework/model/LockedTask.scala
+++ b/app/org/maproulette/framework/model/LockedTask.scala
@@ -14,7 +14,8 @@ import play.api.libs.json.JodaReads._
   */
 case class LockedTaskData(
     id: Long,
-    challengeName: Option[String],
+    parent: Option[Long],
+    parentName: Option[String],
     startedAt: DateTime
 )
 

--- a/app/org/maproulette/framework/model/LockedTask.scala
+++ b/app/org/maproulette/framework/model/LockedTask.scala
@@ -11,11 +11,16 @@ import play.api.libs.json.JodaReads._
 
 /**
   * Mapping of object structure for fetching task lock data
+  *
+  * id - A database assigned id for the Task
+  * parent - The id of the challenge of the locked task
+  * parentName - The name of the challenge of the locked task
+  * startedAt - The time that the task was locked
   */
 case class LockedTaskData(
     id: Long,
     parent: Long,
-    parentName: Option[String],
+    parentName: String,
     startedAt: DateTime
 )
 

--- a/app/org/maproulette/framework/model/LockedTaskData.scala
+++ b/app/org/maproulette/framework/model/LockedTaskData.scala
@@ -5,7 +5,7 @@
 package org.maproulette.framework.model
 
 import org.joda.time.DateTime
-import play.api.libs.json.{Json, Format}
+import play.api.libs.json.{Format, Json}
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
 

--- a/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
+++ b/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
@@ -12,7 +12,12 @@ import org.joda.time.DateTime
 
 import javax.inject.{Inject, Singleton}
 import org.maproulette.framework.model.{Challenge, LockedTaskData, SavedChallenge, SavedTasks, Task}
-import org.maproulette.framework.psql.filter.{BaseParameter, FilterParameter, Operator, SubQueryFilter}
+import org.maproulette.framework.psql.filter.{
+  BaseParameter,
+  FilterParameter,
+  Operator,
+  SubQueryFilter
+}
 import org.maproulette.framework.psql._
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
 import play.api.db.Database

--- a/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
+++ b/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
@@ -6,18 +6,14 @@
 package org.maproulette.framework.repository
 
 import java.sql.Connection
+import anorm.{SQL, SqlParser}
+import anorm.SqlParser._
+import org.joda.time.DateTime
 
-import anorm.SQL
 import javax.inject.{Inject, Singleton}
-import org.maproulette.framework.model.{Challenge, SavedChallenge, SavedTasks}
-import org.maproulette.framework.psql.filter.{
-  BaseParameter,
-  FilterParameter,
-  Operator,
-  SubQueryFilter
-}
+import org.maproulette.framework.model.{Challenge, LockedTaskData, SavedChallenge, SavedTasks, Task}
+import org.maproulette.framework.psql.filter.{BaseParameter, FilterParameter, Operator, SubQueryFilter}
 import org.maproulette.framework.psql._
-import org.maproulette.framework.model.Task
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
 import play.api.db.Database
 
@@ -147,6 +143,40 @@ class UserSavedObjectsRepository @Inject() (
           |LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
           |""".stripMargin)(baseTable = "tasks")
         .as(taskDAL.parser.*)
+    }
+  }
+
+  /**
+    * Retrieves a list of locked tasks for a specific user.
+    *
+    * @param userId       The ID of the user for whom you are requesting the saved challenges.
+    * @param limit        The maximum number of tasks to return.
+    * @param c            An optional existing connection.
+    * @return A list tasks the user has locked, each item containing the task ID, its locked time, and the challenge name.
+    */
+  def getLockedTasks(
+      userId: Long,
+      limit: Long
+  )(implicit c: Option[Connection] = None): List[LockedTaskData] = {
+    this.withMRTransaction { implicit c =>
+      val parser = for {
+        id            <- get[Long]("id")
+        challengeName <- get[Option[String]]("challenges.challenge_name")
+        lockedTime    <- get[DateTime]("locked.locked_time")
+      } yield (LockedTaskData(id, challengeName, lockedTime))
+
+      val query = """
+                    SELECT t.id, l.locked_time, c.name AS challenge_name
+                    FROM tasks t
+                    INNER JOIN locked l ON t.id = l.item_id
+                    LEFT JOIN challenges c ON t.parent_id = c.id
+                    WHERE l.user_id = {userId}
+                    LIMIT {limit}
+                  """
+
+      SQL(query)
+        .on("userId" -> userId, "limit" -> limit)
+        .as(parser.*)
     }
   }
 

--- a/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
+++ b/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
@@ -6,7 +6,7 @@
 package org.maproulette.framework.repository
 
 import java.sql.Connection
-import anorm.{SQL, SqlParser}
+import anorm.SQL
 import anorm.SqlParser._
 import org.joda.time.DateTime
 

--- a/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
+++ b/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
@@ -165,13 +165,14 @@ class UserSavedObjectsRepository @Inject() (
   )(implicit c: Option[Connection] = None): List[LockedTaskData] = {
     this.withMRTransaction { implicit c =>
       val parser = for {
-        id            <- get[Long]("id")
-        challengeName <- get[Option[String]]("challenges.challenge_name")
-        lockedTime    <- get[DateTime]("locked.locked_time")
-      } yield (LockedTaskData(id, challengeName, lockedTime))
+        id         <- get[Long]("id")
+        parent     <- get[Option[Long]]("tasks.parent_id")
+        parentName <- get[Option[String]]("challenges.challenge_name")
+        lockedTime <- get[DateTime]("locked.locked_time")
+      } yield (LockedTaskData(id, parent, parentName, lockedTime))
 
       val query = """
-                    SELECT t.id, l.locked_time, c.name AS challenge_name
+                    SELECT t.id, t.parent_id, l.locked_time, c.name AS challenge_name
                     FROM tasks t
                     INNER JOIN locked l ON t.id = l.item_id
                     LEFT JOIN challenges c ON t.parent_id = c.id

--- a/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
+++ b/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
@@ -167,7 +167,7 @@ class UserSavedObjectsRepository @Inject() (
       val parser = for {
         id         <- get[Long]("id")
         parent     <- get[Long]("tasks.parent_id")
-        parentName <- get[Option[String]]("challenges.challenge_name")
+        parentName <- get[String]("challenges.challenge_name")
         lockedTime <- get[DateTime]("locked.locked_time")
       } yield (LockedTaskData(id, parent, parentName, lockedTime))
 
@@ -175,7 +175,7 @@ class UserSavedObjectsRepository @Inject() (
                     SELECT t.id, t.parent_id, l.locked_time, c.name AS challenge_name
                     FROM tasks t
                     INNER JOIN locked l ON t.id = l.item_id
-                    LEFT JOIN challenges c ON t.parent_id = c.id
+                    INNER JOIN challenges c ON t.parent_id = c.id
                     WHERE l.user_id = {userId}
                     LIMIT {limit}
                   """

--- a/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
+++ b/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
@@ -166,7 +166,7 @@ class UserSavedObjectsRepository @Inject() (
     this.withMRTransaction { implicit c =>
       val parser = for {
         id         <- get[Long]("id")
-        parent     <- get[Option[Long]]("tasks.parent_id")
+        parent     <- get[Long]("tasks.parent_id")
         parentName <- get[Option[String]]("challenges.challenge_name")
         lockedTime <- get[DateTime]("locked.locked_time")
       } yield (LockedTaskData(id, parent, parentName, lockedTime))

--- a/app/org/maproulette/framework/service/UserService.scala
+++ b/app/org/maproulette/framework/service/UserService.scala
@@ -842,6 +842,23 @@ class UserService @Inject() (
   }
 
   /**
+    * Retrieve all the tasks that have been locked by the provided user
+    *
+    * @param userId The id of the user
+    * @param user The user making the actual request
+    * @param limit
+    * @return A list of Tasks that have been locked by the user
+    */
+  def getLockedTasks(
+      userId: Long,
+      user: User,
+      limit: Long
+  ): List[LockedTaskData] = {
+    this.permission.hasReadAccess(UserType(), user)(userId)
+    this.savedObjectsRepository.getLockedTasks(userId, limit)
+  }
+
+  /**
     * Saves the task for the user, will validate that the task actually exists first based on the
     * provided id
     *

--- a/conf/v2_route/user.api
+++ b/conf/v2_route/user.api
@@ -335,7 +335,7 @@ GET     /user/:userId/savedTasks                    @org.maproulette.framework.c
 #   '401':
 #     description: The user is not authorized to make this request.
 #   '404':
-#     description: If User or Task for provided ID's is not found.
+#     description: userId is not known.
 # parameters:
 #   - name: userId
 #     in: path

--- a/conf/v2_route/user.api
+++ b/conf/v2_route/user.api
@@ -331,9 +331,11 @@ GET     /user/:userId/savedTasks                    @org.maproulette.framework.c
 #         schema:
 #           type: array
 #           items:
-#             $ref: '#/components/schemas/org.maproulette.framework.model.Task'
+#             $ref: '#/components/schemas/org.maproulette.framework.model.LockedTask'
 #   '401':
-#     description: The user is not authorized to make this request
+#     description: The user is not authorized to make this request.
+#   '404':
+#     description: If User or Task for provided ID's is not found.
 # parameters:
 #   - name: userId
 #     in: path
@@ -341,6 +343,10 @@ GET     /user/:userId/savedTasks                    @org.maproulette.framework.c
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 50.
+#     required: false
+#     schema:
+#       type: integer
+#       default: 50
 ###
 GET     /user/:userId/lockedTasks                    @org.maproulette.framework.controller.UserController.getLockedTasks(userId:Long, limit:Int ?= 50)
 ###

--- a/conf/v2_route/user.api
+++ b/conf/v2_route/user.api
@@ -331,7 +331,7 @@ GET     /user/:userId/savedTasks                    @org.maproulette.framework.c
 #         schema:
 #           type: array
 #           items:
-#             $ref: '#/components/schemas/org.maproulette.framework.model.LockedTask'
+#             $ref: '#/components/schemas/org.maproulette.framework.model.LockedTaskData'
 #   '401':
 #     description: The user is not authorized to make this request.
 #   '404':

--- a/conf/v2_route/user.api
+++ b/conf/v2_route/user.api
@@ -321,6 +321,30 @@ DELETE   /user/:userId/unsave/:challengeId          @org.maproulette.framework.c
 GET     /user/:userId/savedTasks                    @org.maproulette.framework.controller.UserController.getSavedTasks(userId:Long, challengeIds:String ?= "", limit:Int ?= 10, page:Int ?= 0)
 ###
 # tags: [ User ]
+# summary: Retrieves Users Locked Tasks
+# description: Retrieves a list of all the tasks the user with the matching id has locked
+# responses:
+#   '200':
+#     description: The retrieved Tasks
+#     content:
+#       application/json:
+#         schema:
+#           type: array
+#           items:
+#             $ref: '#/components/schemas/org.maproulette.framework.model.Task'
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The id of the user to retrieve the locked tasks for
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 50.
+###
+GET     /user/:userId/lockedTasks                    @org.maproulette.framework.controller.UserController.getLockedTasks(userId:Long, limit:Int ?= 50)
+###
+# tags: [ User ]
 # summary: Saves a Task for a User
 # description: Saves a Task to a user account
 # responses:


### PR DESCRIPTION
Adds the new endpoint: 
`GET     /user/:userId/lockedTasks?limit={Long}`

This endpoint retrieves a list of data. For each task that is locked by a user, or where the user_id in the locked table matches the requested userId, it returns the task's id, challenge id, challenge name, and the time it was locked.

Example of output:
```
[
    {
        "id": 50109,
        "parent": 63,
        "parentName": "Fix all roads in west Wichita",
        "startedAt": "2024-07-30T17:56:59.650-05:00"
    },
    {
        "id": 50207,
        "parent": 63,
        "parentName": "Fix all roads in west Wichita",
        "startedAt": "2024-07-29T15:40:42.664-05:00"
    },
    {
        "id": 50206,
        "parent": 63,
        "parentName": "Fix all roads in west Wichita",
        "startedAt": "2024-07-29T15:40:42.669-05:00"
    },
    {
        "id": 50210,
        "parent": 63,
        "parentName": "Fix all roads in west Wichita",
        "startedAt": "2024-07-29T15:40:42.673-05:00"
    }
]
```