### PR TITLE
fix isArchived and isGlobal filtering in extendFind endpoint

### DIFF
--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -723,7 +723,7 @@ trait SearchParametersMixin {
     * challengeParams.global value is true
     */
   def filterChallengeGlobal(params: SearchParameters): FilterGroup = {
-    if (params.challengeParams.global.getOrElse("false") == "false") {
+    if (params.challengeParams.global.getOrElse("true") == "false") {
       FilterGroup(
         List(
           FilterParameter.conditional(

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -700,7 +700,7 @@ trait SearchParametersMixin {
     * challengeParams.archived value is true
     */
   def filterChallengeArchived(params: SearchParameters): FilterGroup = {
-    if (params.challengeParams.archived.getOrElse("false") == "false") {
+    if (params.challengeParams.archived.getOrElse(false) == false) {
       FilterGroup(
         List(
           FilterParameter.conditional(
@@ -723,7 +723,7 @@ trait SearchParametersMixin {
     * challengeParams.global value is true
     */
   def filterChallengeGlobal(params: SearchParameters): FilterGroup = {
-    if (params.challengeParams.global.getOrElse("true") == "false") {
+    if (params.challengeParams.global.getOrElse(true) == false) {
       FilterGroup(
         List(
           FilterParameter.conditional(

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -720,24 +720,24 @@ trait SearchParametersMixin {
 
   /**
     * Filters by c.is_global. Will only include if
-    * challengeParams.filterGlobal value is true
+    * challengeParams.gloval value is true
     */
   def filterChallengeGlobal(params: SearchParameters): FilterGroup = {
-    params.challengeParams.filterGlobal match {
-      case Some(v) if v =>
-        FilterGroup(
-          List(
-            FilterParameter.conditional(
-              "is_global",
-              value = "false",
-              Operator.EQ,
-              useValueDirectly = true,
-              includeOnlyIfTrue = true,
-              table = Some("c")
-            )
+    if (params.challengeParams.global.getOrElse("false") == "false") {
+      FilterGroup(
+        List(
+          FilterParameter.conditional(
+            Challenge.FIELD_GLOBAL,
+            value = "false",
+            Operator.EQ,
+            useValueDirectly = true,
+            includeOnlyIfTrue = true,
+            table = Some("c")
           )
         )
-      case _ => FilterGroup(List())
+      )
+    } else {
+      FilterGroup(List())
     }
   }
 

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -720,7 +720,7 @@ trait SearchParametersMixin {
 
   /**
     * Filters by c.is_global. Will only include if
-    * challengeParams.gloval value is true
+    * challengeParams.global value is true
     */
   def filterChallengeGlobal(params: SearchParameters): FilterGroup = {
     if (params.challengeParams.global.getOrElse("false") == "false") {

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -287,6 +287,7 @@ object Challenge extends CommonField {
   val FIELD_PARENT_ID = "parent_id"
   val FIELD_ENABLED   = "enabled"
   val FIELD_ARCHIVED  = "is_archived"
+  val FIELD_GLOBAL    = "is_global"
   val FIELD_STATUS    = "status"
   val FIELD_DELETED   = "deleted"
 

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -490,7 +490,7 @@ class ChallengeDAL @Inject() (
     this.cacheManager.withOptionCaching { () =>
       val insertedChallenge =
         this.withMRTransaction { implicit c =>
-          SQL"""INSERT INTO challenges (name, owner_id, parent_id, difficulty, description, is_global, info_link, blurb,
+          SQL"""INSERT INTO challenges (name, owner_id, parent_id, difficulty, description, info_link, blurb,
                                       instruction, enabled, featured, checkin_comment, checkin_source,
                                       overpass_ql, remote_geo_json, overpass_target_type, status, status_message, default_priority, high_priority_rule,
                                       medium_priority_rule, low_priority_rule, default_zoom, min_zoom, max_zoom,
@@ -498,7 +498,7 @@ class ChallengeDAL @Inject() (
                                       osm_id_property, task_bundle_id_property, last_task_refresh, data_origin_date, preferred_tags, preferred_review_tags,
                                       limit_tags, limit_review_tags, task_styles, requires_local, is_archived, review_setting, dataset_url, require_confirmation, task_widget_layout)
               VALUES (${challenge.name}, ${challenge.general.owner}, ${challenge.general.parent}, ${challenge.general.difficulty},
-                      ${challenge.description}, ${challenge.isGlobal}, ${challenge.infoLink}, ${challenge.general.blurb}, ${challenge.general.instruction},
+                      ${challenge.description}, ${challenge.infoLink}, ${challenge.general.blurb}, ${challenge.general.instruction},
                       ${challenge.general.enabled}, ${challenge.general.featured},
                       ${challenge.general.checkinComment}, ${challenge.general.checkinSource}, ${challenge.creation.overpassQL}, ${challenge.creation.remoteGeoJson},
                       ${challenge.creation.overpassTargetType}, ${challenge.status},
@@ -595,7 +595,6 @@ class ChallengeDAL @Inject() (
           val parentId = (updates \ "parentId").asOpt[Long].getOrElse(cachedItem.general.parent)
           val difficulty =
             (updates \ "difficulty").asOpt[Int].getOrElse(cachedItem.general.difficulty)
-          val isGlobal = (updates \ "isGlobal").asOpt[Boolean].getOrElse(cachedItem.isGlobal)
           val description =
             (updates \ "description").asOpt[String].getOrElse(cachedItem.description.getOrElse(""))
           val infoLink =
@@ -716,7 +715,7 @@ class ChallengeDAL @Inject() (
             .getOrElse(cachedItem.extra.presets.getOrElse(null))
 
           val updatedChallenge =
-            SQL"""UPDATE challenges SET name = $name, owner_id = $ownerId, parent_id = $parentId, difficulty = $difficulty, is_global = $isGlobal,
+            SQL"""UPDATE challenges SET name = $name, owner_id = $ownerId, parent_id = $parentId, difficulty = $difficulty,
                   description = $description, info_link = $infoLink, blurb = $blurb, instruction = $instruction,
                   enabled = $enabled, featured = $featured, checkin_comment = $checkinComment, checkin_source = $checkinSource, overpass_ql = $overpassQL,
                   remote_geo_json = $remoteGeoJson, overpass_target_type = $overpassTargetType, status = $status, status_message = $statusMessage, default_priority = $defaultPriority,
@@ -1864,11 +1863,11 @@ class ChallengeDAL @Inject() (
         case _                      =>
       }
 
-      if (searchParameters.challengeParams.archived == false) {
+      if (searchParameters.challengeParams.archived.getOrElse(false) == false) {
         this.appendInWhereClause(whereClause, s"c.is_archived = false")
       }
 
-      if (searchParameters.challengeParams.filterGlobal == true) {
+      if (searchParameters.challengeParams.global.getOrElse(false) == false) {
         this.appendInWhereClause(whereClause, s"c.is_global = false")
       }
 

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1867,7 +1867,7 @@ class ChallengeDAL @Inject() (
         this.appendInWhereClause(whereClause, s"c.is_archived = false")
       }
 
-      if (searchParameters.challengeParams.global.getOrElse(false) == false) {
+      if (searchParameters.challengeParams.global.getOrElse(true) == false) {
         this.appendInWhereClause(whereClause, s"c.is_global = false")
       }
 

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -32,7 +32,7 @@ case class SearchChallengeParameters(
     challengeStatus: Option[List[Int]] = None,
     requiresLocal: Option[Int] = Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE),
     archived: Option[Boolean] = None,
-    filterGlobal: Option[Boolean] = None
+    global: Option[Boolean] = None
 )
 
 case class SearchReviewParameters(
@@ -441,8 +441,8 @@ object SearchParameters {
         this.getIntParameter(request.getQueryString("cLocal"), Some(params.challengeParams.requiresLocal.getOrElse(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE))),
         //includeArchived
         this.getBooleanParameter(request.getQueryString("ca"), params.challengeParams.archived),
-        //filterGlobal
-        this.getBooleanParameter(request.getQueryString("fg"), params.challengeParams.filterGlobal)
+        //includeGlobal
+        this.getBooleanParameter(request.getQueryString("cg"), params.challengeParams.global)
       ),
       new SearchTaskParameters(
       //taskTags


### PR DESCRIPTION
Resolves: https://github.com/maproulette/maproulette3/issues/2532
Issue
The /api/v2/challenges/extendedFind endpoint was not correctly handling archived and global challenge filtering. The issue arose because the filter condition was always evaluating as false. This happened because the filter was being wrapped in Some(value) (e.g., Some(false) or Some(true)) instead of directly evaluating the value.

Fix Details
This PR updates the condition to handle the wrapped Some(value) correctly, ensuring that the filtering logic now behaves as expected. This is done by adding a default to the variable being filtered. This resolves the bug affecting archived and global challenge filtering.