### PR TITLE
Fix 'sbt: command not found' CI error

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -23,6 +23,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Create sbt dependencyTree
         env:
           CI: true
@@ -57,6 +58,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Run sbt tests with jacoco analysis
         env:
           APPLICATION_SECRET: ${{ needs.generate_app_secret.outputs.application_secret }}
@@ -95,6 +97,7 @@ jobs:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
         cache: sbt
+    - uses: sbt/setup-sbt@v1
     - name: Run sbt compile
       env:
         CI: true


### PR DESCRIPTION
This fixes a CI failure that appeared recently. The `ubuntu-latest` runner now refers to Ubuntu 24.04, which does not contain `sbt` by default. Adding the [setup-sbt](https://github.com/sbt/setup-sbt) action resolves the issue.