### PR TITLE
Update Bundle Naming Convention and Add Task Locking Endpoints

### DIFF
--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -286,11 +286,10 @@ class TaskBundleController @Inject() (
     */
   def unbundleTasks(
       id: Long,
-      taskIds: List[Long],
-      preventTaskIdUnlocks: List[Long]
+      taskIds: List[Long]
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      this.serviceManager.taskBundle.unbundleTasks(user, id, taskIds, preventTaskIdUnlocks)
+      this.serviceManager.taskBundle.unbundleTasks(user, id, taskIds)
       Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
     }
   }

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -262,17 +262,17 @@ class TaskBundleController @Inject() (
   }
 
   /**
-    *  Resets the bundle to the tasks provided, and unlock all tasks removed from current bundle
+    *  Sets the bundle to the tasks provided, and unlock all tasks removed from current bundle
     *
     * @param bundleId The id of the bundle
     * @param taskIds The task ids the bundle will reset to
     */
-  def resetTaskBundle(
+  def updateTaskBundle(
       id: Long,
       taskIds: List[Long]
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      this.serviceManager.taskBundle.resetTaskBundle(user, id, taskIds)
+      this.serviceManager.taskBundle.updateTaskBundle(user, id, taskIds)
       Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
     }
   }

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -201,12 +201,6 @@ class TaskBundleRepository @Inject() (
       }
 
       lockedTasks.foreach { task =>
-        try {
-          this.lockItem(user, task)
-        } catch {
-          case e: Exception =>
-            this.logger.warn(e.getMessage)
-        }
         taskRepository.cacheManager.cache.remove(task.id)
       }
     }
@@ -258,11 +252,6 @@ class TaskBundleRepository @Inject() (
                 )
                 .executeUpdate()
 
-              try {
-                this.unlockItem(user, task)
-              } catch {
-                case e: Exception => this.logger.warn(e.getMessage)
-              }
               taskRepository.cacheManager.cache.remove(task.id)
             case None => // do nothing
           }
@@ -310,11 +299,6 @@ class TaskBundleRepository @Inject() (
               "status" -> STATUS_CREATED
             )
             .executeUpdate()
-          try {
-            this.unlockItem(user, task)
-          } catch {
-            case e: Exception => this.logger.warn(e.getMessage)
-          }
         }
         taskRepository.cacheManager.cache.remove(task.id)
       }

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -112,12 +112,12 @@ class TaskBundleRepository @Inject() (
   }
 
   /**
-    *  Resets the bundle to the tasks provided, and unlock all tasks removed from current bundle
+    *  Sets the bundle to the tasks provided, and unlock all tasks removed from current bundle
     *
     * @param bundleId The id of the bundle
     * @param taskIds The task ids the bundle will reset to
     */
-  def resetTaskBundle(
+  def updateTaskBundle(
       user: User,
       bundleId: Long,
       taskIds: List[Long]

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -120,8 +120,7 @@ class TaskBundleService @Inject() (
   def unbundleTasks(
       user: User,
       bundleId: Long,
-      taskIds: List[Long],
-      preventTaskIdUnlocks: List[Long]
+      taskIds: List[Long]
   )(): TaskBundle = {
     val bundle = this.getTaskBundle(user, bundleId)
 
@@ -132,7 +131,7 @@ class TaskBundleService @Inject() (
       )
     }
 
-    this.repository.unbundleTasks(user, bundleId, taskIds, preventTaskIdUnlocks)
+    this.repository.unbundleTasks(user, bundleId, taskIds)
     this.getTaskBundle(user, bundleId)
   }
 

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -90,12 +90,12 @@ class TaskBundleService @Inject() (
   }
 
   /**
-    *  Resets the bundle to the tasks provided, and unlock all tasks removed from current bundle
+    *  Sets the bundle to the tasks provided, and unlock all tasks removed from current bundle
     *
     * @param bundleId The id of the bundle
     * @param taskIds The task ids the bundle will reset to
     */
-  def resetTaskBundle(
+  def updateTaskBundle(
       user: User,
       bundleId: Long,
       taskIds: List[Long]
@@ -108,7 +108,7 @@ class TaskBundleService @Inject() (
       )
     }
 
-    this.repository.resetTaskBundle(user, bundleId, taskIds)
+    this.repository.updateTaskBundle(user, bundleId, taskIds)
     this.getTaskBundle(user, bundleId)
   }
 

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -47,8 +47,8 @@ POST    /taskBundle                                 @org.maproulette.framework.c
 POST     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long, lockTasks:Boolean ?= false)
 ###
 # tags: [ Bundle ]
-# summary: Resets a Task Bundle
-# description: Resets the bundle to the tasks provided, and unlock all tasks removed from current bundle
+# summary: Updates a Task Bundle
+# description: Sets the bundle to the tasks provided, and unlock all tasks removed from current bundle
 # responses:
 #   '200':
 #     description: Ok with empty body
@@ -63,7 +63,7 @@ POST     /taskBundle/:id                             @org.maproulette.framework.
 #     in: query
 #     description: The task ids the bundle will reset to
 ###
-POST     /taskBundle/:id/reset                          @org.maproulette.framework.controller.TaskBundleController.resetTaskBundle(id: Long, taskIds: List[Long])
+POST     /taskBundle/:id/update                          @org.maproulette.framework.controller.TaskBundleController.updateTaskBundle(id: Long, taskIds: List[Long])
 ###
 # tags: [ Bundle ]
 # summary: Deletes a Task Bundle

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -104,9 +104,5 @@ DELETE     /taskBundle/:id                          @org.maproulette.framework.c
 #     in: query
 #     description: The list of task ids to remove from the bundle
 #     required: true
-#   - name: preventTaskIdUnlocks
-#     in: query
-#     description: The list of task ids to keep locked when removed from bundle
-#     required: true
 ###
-POST       /taskBundle/:id/unbundle                 @org.maproulette.framework.controller.TaskBundleController.unbundleTasks(id:Long, taskIds:List[Long], preventTaskIdUnlocks:List[Long])
+POST       /taskBundle/:id/unbundle                 @org.maproulette.framework.controller.TaskBundleController.unbundleTasks(id:Long, taskIds:List[Long])

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -916,3 +916,66 @@ GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.framework.c
 #     description: Success
 ###
 GET     /taskCluster                                @org.maproulette.framework.controller.TaskController.getTaskClusters(points:Int ?= 100)
+
+###
+# tags: [ Task ]
+# summary: Locks a bundle of tasks
+# description: Locks the specified tasks in the bundle.
+# responses:
+#   '200':
+#     description: Success message
+#   '401':
+#     description: The user is not authorized to make this request
+# requestBody:
+#   description: A JSON array of task IDs to lock.
+#   required: true
+#   content:
+#     application/json:
+#       schema:
+#         type: array
+#         items:
+#           type: integer
+###
+POST    /task/bundle/lock                         @org.maproulette.controllers.api.TaskController.lockTaskBundleByIds(taskIds:List[Long])
+
+###
+# tags: [ Task ]
+# summary: Unlocks a bundle of tasks
+# description: Unlocks the specified tasks in the bundle.
+# responses:
+#   '200':
+#     description: Success message
+#   '401':
+#     description: The user is not authorized to make this request
+# requestBody:
+#   description: A JSON array of task IDs to unlock.
+#   required: true
+#   content:
+#     application/json:
+#       schema:
+#         type: array
+#         items:
+#           type: integer
+###
+POST    /task/bundle/unlock                        @org.maproulette.controllers.api.TaskController.unlockTaskBundleByIds(taskIds:List[Long])
+
+###
+# tags: [ Task ]
+# summary: Refreshes locks on a bundle of tasks
+# description: Refreshes the locks on the specified tasks in the bundle.
+# responses:
+#   '200':
+#     description: Success message
+#   '401':
+#     description: The user is not authorized to make this request
+# requestBody:
+#   description: A JSON array of task IDs to refresh locks.
+#   required: true
+#   content:
+#     application/json:
+#       schema:
+#         type: array
+#         items:
+#           type: integer
+###
+POST    /task/bundle/refresh                      @org.maproulette.controllers.api.TaskController.refreshTaskLocksByIds(taskIds:List[Long])

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -916,14 +916,13 @@ GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.framework.c
 #     description: Success
 ###
 GET     /taskCluster                                @org.maproulette.framework.controller.TaskController.getTaskClusters(points:Int ?= 100)
-
 ###
 # tags: [ Task ]
 # summary: Locks a bundle of tasks
-# description: Locks the specified tasks in the bundle.
+# description: Attempts to lock a set of tasks. If successful, returns the tasks that were locked. If not successful, returns the tasks that were not locked.
 # responses:
 #   '200':
-#     description: Success message
+#     description: List of tasks that were locked or list of tasks that were not locked. Boolean indicates if the tasks were locked.
 #   '401':
 #     description: The user is not authorized to make this request
 # requestBody:
@@ -937,7 +936,6 @@ GET     /taskCluster                                @org.maproulette.framework.c
 #           type: integer
 ###
 POST    /task/bundle/lock                         @org.maproulette.controllers.api.TaskController.lockTaskBundleByIds(taskIds:List[Long])
-
 ###
 # tags: [ Task ]
 # summary: Unlocks a bundle of tasks
@@ -958,7 +956,6 @@ POST    /task/bundle/lock                         @org.maproulette.controllers.a
 #           type: integer
 ###
 POST    /task/bundle/unlock                        @org.maproulette.controllers.api.TaskController.unlockTaskBundleByIds(taskIds:List[Long])
-
 ###
 # tags: [ Task ]
 # summary: Refreshes locks on a bundle of tasks

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -239,7 +239,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         primaryTaskId = Some(task1.id)
       )
 
-      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task2.id), List(task1.id))()
+      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task2.id))()
       val response = this.service.getTaskBundle(User.superUser, bundle.bundleId)
       response.taskIds.length mustEqual 1
       response.taskIds.head mustEqual task1.id
@@ -281,7 +281,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Random user is not allowed to delete this bundle
       an[IllegalAccessException] should be thrownBy
-        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id), List())()
+        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id))()
     }
 
   }


### PR DESCRIPTION
This PR includes the following enhancements and changes:

Bundle Naming Convention:

Replaces resetTaskBundle with updateTaskBundle for better clarity and consistency in naming.
New Task Locking Endpoints:

Adds endpoints to lock, unlock, and refresh locks on multiple tasks at once. These endpoints are critical for efficiently handling task bundle locking.

Introduced new endpoints:
```
POST /task/bundle/lock
POST /task/bundle/unlock
POST /task/bundle/refresh
```