### PR TITLE
Enhance TaskController to send WebSocket notifications on task claim and release

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -389,7 +389,7 @@ class TaskController @Inject() (
       } else {
         // Use bulk locking for better performance
         this.dal.lockItems(user, tasks)
-        
+
         tasks.foreach { task =>
           this.serviceManager.challenge.retrieve(task.parent) match {
             case Some(challenge) =>
@@ -403,12 +403,12 @@ class TaskController @Inject() (
                       WebSocketMessages.userSummary(user)
                     )
                   )
-                case None => 
+                case None =>
               }
-            case None => 
+            case None =>
           }
         }
-        
+
         Ok(Json.toJson(tasks))
       }
     }
@@ -430,14 +430,14 @@ class TaskController @Inject() (
       } else {
         // Use bulk locking for better performance
         this.dal.unlockItems(user, tasks)
-        
+
         // Send WebSocket notifications for each unlocked task
         tasks.foreach { task =>
           webSocketProvider.sendMessage(
             WebSocketMessages.taskReleased(task, Some(WebSocketMessages.userSummary(user)))
           )
         }
-        
+
         Ok(Json.toJson(tasks))
       }
     }

--- a/app/org/maproulette/provider/websockets/WebSocketActor.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketActor.scala
@@ -65,6 +65,8 @@ class WebSocketActor(out: ActorRef) extends Actor {
       out ! Json.toJson(serverMessage)
     case serverMessage: WebSocketMessages.TaskMessage =>
       out ! Json.toJson(serverMessage)
+    case serverMessage: WebSocketMessages.TasksMessage =>
+      out ! Json.toJson(serverMessage)
     case serverMessage: WebSocketMessages.TeamMessage =>
       out ! Json.toJson(serverMessage)
     case serverMessage: WebSocketMessages.FollowMessage =>

--- a/app/org/maproulette/provider/websockets/WebSocketMessages.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketMessages.scala
@@ -150,8 +150,14 @@ object WebSocketMessages {
       Some(userData)
     )
 
+  def tasksCompleted(tasksData: List[Task], userData: Option[UserSummary]): List[ServerMessage] =
+    createTasksMessage("tasks-completed", tasksData, None, None, userData)
+
   def taskUpdated(taskData: Task, userData: Option[UserSummary]): List[ServerMessage] =
     createTaskMessage("task-update", taskData, None, None, userData)
+
+  def tasksUpdated(tasksData: List[Task], userData: Option[UserSummary]): List[ServerMessage] =
+    createTasksMessage("tasks-update", tasksData, None, None, userData)
 
   def teamUpdate(data: TeamUpdateData): TeamMessage = createTeamMessage("team-update", data)
 


### PR DESCRIPTION
- Added functionality to send WebSocket messages when tasks are claimed, including challenge and project summaries.
- Implemented WebSocket notifications for each unlocked task, notifying users of the release.