### PR TITLE
Add active indicator column to tags table

### DIFF
--- a/app/org/maproulette/framework/model/Tag.scala
+++ b/app/org/maproulette/framework/model/Tag.scala
@@ -44,7 +44,6 @@ object Tag extends CommonField {
   val TABLE_TAGS_ON_TASKS      = "tags_on_tasks"
   val TABLE_TAGS_ON_CHALLENGES = "tags_on_challenges"
   val FIELD_TAG_TYPE           = "tag_type"
-  val FIELD_ACTIVE             = "active"
   val FIELD_PARENT_ID          = "parent_id"
   val FIELD_ENABLED            = "enabled"
   val FIELD_TASK_ID            = "task_id"

--- a/app/org/maproulette/framework/model/Tag.scala
+++ b/app/org/maproulette/framework/model/Tag.scala
@@ -24,7 +24,8 @@ case class Tag(
     description: Option[String] = None,
     created: DateTime = DateTime.now(),
     modified: DateTime = DateTime.now(),
-    tagType: String = "challenges"
+    tagType: String = "challenges",
+    active: Boolean = true
 ) extends CacheObject[Long]
 
 /**
@@ -43,6 +44,7 @@ object Tag extends CommonField {
   val TABLE_TAGS_ON_TASKS      = "tags_on_tasks"
   val TABLE_TAGS_ON_CHALLENGES = "tags_on_challenges"
   val FIELD_TAG_TYPE           = "tag_type"
+  val FIELD_ACTIVE             = "active"
   val FIELD_PARENT_ID          = "parent_id"
   val FIELD_ENABLED            = "enabled"
   val FIELD_TASK_ID            = "task_id"

--- a/app/org/maproulette/framework/repository/TagRepository.scala
+++ b/app/org/maproulette/framework/repository/TagRepository.scala
@@ -198,9 +198,10 @@ object TagRepository {
     get[Long]("tags.id") ~
       get[String]("tags.name") ~
       get[Option[String]]("tags.description") ~
-      get[String]("tags.tag_type") map {
-      case id ~ name ~ description ~ tagType =>
-        new Tag(id, name.toLowerCase, description, tagType = tagType)
+      get[String]("tags.tag_type") ~
+      get[Boolean]("tags.active") map {
+      case id ~ name ~ description ~ tagType ~ active =>
+        new Tag(id, name.toLowerCase, description, tagType = tagType, active = active)
     }
   }
 
@@ -209,9 +210,10 @@ object TagRepository {
       get[Long]("tags.id") ~
       get[String]("tags.name") ~
       get[Option[String]]("tags.description") ~
-      get[String]("tags.tag_type") map {
-      case taskId ~ id ~ name ~ description ~ tagType => {
-        new TaskTag(taskId, new Tag(id, name.toLowerCase, description, tagType = tagType))
+      get[String]("tags.tag_type") ~
+      get[Boolean]("tags.active") map {
+      case taskId ~ id ~ name ~ description ~ tagType ~ active => {
+        new TaskTag(taskId, new Tag(id, name.toLowerCase, description, tagType = tagType, active = active))
       }
     }
   }

--- a/app/org/maproulette/framework/repository/TagRepository.scala
+++ b/app/org/maproulette/framework/repository/TagRepository.scala
@@ -213,7 +213,10 @@ object TagRepository {
       get[String]("tags.tag_type") ~
       get[Boolean]("tags.active") map {
       case taskId ~ id ~ name ~ description ~ tagType ~ active => {
-        new TaskTag(taskId, new Tag(id, name.toLowerCase, description, tagType = tagType, active = active))
+        new TaskTag(
+          taskId,
+          new Tag(id, name.toLowerCase, description, tagType = tagType, active = active)
+        )
       }
     }
   }

--- a/conf/evolutions/default/96.sql
+++ b/conf/evolutions/default/96.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+ALTER TABLE IF EXISTS tags
+ADD COLUMN active Boolean DEFAULT true;;
+
+# --- !Downs
+ALTER TABLE IF EXISTS tags
+DROP COLUMN active;;


### PR DESCRIPTION
This PR introduces a new 'active' column to the tags table, enhancing the customizability of error tags. The 'active' column allows error tags to be filtered from the available options on the frontend, while also preserving the history of past error tags for history maintenance.