### PR TITLE
add feature type to csv export

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -824,10 +824,16 @@ class ChallengeController @Inject() (
           }
 
           // Find matching geojson feature properties
-          var propData = ""
+          var propData    = ""
+          var featureType = ""
           task.geojson match {
             case Some(g) =>
-              val taskProps = (Json.parse(g) \\ "properties")(0).as[JsObject]
+              val parsedFeature = Json.parse(g)
+              featureType = (parsedFeature \\ "geometry")(0) \ "type" match {
+                case JsDefined("node") => value.as[String]
+                case JsUndefined()     => "Unknown"
+              }
+              val taskProps = (parsedFeature \\ "properties")(0).as[JsObject]
               for (key <- propsToExportHeaders) {
                 (taskProps \ key) match {
                   case value: JsDefined =>
@@ -879,9 +885,8 @@ class ChallengeController @Inject() (
           var taskLink =
             s"[[hyperlink URL link=${urlPrefix}challenge/${task.parent}/task/${task.taskId}]]"
 
-          s"""${task.taskId},${taskLink},${task.parent},${challengeLink},"${task.name}","${Task.statusMap
-            .get(task.status)
-            .get}",""" +
+          s"""${task.taskId},${taskLink},${task.parent},${challengeLink},"${task.name},""" +
+            s""""${featureType}","${Task.statusMap.get(task.status).get}",""" +
             s""""${Challenge.priorityMap.get(task.priority).get}",${mappedOn},""" +
             s"""${task.completedTimeSpent.getOrElse("")},"${mapper}",""" +
             s"""${Task.reviewStatusMap.get(task.reviewStatus.getOrElse(-1)).get},""" +
@@ -901,7 +906,7 @@ class ChallengeController @Inject() (
             ResponseHeader(OK, Map(CONTENT_DISPOSITION -> s"attachment; filename=${filename}")),
           body = HttpEntity.Strict(
             ByteString(
-              s"""TaskID,TaskLink,ChallengeID,ChallengeLink,TaskName,TaskStatus,TaskPriority,MappedOn,CompletionTime,Mapper,ReviewStatus,Reviewer,ReviewedAt,ReviewTimeSeconds,AdditionalReviewers,Comments,BundleId,IsBundlePrimary,Tags${propsToExportHeaderString}${responseHeaders}\n"""
+              s"""TaskID,TaskLink,ChallengeID,ChallengeLink,TaskName,FeatureType,TaskStatus,TaskPriority,MappedOn,CompletionTime,Mapper,ReviewStatus,Reviewer,ReviewedAt,ReviewTimeSeconds,AdditionalReviewers,Comments,BundleId,IsBundlePrimary,Tags${propsToExportHeaderString}${responseHeaders}\n"""
             ).concat(ByteString(seqString.mkString("\n"))),
             Some("text/csv; header=present")
           )

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -830,8 +830,8 @@ class ChallengeController @Inject() (
             case Some(g) =>
               val parsedFeature = Json.parse(g)
               featureType = (parsedFeature \\ "geometry")(0) \ "type" match {
-                case JsDefined("node") => value.as[String]
-                case JsUndefined()     => "Unknown"
+                case JsDefined(value) => value.as[String]
+                case JsUndefined()    => "Unknown"
               }
               val taskProps = (parsedFeature \\ "properties")(0).as[JsObject]
               for (key <- propsToExportHeaders) {
@@ -885,7 +885,7 @@ class ChallengeController @Inject() (
           var taskLink =
             s"[[hyperlink URL link=${urlPrefix}challenge/${task.parent}/task/${task.taskId}]]"
 
-          s"""${task.taskId},${taskLink},${task.parent},${challengeLink},"${task.name},""" +
+          s"""${task.taskId},${taskLink},${task.parent},${challengeLink},"${task.name}",""" +
             s""""${featureType}","${Task.statusMap.get(task.status).get}",""" +
             s""""${Challenge.priorityMap.get(task.priority).get}",${mappedOn},""" +
             s"""${task.completedTimeSpent.getOrElse("")},"${mapper}",""" +

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -922,7 +922,7 @@ class ChallengeController @Inject() (
             ResponseHeader(OK, Map(CONTENT_DISPOSITION -> s"attachment; filename=${filename}")),
           body = HttpEntity.Strict(
             ByteString(
-              s"""TaskID,TaskLink,ChallengeID,ChallengeLink,TaskName,FeatureType,TaskStatus,TaskPriority,MappedOn,CompletionTime,Mapper,ReviewStatus,Reviewer,ReviewedAt,ReviewTimeSeconds,AdditionalReviewers,Comments,BundleId,IsBundlePrimary,Tags${propsToExportHeaderString}${responseHeaders}\n"""
+              s"""TaskID,TaskLink,ChallengeID,ChallengeLink,TaskName,GeometryType,TaskStatus,TaskPriority,MappedOn,CompletionTime,Mapper,ReviewStatus,Reviewer,ReviewedAt,ReviewTimeSeconds,AdditionalReviewers,Comments,BundleId,IsBundlePrimary,Tags${propsToExportHeaderString}${responseHeaders}\n"""
             ).concat(ByteString(seqString.mkString("\n"))),
             Some("text/csv; header=present")
           )

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -31,6 +31,7 @@ import org.maproulette.permissions.Permission
 import org.maproulette.provider.ChallengeProvider
 import org.maproulette.session.{SearchParameters, SessionManager}
 import org.maproulette.utils.Utils
+import org.maproulette.utils.CSVEncoder
 import play.api.http.HttpEntity
 import play.api.libs.Files
 import play.api.libs.json._
@@ -885,16 +886,31 @@ class ChallengeController @Inject() (
           var taskLink =
             s"[[hyperlink URL link=${urlPrefix}challenge/${task.parent}/task/${task.taskId}]]"
 
-          s"""${task.taskId},${taskLink},${task.parent},${challengeLink},"${task.name}",""" +
-            s""""${featureType}","${Task.statusMap.get(task.status).get}",""" +
-            s""""${Challenge.priorityMap.get(task.priority).get}",${mappedOn},""" +
-            s"""${task.completedTimeSpent.getOrElse("")},"${mapper}",""" +
-            s"""${Task.reviewStatusMap.get(task.reviewStatus.getOrElse(-1)).get},""" +
-            s""""${task.reviewedBy.getOrElse("")}",${reviewedAt},"${reviewTimeSeconds}",""" +
-            s""""${task.additionalReviewers.getOrElse(List()).mkString(", ")}",""" +
-            s""""${comments}","${task.bundleId.getOrElse("")}","${task.isBundlePrimary
-              .getOrElse("")}",""" +
-            s""""${task.tags.getOrElse("")}"${propData}${responseData}""".stripMargin
+          // Create a CSV row with more meaningful column names and data
+          val csvRow = List(
+            task.taskId,
+            taskLink,
+            task.parent,
+            challengeLink,
+            task.name,
+            featureType,
+            Task.statusMap.get(task.status).getOrElse(""),
+            Challenge.priorityMap.get(task.priority).getOrElse(""),
+            mappedOn,
+            task.completedTimeSpent.getOrElse(""),
+            mapper,
+            Task.reviewStatusMap.get(task.reviewStatus.getOrElse(-1)).get,
+            task.reviewedBy.getOrElse(""),
+            reviewedAt,
+            reviewTimeSeconds,
+            task.additionalReviewers.getOrElse(List()).mkString(", "),
+            comments,
+            task.bundleId.getOrElse(""),
+            task.isBundlePrimary.getOrElse(""),
+            task.tags.getOrElse("")
+          )
+
+          CSVEncoder.encodeRow(csvRow)
         })
 
         var propsToExportHeaderString = propsToExportHeaders.mkString(",")

--- a/app/org/maproulette/utils/CSVEncoder.scala
+++ b/app/org/maproulette/utils/CSVEncoder.scala
@@ -1,0 +1,16 @@
+package org.maproulette.utils
+
+object CSVEncoder {
+  def encodeRow(row: List[Any]): String = {
+    row.map(escape).mkString(",")
+  }
+
+  private def escape(value: Any): String = {
+    val strValue = value.toString
+    if (strValue.contains(",") || strValue.contains("\"") || strValue.contains("\n")) {
+      "\"" + strValue.replace("\"", "\"\"") + "\""
+    } else {
+      strValue
+    }
+  }
+} 

--- a/app/org/maproulette/utils/CSVEncoder.scala
+++ b/app/org/maproulette/utils/CSVEncoder.scala
@@ -13,4 +13,4 @@ object CSVEncoder {
       strValue
     }
   }
-} 
+}


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/1902

This pr add the FeatureType column to the task csv export tables. The main 3 results for the column will be "Point", "LineString", and "GeometryCollection", or unknown if there is no type. Edge case scenarios were another type is used (if this is possible) will results in the type value, example: 

feature: { geometry: [{ type: "MultiLineString" }]} -> FeatureType = "MultilineString". 

Equivalents:
MapRoulette              | OSM
Point                          | Node
LineString                  | Way
GeometryCollection | Relation