### PR TITLE
Swagger: How to get the API Key and other notes

### DIFF
--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -2,7 +2,7 @@
 openapi: "3.0.3"
 info:
   title: "MapRoulette API"
-  description: "API for MapRoulette enabling the creation and maintenance of MapRoulette challenges"
+  description: "API for MapRoulette enabling the creation and maintenance of MapRoulette challenges. Using the api requires a user apiKey which you can find at the bottom of https://maproulette.org/user/profile. There are Python and Java Wrapper for this API which are linked in the Navigation at https://learn.maproulette.org/en-us/documentation/."
   contact:
     name: "maproulette@maproulette.org"
   license:
@@ -315,4 +315,4 @@ components:
       type: apiKey
       in: header
       name: apiKey
-      description: The user's apiKey to authorize the request
+      description: The user's apiKey to authorize the request; find it on https://maproulette.org/user/profile at the bottom of the page.


### PR DESCRIPTION
I found it way to hard to collect these bits of information. This is mainly due to the fact that Google links directly to https://maproulette.org/docs/swagger-ui/index.html?url=/assets/swagger.json&docExpansion=none so that becomes the entry point when looking for the API. But also due to the fact that there is no API docs entry page in the docs which could explain some basic things. 

I finally found the info where to get the API key in https://github.com/osmlab/maproulette-python-client/tree/master?tab=readme-ov-file. I suggest to add the info where to find the API key right here; I added them in two places.

I also thing the swagger page should hint at the libraries. I did that too but without linking to them directly so only one place need to keep updates links (the docs page).

Finally, my understanding is that all?? api calls require the API key? Is that true? I think this is important information and I added it to the description as well. Happy to update this with a better explanation on what is public / requires a key.
