### PR TITLE
Move bundling to transactions and return lockedBy datapoint in fetch markers/clusters endpoints

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -375,7 +375,7 @@ class TaskController @Inject() (
     * @param taskIds The IDs of the tasks to lock
     * @return
     */
-  def lockTaskBundleByIds(taskIds: List[Long]): Action[AnyContent] = Action.async {
+  def lockTaskBundle(taskIds: List[Long]): Action[AnyContent] = Action.async {
     implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
         // First retrieve all the tasks
@@ -401,7 +401,7 @@ class TaskController @Inject() (
     * @param taskIds The IDs of the tasks to unlock
     * @return
     */
-  def unlockTaskBundleByIds(taskIds: List[Long]): Action[AnyContent] = Action.async {
+  def unlockTaskBundle(taskIds: List[Long]): Action[AnyContent] = Action.async {
     implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
         val tasks = taskIds.flatMap(taskId => this.dal.retrieveById(taskId))

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -375,24 +375,23 @@ class TaskController @Inject() (
     * @param taskIds The IDs of the tasks to lock
     * @return
     */
-  def lockTaskBundle(taskIds: List[Long]): Action[AnyContent] = Action.async {
-    implicit request =>
-      this.sessionManager.authenticatedRequest { implicit user =>
-        // First retrieve all the tasks
-        val tasks = taskIds.flatMap(taskId => this.dal.retrieveById(taskId))
+  def lockTaskBundle(taskIds: List[Long]): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      // First retrieve all the tasks
+      val tasks = taskIds.flatMap(taskId => this.dal.retrieveById(taskId))
 
-        if (tasks.length != taskIds.length) {
-          val missingTaskIds = taskIds.filter(taskId => !tasks.map(_.id).contains(taskId))
-          // No valid tasks found
-          throw new IllegalAccessException(
-            s"Tasks not found to unlock: ${missingTaskIds.mkString(", ")}"
-          )
-        } else {
-          // Use bulk locking for better performance
-          this.dal.lockItems(user, tasks)
-          Ok(Json.toJson(tasks))
-        }
+      if (tasks.length != taskIds.length) {
+        val missingTaskIds = taskIds.filter(taskId => !tasks.map(_.id).contains(taskId))
+        // No valid tasks found
+        throw new IllegalAccessException(
+          s"Tasks not found to unlock: ${missingTaskIds.mkString(", ")}"
+        )
+      } else {
+        // Use bulk locking for better performance
+        this.dal.lockItems(user, tasks)
+        Ok(Json.toJson(tasks))
       }
+    }
   }
 
   /**
@@ -401,20 +400,19 @@ class TaskController @Inject() (
     * @param taskIds The IDs of the tasks to unlock
     * @return
     */
-  def unlockTaskBundle(taskIds: List[Long]): Action[AnyContent] = Action.async {
-    implicit request =>
-      this.sessionManager.authenticatedRequest { implicit user =>
-        val tasks = taskIds.flatMap(taskId => this.dal.retrieveById(taskId))
-        if (tasks.length != taskIds.length) {
-          val missingTaskIds = taskIds.filter(taskId => !tasks.map(_.id).contains(taskId))
-          // No valid tasks found
-          throw new Exception(s"Tasks not found to unlock: ${missingTaskIds.mkString(", ")}")
-        } else {
-          // Use bulk locking for better performance
-          this.dal.unlockItems(user, tasks)
-          Ok(Json.toJson(tasks))
-        }
+  def unlockTaskBundle(taskIds: List[Long]): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      val tasks = taskIds.flatMap(taskId => this.dal.retrieveById(taskId))
+      if (tasks.length != taskIds.length) {
+        val missingTaskIds = taskIds.filter(taskId => !tasks.map(_.id).contains(taskId))
+        // No valid tasks found
+        throw new Exception(s"Tasks not found to unlock: ${missingTaskIds.mkString(", ")}")
+      } else {
+        // Use bulk locking for better performance
+        this.dal.unlockItems(user, tasks)
+        Ok(Json.toJson(tasks))
       }
+    }
   }
 
   /**

--- a/app/org/maproulette/framework/mixins/Locking.scala
+++ b/app/org/maproulette/framework/mixins/Locking.scala
@@ -226,8 +226,11 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
       if (items.isEmpty) {
         Map.empty[Long, Long]
       } else {
+        // Remove duplicates from the input list while preserving order
+        val distinctItems = items.distinctBy(_.id)
+
         // Build a single query with multiple value sets for better performance
-        val valuesList = items
+        val valuesList = distinctItems
           .map { item =>
             s"(${item.itemType.typeId}, ${item.id}, ${user.id}, NOW())"
           }
@@ -291,9 +294,11 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
       if (items.isEmpty) {
         0
       } else {
+        // Remove duplicates from the input list while preserving order
+        val distinctItems = items.distinctBy(_.id)
         // Create a list of item IDs and types for the IN clause
-        val itemIds  = items.map(_.id)
-        val itemType = items.headOption.map(_.itemType.typeId).getOrElse(0)
+        val itemIds  = distinctItems.map(_.id)
+        val itemType = distinctItems.headOption.map(_.itemType.typeId).getOrElse(0)
 
         // Check the lock status of all requested items
         val checkQuery =

--- a/app/org/maproulette/framework/model/ClusteredPoint.scala
+++ b/app/org/maproulette/framework/model/ClusteredPoint.scala
@@ -69,7 +69,8 @@ case class ClusteredPoint(
     pointReview: PointReview,
     priority: Int,
     bundleId: Option[Long] = None,
-    isBundlePrimary: Option[Boolean] = None
+    isBundlePrimary: Option[Boolean] = None,
+    lockedBy: Option[Long] = None
 )
 
 object ClusteredPoint {

--- a/app/org/maproulette/framework/repository/ProjectRepository.scala
+++ b/app/org/maproulette/framework/repository/ProjectRepository.scala
@@ -385,6 +385,7 @@ object ProjectRepository extends Readers {
           pointReview,
           -1,
           None,
+          None,
           None
         )
     }

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -330,13 +330,18 @@ class TaskBundleRepository @Inject() (
     */
   def lockBundledTasks(user: User, tasks: List[Task]) = {
     this.withMRConnection { implicit c =>
-      for (task <- tasks) {
-        try {
-          this.lockItem(user, task)
-        } catch {
-          case e: Exception => this.logger.warn(e.getMessage)
+      try {
+        if (tasks.isEmpty) {
+          // No valid tasks found
+          throw new Exception("No valid tasks found")
+        } else {
+          // Use bulk locking for better performance
+          this.lockItems(user, tasks)
         }
+      } catch {
+        case e: Exception => this.logger.warn(e.getMessage)
       }
     }
+
   }
 }

--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -32,6 +32,7 @@ class TaskClusterRepository @Inject() (override val db: Database, challengeDAL: 
     INNER JOIN challenges c ON c.id = tasks.parent_id
     INNER JOIN projects p ON p.id = c.parent_id
     LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
+    LEFT OUTER JOIN locked l ON l.item_id = tasks.id
   """
 
   // SQL query used to select list of ClusteredPoint data
@@ -42,7 +43,7 @@ class TaskClusterRepository @Inject() (override val db: Database, challengeDAL: 
           task_review.review_status, task_review.review_requested_by, task_review.reviewed_by, task_review.reviewed_at,
           task_review.review_started_at, task_review.meta_review_status, task_review.meta_reviewed_by,
           task_review.meta_reviewed_at, task_review.additional_reviewers,
-          ST_AsGeoJSON(tasks.location) AS location, priority,
+          ST_AsGeoJSON(tasks.location) AS location, priority, l.user_id as locked_by,
           CASE WHEN task_review.review_started_at IS NULL
                 THEN 0
                 ELSE EXTRACT(epoch FROM (task_review.reviewed_at - task_review.review_started_at)) END

--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -134,7 +134,8 @@ class TaskClusterRepository @Inject() (override val db: Database, challengeDAL: 
                    c.name as challengeName,
                    tasks.location AS taskLocation,
                    c.id AS challengeId,
-                   c.status AS challengeStatus
+                   c.status AS challengeStatus,
+                   l.user_id as locked_by
             FROM tasks
             $joinClause
             WHERE ${query.filter.sql()}

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -142,9 +142,12 @@ class TaskBundleService @Inject() (
     */
   def deleteTaskBundle(user: User, bundleId: Long): Unit = {
     val bundle = this.getTaskBundle(user, bundleId)
-
+    val primaryTask = bundle.tasks.getOrElse(List()).find(_.isBundlePrimary.getOrElse(false))
+    
     // Verify permissions to delete this bundle
-    if (!permission.isSuperUser(user) && bundle.ownerId != user.id) {
+    if (!permission.isSuperUser(user) && bundle.ownerId != user.id && primaryTask.isDefined && 
+        primaryTask.get.status.getOrElse(-1) != org.maproulette.framework.model.Task.STATUS_SKIPPED && 
+        primaryTask.get.status.getOrElse(-1) != org.maproulette.framework.model.Task.STATUS_TOO_HARD) {
       val challengeId = bundle.tasks.getOrElse(List()).head.parent
       val challenge   = this.challengeDAL.retrieveById(challengeId)
       this.permission.hasObjectWriteAccess(challenge.get, user)

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -141,12 +141,12 @@ class TaskBundleService @Inject() (
     * @param bundleId The id of the bundle
     */
   def deleteTaskBundle(user: User, bundleId: Long): Unit = {
-    val bundle = this.getTaskBundle(user, bundleId)
+    val bundle      = this.getTaskBundle(user, bundleId)
     val primaryTask = bundle.tasks.getOrElse(List()).find(_.isBundlePrimary.getOrElse(false))
-    
+
     // Verify permissions to delete this bundle
-    if (!permission.isSuperUser(user) && bundle.ownerId != user.id && primaryTask.isDefined && 
-        primaryTask.get.status.getOrElse(-1) != org.maproulette.framework.model.Task.STATUS_SKIPPED && 
+    if (!permission.isSuperUser(user) && bundle.ownerId != user.id && primaryTask.isDefined &&
+        primaryTask.get.status.getOrElse(-1) != org.maproulette.framework.model.Task.STATUS_SKIPPED &&
         primaryTask.get.status.getOrElse(-1) != org.maproulette.framework.model.Task.STATUS_TOO_HARD) {
       val challengeId = bundle.tasks.getOrElse(List()).head.parent
       val challenge   = this.challengeDAL.retrieveById(challengeId)

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -382,12 +382,13 @@ class ChallengeDAL @Inject() (
       get[Option[List[Long]]]("task_review.additional_reviewers") ~
       get[Option[Int]]("task_review.meta_review_status") ~
       get[Option[Long]]("task_review.meta_reviewed_by") ~
-      get[Option[DateTime]]("task_review.meta_reviewed_at") map {
+      get[Option[DateTime]]("task_review.meta_reviewed_at") ~
+      get[Option[Long]]("locked_by") map {
       case id ~ name ~ parentId ~ parentName ~ orParentName ~ instruction ~ location ~ status ~
             mappedOn ~ completedTimeSpent ~ completedBy ~ priority ~ bundleId ~
             isBundlePrimary ~ cooperativeWork ~ reviewStatus ~ reviewRequestedBy ~
             reviewedBy ~ reviewedAt ~ reviewStartedAt ~ additionalReviewers ~
-            metaReviewStatus ~ metaReviewedBy ~ metaReviewedAt =>
+            metaReviewStatus ~ metaReviewedBy ~ metaReviewedAt ~ lockedBy =>
         val locationJSON = Json.parse(location)
         val coordinates  = (locationJSON \ "coordinates").as[List[Double]]
         val point        = Point(coordinates(1), coordinates.head)
@@ -424,7 +425,8 @@ class ChallengeDAL @Inject() (
           pointReview,
           priority,
           bundleId,
-          isBundlePrimary
+          isBundlePrimary,
+          lockedBy
         )
     }
   }

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -526,11 +526,12 @@ class VirtualChallengeDAL @Inject() (
         get[Option[DateTime]]("review_started_at") ~ get[Option[List[Long]]]("additional_reviewers") ~
         get[Option[Int]]("meta_review_status") ~ get[Option[Long]]("meta_reviewed_by") ~
         get[Option[DateTime]]("meta_reviewed_at") ~ int("priority") ~
-        get[Option[Long]]("bundle_id") ~ get[Option[Boolean]]("is_bundle_primary") map {
+        get[Option[Long]]("bundle_id") ~ get[Option[Boolean]]("is_bundle_primary") ~
+        get[Option[Long]]("locked_by") map {
         case id ~ name ~ instruction ~ location ~ status ~ cooperativeWork ~ mappedOn ~ completedTimeSpent ~
               completedBy ~ reviewStatus ~ reviewRequestedBy ~ reviewedBy ~ reviewedAt ~ reviewStartedAt ~
               additionalReviewers ~ metaReviewStatus ~ metaReviewedBy ~ metaReviewedAt ~
-              priority ~ bundleId ~ isBundlePrimary =>
+              priority ~ bundleId ~ isBundlePrimary ~ lockedBy =>
           val locationJSON = Json.parse(location)
           val coordinates  = (locationJSON \ "coordinates").as[List[Double]]
           val point        = Point(coordinates(1), coordinates.head)
@@ -567,7 +568,8 @@ class VirtualChallengeDAL @Inject() (
             pointReview,
             priority,
             bundleId,
-            isBundlePrimary
+            isBundlePrimary,
+            lockedBy
           )
       }
       SQL"""SELECT tasks.id, name, instruction, status, cooperative_work_json::TEXT as cooperative_work,

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -956,7 +956,7 @@ GET     /taskCluster                                @org.maproulette.framework.c
 #         items:
 #           type: integer
 ###
-POST    /task/bundle/lock                         @org.maproulette.controllers.api.TaskController.lockTaskBundleByIds(taskIds:List[Long])
+POST    /task/bundle/lock                         @org.maproulette.controllers.api.TaskController.lockTaskBundle(taskIds:List[Long])
 ###
 # tags: [ Task ]
 # summary: Unlocks a bundle of tasks
@@ -976,4 +976,4 @@ POST    /task/bundle/lock                         @org.maproulette.controllers.a
 #         items:
 #           type: integer
 ###
-POST    /task/bundle/unlock                        @org.maproulette.controllers.api.TaskController.unlockTaskBundleByIds(taskIds:List[Long])
+POST    /task/bundle/unlock                        @org.maproulette.controllers.api.TaskController.unlockTaskBundle(taskIds:List[Long])

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -977,23 +977,3 @@ POST    /task/bundle/lock                         @org.maproulette.controllers.a
 #           type: integer
 ###
 POST    /task/bundle/unlock                        @org.maproulette.controllers.api.TaskController.unlockTaskBundleByIds(taskIds:List[Long])
-###
-# tags: [ Task ]
-# summary: Refreshes locks on a bundle of tasks
-# description: Refreshes the locks on the specified tasks in the bundle.
-# responses:
-#   '200':
-#     description: Success message
-#   '401':
-#     description: The user is not authorized to make this request
-# requestBody:
-#   description: A JSON array of task IDs to refresh locks.
-#   required: true
-#   content:
-#     application/json:
-#       schema:
-#         type: array
-#         items:
-#           type: integer
-###
-POST    /task/bundle/refresh                      @org.maproulette.controllers.api.TaskController.refreshTaskLocksByIds(taskIds:List[Long])


### PR DESCRIPTION
Related: https://github.com/maproulette/maproulette3/pull/2619
Refactor task locking and unlocking methods for improved performance and error handling. Introduce bulk operations in TaskController and Locking mixin, and update API routes accordingly. Add 'lockedBy' field to ClusteredPoint model and adjust related DALs for consistency.