### PR TITLE
Add API endpoint to mark notifications as unread

### DIFF
--- a/app/org/maproulette/framework/controller/NotificationController.scala
+++ b/app/org/maproulette/framework/controller/NotificationController.scala
@@ -83,6 +83,17 @@ class NotificationController @Inject() (
       }
     }
 
+  def markNotificationsUnread(userId: Long): Action[JsValue] =
+    Action.async(bodyParsers.json) { implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        val notificationIds = (request.body \ "notificationIds").as[List[Long]]
+        if (!notificationIds.isEmpty) {
+          this.service.markNotificationsUnread(userId, user, notificationIds)
+        }
+        Ok(Json.toJson(StatusMessage("OK", JsString(s"Notifications marked as unread"))))
+      }
+    }
+
   def deleteNotifications(userId: Long): Action[JsValue] =
     Action.async(bodyParsers.json) { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>

--- a/app/org/maproulette/framework/repository/NotificationRepository.scala
+++ b/app/org/maproulette/framework/repository/NotificationRepository.scala
@@ -148,6 +148,28 @@ class NotificationRepository @Inject() (override val db: Database) extends Repos
   }
 
   /**
+    * Marks as unread the given notifications owned by the given userId
+    *
+    * @param userId          The id of the user that owns the notifications
+    * @param notificationIds The ids of the notifications to be marked unread
+    */
+  def markNotificationsUnread(userId: Long, notificationIds: List[Long])(
+      implicit c: Option[Connection] = None
+  ): Boolean = {
+    withMRConnection { implicit c =>
+      Query
+        .simple(
+          List(
+            BaseParameter(UserNotification.FIELD_USER_ID, userId),
+            BaseParameter(UserNotification.FIELD_ID, notificationIds, Operator.IN)
+          )
+        )
+        .build("UPDATE user_notifications SET is_read=FALSE")
+        .execute()
+    }
+  }
+
+  /**
     * Deletes the given notifications owned by the given userId
     *
     * @param userId          The id of the user that owns the notifications

--- a/app/org/maproulette/framework/service/NotificationService.scala
+++ b/app/org/maproulette/framework/service/NotificationService.scala
@@ -126,6 +126,18 @@ class NotificationService @Inject() (
   }
 
   /**
+    * Marks as unread the given notifications owned by the given userId
+    *
+    * @param userId          The id of the user that owns the notifications
+    * @param user            The user making the request
+    * @param notificationIds The ids of the notifications to be marked unread
+    */
+  def markNotificationsUnread(userId: Long, user: User, notificationIds: List[Long]): Boolean = {
+    permission.hasWriteAccess(UserType(), user)(userId)
+    this.repository.markNotificationsUnread(userId, notificationIds)
+  }
+
+  /**
     * Deletes the given notifications owned by the given userId
     *
     * @param userId          The id of the user that owns the notifications

--- a/conf/v2_route/notification.api
+++ b/conf/v2_route/notification.api
@@ -66,6 +66,30 @@ GET     /user/:userId/notifications                 @org.maproulette.framework.c
 PUT     /user/:userId/notifications                 @org.maproulette.framework.controller.NotificationController.markNotificationsRead(userId:Long)
 ###
 # tags: [ Notification ]
+# summary: Mark user notifications as unread
+# description: Marks user notifications as unread
+# responses:
+#   '200':
+#     description: Ok with a standard message
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The id of the user that owns the notifications
+# requestBody:
+#   description: A JSON array of notification ids
+#   required: true
+#   content:
+#     application/json:
+#       schema:
+#         type: array
+#         items:
+#           type: integer
+###
+PUT     /user/:userId/notifications/unread          @org.maproulette.framework.controller.NotificationController.markNotificationsUnread(userId:Long)
+###
+# tags: [ Notification ]
 # summary: Delete user notifications
 # description: Deletes the specified user notifications
 # responses:

--- a/test/org/maproulette/framework/repository/NotificationRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/NotificationRepositorySpec.scala
@@ -111,6 +111,33 @@ class NotificationRepositorySpec(implicit val application: Application) extends 
       readNotifications.head.isRead mustEqual true
     }
 
+    "mark notifications as unread" taggedAs NotificationTag in {
+      val freshUser = this.serviceManager.user.create(
+        this.getTestUser(199911115, "MarkNotificationUnreadOUser"),
+        User.superUser
+      )
+      this.repository.create(this.getTestNotification(freshUser.id))
+
+      val initialNotifications = this.repository.getUserNotifications(freshUser.id)
+      initialNotifications.size mustEqual 1
+      initialNotifications.head.isRead mustEqual false
+
+      // First mark as read
+      this.repository.markNotificationsRead(freshUser.id, initialNotifications.map(_.id))
+      val readNotifications =
+        this.repository.getUserNotifications(freshUser.id, isRead = Some(true))
+      readNotifications.size mustEqual 1
+      readNotifications.head.isRead mustEqual true
+
+      // Then mark as unread
+      this.repository.markNotificationsUnread(freshUser.id, readNotifications.map(_.id))
+      val unreadAgainNotifications =
+        this.repository.getUserNotifications(freshUser.id, isRead = Some(false))
+      unreadAgainNotifications.size mustEqual 1
+      unreadAgainNotifications.head.id mustEqual initialNotifications.head.id
+      unreadAgainNotifications.head.isRead mustEqual false
+    }
+
     "delete notifications" taggedAs NotificationTag in {
       val freshUser = this.serviceManager.user.create(
         this.getTestUser(199911114, "DeleteNotificationsOUser"),

--- a/test/org/maproulette/framework/service/NotificationServiceSpec.scala
+++ b/test/org/maproulette/framework/service/NotificationServiceSpec.scala
@@ -216,7 +216,7 @@ class NotificationServiceSpec(implicit val application: Application) extends Fra
 
     "mark notifications as unread" taggedAs NotificationTag in {
       val freshUser = this.serviceManager.user.create(
-        this.getTestUser(299911125, "Service_markNotificationUnreadOUser"),
+        this.getTestUser(299911134, "Service_markNotificationUnreadOUser"),
         User.superUser
       )
       this.repository.create(this.getTestNotification(freshUser.id))
@@ -257,12 +257,13 @@ class NotificationServiceSpec(implicit val application: Application) extends Fra
       val notifications = this.service.getUserNotifications(this.defaultUser.id, this.defaultUser)
 
       val freshUser = this.serviceManager.user.create(
-        this.getTestUser(299911126, "Service_markNotificationsUnreadFailureOUser"),
+        this.getTestUser(299911133, "Service_markNotificationsUnreadFailureOUser"),
         User.superUser
       )
 
       an[IllegalAccessException] should be thrownBy
-        this.service.markNotificationsUnread(this.defaultUser.id, freshUser, notifications.map(_.id))
+        this.service
+          .markNotificationsUnread(this.defaultUser.id, freshUser, notifications.map(_.id))
     }
 
     "delete notifications" taggedAs NotificationTag in {


### PR DESCRIPTION
Corresponding PR: https://github.com/maproulette/maproulette3/pull/2683

Adds functionality to mark user notifications as unread, providing users with better control over their notification management.

### API Details
- **Endpoint**: `PUT /user/:userId/notifications/unread`
- **Request Body**: `{ "notificationIds": [1, 2, 3] }`
- **Response**: `{ "status": "OK", "message": "Notifications marked as unread" }`
- **Authorization**: Users can only modify their own notifications
