### PR TITLE
Challenge Rapid Dataset support

### DIFF
--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -136,8 +136,9 @@ case class ChallengeExtra(
     isArchived: Boolean = false,
     reviewSetting: Int = Challenge.REVIEW_SETTING_NOT_REQUIRED,
     taskWidgetLayout: Option[JsValue] = None,
+    datasetUrl: Option[String] = None,
     systemArchivedAt: Option[DateTime] = None,
-    presets: Option[List[String]] = None
+    presets: Option[List[String]] = None,
 ) extends DefaultWrites
 
 case class ChallengeListing(

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -138,7 +138,7 @@ case class ChallengeExtra(
     taskWidgetLayout: Option[JsValue] = None,
     datasetUrl: Option[String] = None,
     systemArchivedAt: Option[DateTime] = None,
-    presets: Option[List[String]] = None,
+    presets: Option[List[String]] = None
 ) extends DefaultWrites
 
 case class ChallengeListing(

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -264,6 +264,7 @@ object ChallengeRepository {
       get[Option[List[Long]]]("virtual_parent_ids") ~
       get[Boolean]("challenges.is_archived") ~
       get[Int]("challenges.review_setting") ~
+      get[Option[String]]("challenges.dataset_url") ~
       get[Option[JsValue]]("challenges.task_widget_layout") ~
       get[Option[DateTime]]("challenges.system_archived_at") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
@@ -272,7 +273,7 @@ object ChallengeRepository {
             mediumPriorityRule ~ lowPriorityRule ~ defaultZoom ~ minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~
             customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ preferredTags ~ preferredReviewTags ~
             limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~ dataOriginDate ~ requiresLocal ~ location ~ bounding ~
-            deleted ~ virtualParents ~ isArchived ~ reviewSetting ~ taskWidgetLayout ~ systemArchivedAt =>
+            deleted ~ virtualParents ~ isArchived ~ reviewSetting ~ datasetUrl ~ taskWidgetLayout ~ systemArchivedAt =>
         val hpr = highPriorityRule match {
           case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
           case r                                                                => r
@@ -330,7 +331,8 @@ object ChallengeRepository {
             isArchived,
             reviewSetting,
             taskWidgetLayout,
-            systemArchivedAt
+            datasetUrl,
+            systemArchivedAt,
           ),
           status,
           statusMessage,

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -332,7 +332,7 @@ object ChallengeRepository {
             reviewSetting,
             taskWidgetLayout,
             datasetUrl,
-            systemArchivedAt,
+            systemArchivedAt
           ),
           status,
           statusMessage,

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -477,7 +477,6 @@ class ChallengeDAL @Inject() (
 
     this.permission.hasObjectWriteAccess(challenge, user)
     this.cacheManager.withOptionCaching { () =>
-      var a = "a"
       val insertedChallenge =
         this.withMRTransaction { implicit c =>
           SQL"""INSERT INTO challenges (name, owner_id, parent_id, difficulty, description, info_link, blurb,

--- a/conf/evolutions/default/97.sql
+++ b/conf/evolutions/default/97.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+ALTER TABLE challenges ADD COLUMN dataset_url VARCHAR DEFAULT NULL;;
+
+# --- !Downs
+ALTER TABLE IF EXISTS challenges DROP COLUMN dataset_url;;


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2385

Deploy with: https://github.com/maproulette/maproulette3/pull/2494

Users can now add rapid dataset URLs to challenges via the create challenge form. The dataset url will be added to the rapid parameters in the Edit Mode window on the task inspection page.