### PR TITLE
refactor 101.sql to handle existing index and extension

### DIFF
--- a/conf/evolutions/default/101.sql
+++ b/conf/evolutions/default/101.sql
@@ -1,10 +1,10 @@
 # --- !Ups
-CREATE EXTENSION btree_gist; 
+CREATE EXTENSION IF NOT EXISTS btree_gist; 
 
-CREATE INDEX idx_tasks_parent_location ON tasks USING GIST (parent_id, location);
+CREATE INDEX IF NOT EXISTS idx_tasks_parent_location ON tasks USING GIST (parent_id, location);
 
 # --- !Downs
 
-DROP INDEX idx_tasks_parent_location;
+DROP INDEX IF EXISTS idx_tasks_parent_location;
 
-DROP EXTENSION btree_gist;
+DROP EXTENSION IF EXISTS btree_gist;


### PR DESCRIPTION
This PR modifies the database migration script to use conditional creation for both the btree_gist extension and the GiST index on tasks. By adding IF NOT EXISTS clauses to both the extension creation and index creation statements, the migration will run safely on databases where these objects may have been previously created.