### PR TITLE
Add limit to string length in  fuzzy search parameter sql query

### DIFF
--- a/app/org/maproulette/framework/psql/filter/Parameter.scala
+++ b/app/org/maproulette/framework/psql/filter/Parameter.scala
@@ -225,7 +225,8 @@ case class FuzzySearchParameter(
     val columnKey = this.getColumnKey(table.getOrElse(tableKey))
     s"""($columnKey <> '' AND
       (LEVENSHTEIN(LOWER(LEFT($columnKey, 255)), LOWER({${this.getKey()}})) < $score OR
-      METAPHONE(LOWER(LEFT($columnKey, 255)), 4) = METAPHONE(LOWER({${this.getKey()}}), $metaphoneSize) OR
+      METAPHONE(LOWER(LEFT($columnKey, 255)), 4) = METAPHONE(LOWER({${this
+      .getKey()}}), $metaphoneSize) OR
       SOUNDEX(LOWER($columnKey)) = SOUNDEX(LOWER({${this.getKey()}})))
       )"""
   }

--- a/app/org/maproulette/framework/psql/filter/Parameter.scala
+++ b/app/org/maproulette/framework/psql/filter/Parameter.scala
@@ -225,7 +225,7 @@ case class FuzzySearchParameter(
     val columnKey = this.getColumnKey(table.getOrElse(tableKey))
     s"""($columnKey <> '' AND
       (LEVENSHTEIN(LOWER(LEFT($columnKey, 255)), LOWER({${this.getKey()}})) < $score OR
-      METAPHONE(LOWER(LEFT($columnKey, 255)), 4) = METAPHONE(LOWER({${this
+      METAPHONE(LOWER(LEFT($columnKey, 255)), $metaphoneSize) = METAPHONE(LOWER({${this
       .getKey()}}), $metaphoneSize) OR
       SOUNDEX(LOWER($columnKey)) = SOUNDEX(LOWER({${this.getKey()}})))
       )"""

--- a/app/org/maproulette/framework/psql/filter/Parameter.scala
+++ b/app/org/maproulette/framework/psql/filter/Parameter.scala
@@ -224,8 +224,8 @@ case class FuzzySearchParameter(
     }
     val columnKey = this.getColumnKey(table.getOrElse(tableKey))
     s"""($columnKey <> '' AND
-      (LEVENSHTEIN(LOWER($columnKey), LOWER({${this.getKey()}})) < $score OR
-      METAPHONE(LOWER($columnKey), 4) = METAPHONE(LOWER({${this.getKey()}}), $metaphoneSize) OR
+      (LEVENSHTEIN(LOWER(LEFT($columnKey, 255)), LOWER({${this.getKey()}})) < $score OR
+      METAPHONE(LOWER(LEFT($columnKey, 255)), 4) = METAPHONE(LOWER({${this.getKey()}}), $metaphoneSize) OR
       SOUNDEX(LOWER($columnKey)) = SOUNDEX(LOWER({${this.getKey()}})))
       )"""
   }

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -284,7 +284,7 @@ trait DALHelper {
     }
     s""" ${this.getSqlKey} ($column <> '' AND
           (LEVENSHTEIN(LOWER($column), LOWER({$key})) < $score OR
-            METAPHONE(LOWER($column), 4) = METAPHONE(LOWER({$key}), $metaphoneSize) OR
+            METAPHONE(LOWER($column), $metaphoneSize) = METAPHONE(LOWER({$key}), $metaphoneSize) OR
             SOUNDEX(LOWER($column)) = SOUNDEX(LOWER({$key})))
           )"""
   }

--- a/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
+++ b/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
@@ -799,9 +799,9 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
       val filter     = this.filterChallenges(params)
       val parameters = filter.parameters()
       normalized(filter.sql().replaceAll(parameters.head.name, "testC")) mustEqual
-        "(c.name <> '' AND (LEVENSHTEIN(LOWER(LEFT(c.name, 255)), LOWER(LEFT({testC}, 255))) < 2 OR " +
-          "METAPHONE(LOWER(LEFT(c.name, 255)), 4) = METAPHONE(LOWER(LEFT({testC}, 255)), 4) OR " +
-          "SOUNDEX(LOWER(LEFT(c.name, 255))) = SOUNDEX(LOWER(LEFT({testC}, 255)))) )"
+        "(c.name <> '' AND (LEVENSHTEIN(LOWER(LEFT(c.name, 255)), LOWER({testC})) < 2 OR " +
+          "METAPHONE(LOWER(LEFT(c.name, 255)), 4) = METAPHONE(LOWER({testC}), 4) OR " +
+          "SOUNDEX(LOWER(c.name)) = SOUNDEX(LOWER({testC}))) )"
     }
 
     "does search on name" in {

--- a/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
+++ b/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
@@ -756,8 +756,8 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
       val parameters = filter.parameters()
       normalized(filter.sql().replaceAll(parameters.head.name, "abc")) mustEqual
         "(p.display_name <> '' AND " +
-          "(LEVENSHTEIN(LOWER(p.display_name), LOWER({abc})) < 2 OR " +
-          "METAPHONE(LOWER(p.display_name), 4) = METAPHONE(LOWER({abc}), 4) OR " +
+          "(LEVENSHTEIN(LOWER(LEFT(p.display_name, 255)), LOWER({abc})) < 2 OR " +
+          "METAPHONE(LOWER(LEFT(p.display_name, 255)), 4) = METAPHONE(LOWER({abc}), 4) OR " +
           "SOUNDEX(LOWER(p.display_name)) = SOUNDEX(LOWER({abc}))) )"
     }
 
@@ -799,9 +799,9 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
       val filter     = this.filterChallenges(params)
       val parameters = filter.parameters()
       normalized(filter.sql().replaceAll(parameters.head.name, "testC")) mustEqual
-        "(c.name <> '' AND (LEVENSHTEIN(LOWER(c.name), LOWER({testC})) < 2 OR " +
-          "METAPHONE(LOWER(c.name), 4) = METAPHONE(LOWER({testC}), 4) OR " +
-          "SOUNDEX(LOWER(c.name)) = SOUNDEX(LOWER({testC}))) )"
+        "(c.name <> '' AND (LEVENSHTEIN(LOWER(LEFT(c.name, 255)), LOWER(LEFT({testC}, 255))) < 2 OR " +
+          "METAPHONE(LOWER(LEFT(c.name, 255)), 4) = METAPHONE(LOWER(LEFT({testC}, 255)), 4) OR " +
+          "SOUNDEX(LOWER(LEFT(c.name, 255))) = SOUNDEX(LOWER(LEFT({testC}, 255)))) )"
     }
 
     "does search on name" in {

--- a/test/org/maproulette/framework/psql/FilterParameterSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterParameterSpec.scala
@@ -296,8 +296,8 @@ object FilterParameterSpec {
       size: Int = FilterParameter.DEFAULT_METAPHONE_SIZE,
       keyPrefix: String = ""
   ) = s"""($key <> '' AND
-      (LEVENSHTEIN(LOWER($key), LOWER({$keyPrefix$key})) < $score OR
-      METAPHONE(LOWER($key), 4) = METAPHONE(LOWER({$keyPrefix$key}), $size) OR
+      (LEVENSHTEIN(LOWER(LEFT($key, 255)), LOWER({$keyPrefix$key})) < $score OR
+      METAPHONE(LOWER(LEFT($key, 255)), $size) = METAPHONE(LOWER({$keyPrefix$key}), $size) OR
       SOUNDEX(LOWER($key)) = SOUNDEX(LOWER({$keyPrefix$key})))
       )"""
 }


### PR DESCRIPTION
Resolves this error: ERROR: levenshtein argument exceeds maximum length of 255 characters
org.postgresql.util.PSQLException: ERROR: levenshtein argument exceeds maximum length of 255 characters

<img width="1593" alt="Screenshot 2025-05-13 at 3 22 31 PM" src="https://github.com/user-attachments/assets/cdf3fe22-4ffc-40ff-ab8e-48b785cf7f22" />

Appears to be caused by excessively large challenge or project names