### PR TITLE
fix "deletion already in-progress" bug

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -578,7 +578,15 @@ class ChallengeController @Inject() (
               try {
                 this.dal.deleteTasks(user, challengeId, Utils.split(statusFilters).map(_.toInt))
               } finally {
-                dalManager.challenge.update(Json.obj("status" -> originalStatus), user)(challengeId)
+                // Check if original status is defined before reverting
+                originalStatus match {
+                  case Some(status) =>
+                    dalManager.challenge.update(Json.obj("status" -> status), user)(challengeId)
+                  case None =>
+                    throw new InvalidException(
+                      "Original status is not defined, cannot revert status."
+                    )
+                }
               }
             }
             Ok


### PR DESCRIPTION
Issue originally discussed in slack #maproulette-dev channel: https://osmus.slack.com/archives/C04M1NHPEQY/p1730405450254649 

Issue: Challenges are unable to be edited in many ways whenever a task is in the process of deleting tasks. There is an edge case scenario, that this pr fix's, were the "deleting tasks" status on a challenge persists indefinitely.

Steps to reproduce bug bug:
1. Create a challenge with no tasks ( results in a challenge with no status ).
2. Delete tasks in the challenge via the deleteTasks endpoint using the api.
3. Try again and see error.

This is fixed by preventing the challenge status resetting after all tasks are deleted if there was no original status.
