### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+ARG TEMURIN_JDK_TAG=17
+FROM docker.io/library/eclipse-temurin:${TEMURIN_JDK_TAG} AS builder
+
+ARG SBT_VERSION=1.9.9
+
+# This is based on mozilla docker-sbt https://github.com/mozilla/docker-sbt/blob/main/Dockerfile
+# Install sbt
+RUN \
+  curl -L -o sbt-$SBT_VERSION.deb https://repo.scala-sbt.org/scalasbt/debian/sbt-$SBT_VERSION.deb && \
+  dpkg -i sbt-$SBT_VERSION.deb && \
+  rm sbt-$SBT_VERSION.deb && \
+  apt-get update && \
+  apt-get install --no-install-recommends -y git sbt unzip
+
+COPY . /maproulette-api
+
+WORKDIR /maproulette-api
+RUN \
+    sbt evicted && \
+    sbt clean compile dist && \
+    unzip -d / target/universal/MapRouletteAPI.zip
+
+FROM docker.io/library/eclipse-temurin:${TEMURIN_JDK_TAG}
+
+# Runtime image needs to have the most up-to-date patches
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    rm -rf /var/lib/apt/lists/*
+RUN \
+    groupadd -g 1001 maproulette && \
+    useradd --uid 1001 --gid 1001 --groups 0 --create-home --home-dir /MapRouletteAPI maproulette && \
+    chmod 0775 /MapRouletteAPI && \
+    chown -R 1001:0 /MapRouletteAPI
+
+COPY --from=builder --chown=1001:0 /MapRouletteAPI /MapRouletteAPI
+USER maproulette
+WORKDIR /MapRouletteAPI
+
+CMD /MapRouletteAPI/bin/maprouletteapi -Dhttp.port=80

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker run \
 * NOTE: It is helpful to see logs with `docker logs -f maproulette-postgis`
 * NOTE: To stop the container, that'd be `docker stop maproulette-postgis`. Then you can start it again using `docker start maproulette-postgis`.
 
-#### MapRoulette Database Configuration
+#### Configuration
 
 Clone the maproulette-backend repository and `cd` to that directory, and create `conf/dev.conf` using the example file:
 
@@ -109,6 +109,13 @@ db.default {
   password="maproulette-db-pass"
 }
 ```
+
+Alternatively, you can configure the backend using environment variables. The
+variables `MR_DATABASE_URL`, `MR_DATABASE_USERNAME` and `MR_DATABASE_PASSWORD`
+control the same values as the config parameters shown above. Look in `conf/
+application.conf` for what else can be overridden via environment variables.
+Any pattern like `${?FOO}` in that file will be replaced with the value of the
+environment variable `FOO` at runtime.
 
 Now start the MapRoulette server! Run this command in a terminal, **not within Intellij/vscode**:
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -186,6 +186,7 @@ maproulette {
 
   # redirect for OSM
   frontend="http://127.0.0.1:3000"
+  frontend=${?MR_FRONTEND_URL}
 
   task {
     # number of days till we reset the status if it has not been fixed


### PR DESCRIPTION
This PR adds a production-ready Dockerfile. It is similar to what's currently in https://github.com/maproulette/maproulette2-docker, except using a more conventional build workflow (building from the source code in the CWD, instead of using `git clone`).

In a future PR I'll be adding a CI step to build an image from this Dockerfile and push it to GHCR. That image will then be deployed automatically to staging, and when new releases are published, also to prod. Ultimately we won't need the maproulette2-docker repo anymore and can probably archive it.

Having official Docker images will also make it easier for anyone running their own instance of MapRoulette to keep up with new versions.