### PR TITLE
fix isArchived and isGlobal filtering in extendFind endpoint

### DIFF
--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -701,7 +701,7 @@ trait SearchParametersMixin {
     */
   def filterChallengeArchived(params: SearchParameters): FilterGroup = {
     params.challengeParams.archived match {
-      case Some(false) =>
+      case Some(false) | None =>
         FilterGroup(
           List(
             FilterParameter.conditional(

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -700,31 +700,31 @@ trait SearchParametersMixin {
     * challengeParams.archived value is true
     */
   def filterChallengeArchived(params: SearchParameters): FilterGroup = {
-    if (params.challengeParams.archived.getOrElse("false") == "false") {
-      FilterGroup(
-        List(
-          FilterParameter.conditional(
-            Challenge.FIELD_ARCHIVED,
-            value = "false",
-            Operator.EQ,
-            useValueDirectly = true,
-            includeOnlyIfTrue = true,
-            table = Some("c")
+    params.challengeParams.archived match {
+      case Some(false) =>
+        FilterGroup(
+          List(
+            FilterParameter.conditional(
+              Challenge.FIELD_ARCHIVED,
+              value = "false",
+              Operator.EQ,
+              useValueDirectly = true,
+              includeOnlyIfTrue = true,
+              table = Some("c")
+            )
           )
         )
-      )
-    } else {
-      FilterGroup(List())
+      case _ => FilterGroup(List())
     }
   }
 
   /**
     * Filters by c.is_global. Will only include if
-    * challengeParams.filterGlobal value is true
+    * challengeParams.filterGlobal value is false
     */
   def filterChallengeGlobal(params: SearchParameters): FilterGroup = {
-    params.challengeParams.filterGlobal match {
-      case Some(v) if v =>
+    params.challengeParams.global match {
+      case false =>
         FilterGroup(
           List(
             FilterParameter.conditional(

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1865,13 +1865,13 @@ class ChallengeDAL @Inject() (
       }
 
       searchParameters.challengeParams.archived match {
-        case Some(false) | None => this.appendInWhereClause(whereClause, s"c.is_archived = false")  
-          case _ =>
+        case Some(false) | None => this.appendInWhereClause(whereClause, s"c.is_archived = false")
+        case _                  =>
       }
 
       searchParameters.challengeParams.filterGlobal match {
         case Some(true) | None => this.appendInWhereClause(whereClause, s"c.is_global = false")
-          case _ =>
+        case _                 =>
       }
 
       searchParameters.challengeParams.requiresLocal match {

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1864,12 +1864,14 @@ class ChallengeDAL @Inject() (
         case _                      =>
       }
 
-      if (searchParameters.challengeParams.archived == false) {
-        this.appendInWhereClause(whereClause, s"c.is_archived = false")
+      searchParameters.challengeParams.archived match {
+        case Some(false) | None => this.appendInWhereClause(whereClause, s"c.is_archived = false")  
+          case _ =>
       }
 
-      if (searchParameters.challengeParams.filterGlobal == true) {
-        this.appendInWhereClause(whereClause, s"c.is_global = false")
+      searchParameters.challengeParams.filterGlobal match {
+        case Some(true) | None => this.appendInWhereClause(whereClause, s"c.is_global = false")
+          case _ =>
       }
 
       searchParameters.challengeParams.requiresLocal match {

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1864,8 +1864,8 @@ class ChallengeDAL @Inject() (
       }
 
       searchParameters.challengeParams.archived match {
-        case Some(false) => this.appendInWhereClause(whereClause, s"c.is_archived = false")
-        case _           =>
+        case Some(false) | None => this.appendInWhereClause(whereClause, s"c.is_archived = false")
+        case _                  =>
       }
 
       searchParameters.challengeParams.global match {

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -490,7 +490,7 @@ class ChallengeDAL @Inject() (
     this.cacheManager.withOptionCaching { () =>
       val insertedChallenge =
         this.withMRTransaction { implicit c =>
-          SQL"""INSERT INTO challenges (name, owner_id, parent_id, difficulty, description, is_global, info_link, blurb,
+          SQL"""INSERT INTO challenges (name, owner_id, parent_id, difficulty, description, info_link, blurb,
                                       instruction, enabled, featured, checkin_comment, checkin_source,
                                       overpass_ql, remote_geo_json, overpass_target_type, status, status_message, default_priority, high_priority_rule,
                                       medium_priority_rule, low_priority_rule, default_zoom, min_zoom, max_zoom,
@@ -498,7 +498,7 @@ class ChallengeDAL @Inject() (
                                       osm_id_property, task_bundle_id_property, last_task_refresh, data_origin_date, preferred_tags, preferred_review_tags,
                                       limit_tags, limit_review_tags, task_styles, requires_local, is_archived, review_setting, dataset_url, require_confirmation, task_widget_layout)
               VALUES (${challenge.name}, ${challenge.general.owner}, ${challenge.general.parent}, ${challenge.general.difficulty},
-                      ${challenge.description}, ${challenge.isGlobal}, ${challenge.infoLink}, ${challenge.general.blurb}, ${challenge.general.instruction},
+                      ${challenge.description}, ${challenge.infoLink}, ${challenge.general.blurb}, ${challenge.general.instruction},
                       ${challenge.general.enabled}, ${challenge.general.featured},
                       ${challenge.general.checkinComment}, ${challenge.general.checkinSource}, ${challenge.creation.overpassQL}, ${challenge.creation.remoteGeoJson},
                       ${challenge.creation.overpassTargetType}, ${challenge.status},
@@ -595,7 +595,6 @@ class ChallengeDAL @Inject() (
           val parentId = (updates \ "parentId").asOpt[Long].getOrElse(cachedItem.general.parent)
           val difficulty =
             (updates \ "difficulty").asOpt[Int].getOrElse(cachedItem.general.difficulty)
-          val isGlobal = (updates \ "isGlobal").asOpt[Boolean].getOrElse(cachedItem.isGlobal)
           val description =
             (updates \ "description").asOpt[String].getOrElse(cachedItem.description.getOrElse(""))
           val infoLink =
@@ -716,7 +715,7 @@ class ChallengeDAL @Inject() (
             .getOrElse(cachedItem.extra.presets.getOrElse(null))
 
           val updatedChallenge =
-            SQL"""UPDATE challenges SET name = $name, owner_id = $ownerId, parent_id = $parentId, difficulty = $difficulty, is_global = $isGlobal,
+            SQL"""UPDATE challenges SET name = $name, owner_id = $ownerId, parent_id = $parentId, difficulty = $difficulty,
                   description = $description, info_link = $infoLink, blurb = $blurb, instruction = $instruction,
                   enabled = $enabled, featured = $featured, checkin_comment = $checkinComment, checkin_source = $checkinSource, overpass_ql = $overpassQL,
                   remote_geo_json = $remoteGeoJson, overpass_target_type = $overpassTargetType, status = $status, status_message = $statusMessage, default_priority = $defaultPriority,
@@ -1865,13 +1864,13 @@ class ChallengeDAL @Inject() (
       }
 
       searchParameters.challengeParams.archived match {
-        case Some(false) | None => this.appendInWhereClause(whereClause, s"c.is_archived = false")
-        case _                  =>
+        case Some(false) => this.appendInWhereClause(whereClause, s"c.is_archived = false")
+        case _           =>
       }
 
-      searchParameters.challengeParams.filterGlobal match {
-        case Some(true) | None => this.appendInWhereClause(whereClause, s"c.is_global = false")
-        case _                 =>
+      searchParameters.challengeParams.global match {
+        case false => this.appendInWhereClause(whereClause, s"c.is_global = false")
+        case _     =>
       }
 
       searchParameters.challengeParams.requiresLocal match {

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -32,7 +32,7 @@ case class SearchChallengeParameters(
     challengeStatus: Option[List[Int]] = None,
     requiresLocal: Option[Int] = Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE),
     archived: Option[Boolean] = None,
-    filterGlobal: Option[Boolean] = None
+    global: Boolean = true
 )
 
 case class SearchReviewParameters(
@@ -441,8 +441,8 @@ object SearchParameters {
         this.getIntParameter(request.getQueryString("cLocal"), Some(params.challengeParams.requiresLocal.getOrElse(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE))),
         //includeArchived
         this.getBooleanParameter(request.getQueryString("ca"), params.challengeParams.archived),
-        //filterGlobal
-        this.getBooleanParameter(request.getQueryString("fg"), params.challengeParams.filterGlobal)
+        //includeGlobal
+        this.getBooleanParameter(request.getQueryString("cg"), Some(params.challengeParams.global)).getOrElse(true)
       ),
       new SearchTaskParameters(
       //taskTags


### PR DESCRIPTION
**Issue**  
The `/api/v2/challenges/extendedFind` endpoint was not correctly handling archived and global challenge filtering. The issue arose because the filter condition was always evaluating as `false`. This happened because the filter was being wrapped in `Some(value)` (e.g., `Some(false)` or `Some(true)`) instead of directly evaluating the `value`.

**Fix Details**  
This PR updates the condition to handle the wrapped `Some(value)` correctly, ensuring that the filtering logic now behaves as expected. This resolves the bug affecting archived and global challenge filtering.