### PR TITLE
optimize map marker fetching

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -516,16 +516,17 @@ class TaskController @Inject() (
     */
   def bulkStatusChange(newStatus: Int): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      SearchParameters.withSearch { p =>
-        var params = p
-        params.location match {
-          case Some(l) => // do nothing, already have bounding box
-          case None    =>
-            // No bounding box, so search everything
-            params = p.copy(location = Some(SearchLocation(-180, -90, 180, 90)))
-        }
-        val (count, tasks) = this.taskClusterService.getTasksInBoundingBox(user, params, Paging(-1))
-        val challengeIds   = params.challengeParams.challengeIds.getOrElse(List()).distinct.sorted
+      SearchParameters.withSearch { params =>
+        val (count, tasks) = this.taskClusterService.getTasksInBoundingBox(
+          user,
+          params,
+          Paging(-1),
+          false,
+          "",
+          "",
+          Some(SearchLocation(-180, -90, 180, 90))
+        )
+        val challengeIds = params.challengeParams.challengeIds.getOrElse(List()).distinct.sorted
 
         // Update challenge status to building
         challengeIds.foreach(challengeId => {

--- a/app/org/maproulette/framework/controller/TaskController.scala
+++ b/app/org/maproulette/framework/controller/TaskController.scala
@@ -100,15 +100,15 @@ class TaskController @Inject() (
       includeTags: Boolean = false
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
-      SearchParameters.withSearch { p =>
-        val params = p.copy(location = Some(SearchLocation(left, bottom, right, top)))
+      SearchParameters.withSearch { params =>
         val (count, result) = this.taskClusterService.getTasksInBoundingBox(
           User.userOrMocked(user),
           params,
           Paging(limit, page),
           excludeLocked,
           sort,
-          order
+          order,
+          Some(SearchLocation(left, bottom, right, top))
         )
 
         val resultJson = this.insertExtraTaskJSON(result, includeGeometries, includeTags)

--- a/app/org/maproulette/framework/controller/TaskController.scala
+++ b/app/org/maproulette/framework/controller/TaskController.scala
@@ -143,13 +143,13 @@ class TaskController @Inject() (
       includeTags: Boolean
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
-      SearchParameters.withSearch { p =>
-        val params = p.copy(location = Some(SearchLocation(left, bottom, right, top)))
+      SearchParameters.withSearch { params =>
         val result = this.taskClusterService.getTaskMarkerDataInBoundingBox(
           User.userOrMocked(user),
           params,
           limit,
-          excludeLocked
+          excludeLocked,
+          Some(SearchLocation(left, bottom, right, top))
         )
 
         val resultJson = this.insertExtraTaskJSON(result, includeGeometries, includeTags)

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -564,18 +564,20 @@ class TaskReviewController @Inject() (
   def removeReviewRequest(ids: String, asMetaReview: Boolean = false): Action[AnyContent] =
     Action.async { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        SearchParameters.withSearch { p =>
+        SearchParameters.withSearch { params =>
           implicit val taskIds = Utils.toLongList(ids) match {
             case Some(l) if !l.isEmpty => l
             case None => {
-              val params = p.location match {
-                case Some(l) => p
-                case None    =>
-                  // No bounding box, so search everything
-                  p.copy(location = Some(SearchLocation(-180, -90, 180, 90)))
-              }
               val (count, tasks) =
-                this.serviceManager.taskCluster.getTasksInBoundingBox(user, params, Paging(-1))
+                this.serviceManager.taskCluster.getTasksInBoundingBox(
+                  user,
+                  params,
+                  Paging(-1),
+                  false,
+                  "",
+                  "",
+                  Some(SearchLocation(-180, -90, 180, 90))
+                )
               tasks.map(task => task.id)
             }
           }

--- a/test/org/maproulette/framework/service/TaskClusterServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskClusterServiceSpec.scala
@@ -64,11 +64,11 @@ class TaskClusterServiceSpec(implicit val application: Application) extends Fram
       val (count, response) = this.service.getTasksInBoundingBox(
         User.superUser,
         SearchParameters(
-          location = Some(SearchLocation(-180, -85, 180, 85)),
           challengeParams = SearchChallengeParameters(
             challengeIds = Some(List(randomChallenge.id))
           )
-        )
+        ),
+        location = Some(SearchLocation(-180, -85, 180, 85))
       )
       count mustEqual 2
       response.length mustEqual 2
@@ -78,12 +78,14 @@ class TaskClusterServiceSpec(implicit val application: Application) extends Fram
       val (count, response) = this.service.getTasksInBoundingBox(
         User.superUser,
         SearchParameters(
-          location = Some(SearchLocation(-180, -85, 180, 85)),
           challengeParams = SearchChallengeParameters(
             challengeIds = Some(List(randomChallenge.id))
           )
         ),
-        ignoreLocked = true
+        ignoreLocked = true,
+        sort = "id",
+        orderDirection = "DESC",
+        location = Some(SearchLocation(-180, -85, 180, 85))
       )
       count mustEqual 3
       response.length mustEqual 3
@@ -93,13 +95,13 @@ class TaskClusterServiceSpec(implicit val application: Application) extends Fram
       val (count, response) = this.service.getTasksInBoundingBox(
         User.superUser,
         SearchParameters(
-          location = Some(SearchLocation(-180, -85, 180, 85)),
           challengeParams = SearchChallengeParameters(
             challengeIds = Some(List(randomChallenge.id))
           )
         ),
         Paging(1, 0),
-        ignoreLocked = true
+        ignoreLocked = true,
+        location = Some(SearchLocation(-180, -85, 180, 85))
       )
       count mustEqual 3
       response.length mustEqual 1
@@ -109,38 +111,38 @@ class TaskClusterServiceSpec(implicit val application: Application) extends Fram
       val (count, response) = this.service.getTasksInBoundingBox(
         User.superUser,
         SearchParameters(
-          location = Some(SearchLocation(-180, -85, 180, 85)),
           challengeParams = SearchChallengeParameters(
             challengeIds = Some(List(randomChallenge.id))
           )
         ),
         ignoreLocked = true,
         sort = "id",
-        orderDirection = "DESC"
+        orderDirection = "DESC",
+        location = Some(SearchLocation(-180, -85, 180, 85))
       )
       count mustEqual 3
       response.last.id mustEqual randomTask.id
     }
-  }
 
-  "get tasks in bounding box excluding task ids" taggedAs (TaskTag) in {
-    val (count, response) = this.service.getTasksInBoundingBox(
-      User.superUser,
-      SearchParameters(
-        location = Some(SearchLocation(-180, -85, 180, 85)),
-        challengeParams = SearchChallengeParameters(
-          challengeIds = Some(List(randomChallenge.id))
+    "get tasks in bounding box excluding task ids" taggedAs (TaskTag) in {
+      val (count, response) = this.service.getTasksInBoundingBox(
+        User.superUser,
+        SearchParameters(
+          challengeParams = SearchChallengeParameters(
+            challengeIds = Some(List(randomChallenge.id))
+          ),
+          taskParams = SearchTaskParameters(
+            excludeTaskIds = Some(List(randomTask.id))
+          )
         ),
-        taskParams = SearchTaskParameters(
-          excludeTaskIds = Some(List(randomTask.id))
-        )
-      ),
-      ignoreLocked = true
-    )
-    count mustEqual 2
-    response.length mustEqual 2
-    (response.head.id != randomTask.id) mustEqual true
-    (response.last.id != randomTask.id) mustEqual true
+        ignoreLocked = true,
+        location = Some(SearchLocation(-180, -85, 180, 85))
+      )
+      count mustEqual 2
+      response.length mustEqual 2
+      (response.head.id != randomTask.id) mustEqual true
+      (response.last.id != randomTask.id) mustEqual true
+    }
   }
 
   override implicit val projectTestName: String = "TaskSpecProject"


### PR DESCRIPTION
This pull request refactors the code for the tasks/box and tasks/markers endpoints, optimizing the underlying SQL query for better performance. The original query combined spatial filtering with other conditions directly in the WHERE clause, often resulting in inefficient execution plans—such as full-table scans or the creation of a large bitmap hash map spanning the entire tasks table within the specified map bounds. This inefficiency is evident in the staging query, which took approximately 1.1 seconds to execute and processed an excessive number of rows during the spatial filter, as shown in its execution plan.

Example of old query in staging:

```
SELECT tasks.id, tasks.name, tasks.parent_id, c.name, tasks.instruction, tasks.status, tasks.mapped_on,
          tasks.completed_time_spent, tasks.completed_by,
          tasks.bundle_id, tasks.is_bundle_primary, tasks.cooperative_work_json::TEXT as cooperative_work,
          task_review.review_status, task_review.review_requested_by, task_review.reviewed_by, task_review.reviewed_at,
          task_review.review_started_at, task_review.meta_review_status, task_review.meta_reviewed_by,
          task_review.meta_reviewed_at, task_review.additional_reviewers,
          ST_AsGeoJSON(tasks.location) AS location, priority,
          CASE WHEN task_review.review_started_at IS NULL
                THEN 0
                ELSE EXTRACT(epoch FROM (task_review.reviewed_at - task_review.review_started_at)) END
          AS reviewDuration
    FROM tasks
    
        INNER JOIN challenges c ON c.id = tasks.parent_id
        INNER JOIN projects p ON p.id = c.parent_id
        LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
      
   WHERE (tasks.id NOT IN (select item_id from locked WHERE
                  item_id = tasks.id AND item_type = 2
                  AND user_id != 1)) AND (c.deleted = false AND p.deleted = false) AND (tasks.location && ST_MakeEnvelope (-115.57617187500001, 32.54681317351517, -87.5390625, 52.908902047770255, 4326)) AND (tasks.status IN (0,1,2,3,4,5,6,9)) AND ((tasks.id IN (SELECT task_id FROM task_review WHERE task_review.task_id = tasks.id AND task_review.review_status IN (0,1,2,3,4,5,6,7,-1)) OR NOT tasks.id IN (SELECT task_id FROM task_review task_review WHERE task_review.task_id = tasks.id))) AND ((tasks.id IN (SELECT task_id FROM task_review WHERE (task_review.task_id = tasks.id) AND ((task_review.meta_review_status IN (0,1,2,3,5,6,7,-2,-1) OR task_review.meta_review_status IS NULL))) OR NOT tasks.id IN (SELECT task_id FROM task_review task_review WHERE task_review.task_id = tasks.id))) AND (tasks.priority IN (0,1,2)) AND (c.id IN (40400)) LIMIT 1001;
```
                  
 This is its reads/workflow (take not of the number of rows read in the location filter):
<img width="965" alt="Screenshot 2025-02-27 at 1 22 25 PM" src="https://github.com/user-attachments/assets/b1d57584-df48-408e-9056-b1de2007deaa" />

And takes roughly 1.1seconds to complete.

This is the new query:

```
WITH filtered_tasks AS (
          SELECT tasks.id
          FROM tasks
          INNER JOIN challenges c ON c.id = tasks.parent_id
          INNER JOIN projects p ON p.id = c.parent_id
          LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
          WHERE (tasks.id NOT IN (select item_id from locked WHERE
                  item_id = tasks.id AND item_type = 2
                  AND user_id != 1)) AND (c.deleted = false AND p.deleted = false) AND (tasks.status IN (0,1,2,3,4,5,6,9)) AND ((tasks.id IN (SELECT task_id FROM task_review WHERE task_review.task_id = tasks.id AND task_review.review_status IN (0,1,2,3,4,5,6,7,-1)) OR NOT tasks.id IN (SELECT task_id FROM task_review task_review WHERE task_review.task_id = tasks.id))) AND ((tasks.id IN (SELECT task_id FROM task_review WHERE (task_review.task_id = tasks.id) AND ((task_review.meta_review_status IN (0,1,2,3,5,6,7,-2,-1) OR task_review.meta_review_status IS NULL))) OR NOT tasks.id IN (SELECT task_id FROM task_review task_review WHERE task_review.task_id = tasks.id))) AND (tasks.priority IN (0,1,2)) AND (c.id IN (40400))
        )
        SELECT  tasks.id,
    tasks.name,
    tasks.parent_id,
    c.name,
    tasks.instruction,
    tasks.status,
    tasks.mapped_on,
    tasks.completed_time_spent,
    tasks.completed_by,
    tasks.bundle_id,
    tasks.is_bundle_primary,
    tasks.cooperative_work_json::TEXT as cooperative_work,
    task_review.review_status,
    task_review.review_requested_by,
    task_review.reviewed_by,
    task_review.reviewed_at,
    task_review.review_started_at,
    task_review.meta_review_status,
    task_review.meta_reviewed_by,
    task_review.meta_reviewed_at,
    task_review.additional_reviewers,
    ST_AsGeoJSON(tasks.location) AS location,
    priority,
    CASE 
        WHEN task_review.review_started_at IS NULL THEN 0
        ELSE EXTRACT(epoch FROM (task_review.reviewed_at - task_review.review_started_at))
    END AS reviewDuration
        FROM filtered_tasks
        INNER JOIN tasks ON tasks.id = filtered_tasks.id
        INNER JOIN challenges c ON c.id = tasks.parent_id
        INNER JOIN projects p ON p.id = c.parent_id
        LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
        WHERE tasks.location && ST_MakeEnvelope(-115.57617187500001, 32.54681317351517, -87.5390625, 52.908902047770255, 4326)
        LIMIT 1001
      ;
```
      
This is its reads/workflow:
<img width="965" alt="Screenshot 2025-02-27 at 1 22 25 PM" src="https://github.com/user-attachments/assets/7aaa25fc-3cbc-477a-ac00-13d5b487b857" />

and it takes roughly 150-200ms.

The refactored approach introduces a Common Table Expression (CTE) to streamline the process. By pre-filtering tasks based on non-spatial conditions (e.g., status, priority, and review criteria) in the CTE, the query reduces the dataset before applying the spatial filter. This significantly cuts down the rows processed by the spatial operation, leading to a more efficient execution plan. The updated query, now completing in 150–200 milliseconds, leverages a CTE scan to ensure the spatial filter (ST_MakeEnvelope) operates only on the pre-filtered subset of tasks, avoiding the bloated bitmap index issue seen previously. The new execution plan confirms this optimization, showing a marked reduction in rows read compared to the original.
