### PR TITLE
Refactor challenge extra json serialization in challenge writes

### DIFF
--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -45,33 +45,38 @@ trait ChallengeWrites extends DefaultWrites {
 
   implicit val challengeExtraWrites = new Writes[ChallengeExtra] {
     def writes(o: ChallengeExtra): JsValue = {
-      // Create the JSON manually since automatic derivation isn't working
-      val json = Json.obj(
-        "defaultZoom"          -> o.defaultZoom,
-        "minZoom"              -> o.minZoom,
-        "maxZoom"              -> o.maxZoom,
-        "defaultBasemap"       -> o.defaultBasemap,
-        "defaultBasemapId"     -> o.defaultBasemapId,
-        "customBasemap"        -> o.customBasemap,
-        "updateTasks"          -> o.updateTasks,
-        "exportableProperties" -> o.exportableProperties,
-        "osmIdProperty"        -> o.osmIdProperty,
-        "preferredTags"        -> o.preferredTags,
-        "preferredReviewTags"  -> o.preferredReviewTags,
-        "limitTags"            -> o.limitTags,
-        "limitReviewTags"      -> o.limitReviewTags,
-        "taskBundleIdProperty" -> o.taskBundleIdProperty,
-        "isArchived"           -> o.isArchived,
-        "reviewSetting"        -> o.reviewSetting,
-        "taskWidgetLayout"     -> o.taskWidgetLayout,
-        "datasetUrl"           -> o.datasetUrl,
-        "systemArchivedAt"     -> o.systemArchivedAt,
-        "presets"              -> o.presets,
-        "requireConfirmation"  -> o.requireConfirmation,
-        "mrTagMetrics"         -> o.mrTagMetrics
+      // Build JSON manually and omit Option fields that are None (avoid serializing as null)
+      val baseFields: Seq[(String, JsValue)] = Seq(
+        "defaultZoom"         -> JsNumber(o.defaultZoom),
+        "minZoom"             -> JsNumber(o.minZoom),
+        "maxZoom"             -> JsNumber(o.maxZoom),
+        "updateTasks"         -> JsBoolean(o.updateTasks),
+        "limitTags"           -> JsBoolean(o.limitTags),
+        "limitReviewTags"     -> JsBoolean(o.limitReviewTags),
+        "isArchived"          -> JsBoolean(o.isArchived),
+        "reviewSetting"       -> JsNumber(o.reviewSetting),
+        "requireConfirmation" -> JsBoolean(o.requireConfirmation)
       )
 
-      // Handle taskStyles specially
+      val optionFields: Seq[Option[(String, JsValue)]] = Seq(
+        o.defaultBasemap.map(v => "defaultBasemap"       -> JsNumber(v)),
+        o.defaultBasemapId.map(v => "defaultBasemapId"    -> JsString(v)),
+        o.customBasemap.map(v => "customBasemap"          -> JsString(v)),
+        o.exportableProperties.map(v => "exportableProperties" -> JsString(v)),
+        o.osmIdProperty.map(v => "osmIdProperty"          -> JsString(v)),
+        o.preferredTags.map(v => "preferredTags"          -> JsString(v)),
+        o.preferredReviewTags.map(v => "preferredReviewTags" -> JsString(v)),
+        o.taskBundleIdProperty.map(v => "taskBundleIdProperty" -> JsString(v)),
+        o.taskWidgetLayout.map(v => "taskWidgetLayout"    -> v),
+        o.datasetUrl.map(v => "datasetUrl"                -> JsString(v)),
+        o.systemArchivedAt.map(dt => "systemArchivedAt"   -> Json.toJson(dt)),
+        o.presets.map(v => "presets"                      -> Json.toJson(v)),
+        o.mrTagMetrics.map(v => "mrTagMetrics"            -> v)
+      )
+
+      val json = JsObject(baseFields ++ optionFields.flatten)
+
+      // Handle taskStyles specially (stored as JSON string; return as parsed JSON when present)
       o.taskStyles match {
         case Some(ts) => Utils.insertIntoJson(json, "taskStyles", Json.parse(ts), true)
         case None     => json

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -59,19 +59,19 @@ trait ChallengeWrites extends DefaultWrites {
       )
 
       val optionFields: Seq[Option[(String, JsValue)]] = Seq(
-        o.defaultBasemap.map(v => "defaultBasemap"       -> JsNumber(v)),
-        o.defaultBasemapId.map(v => "defaultBasemapId"    -> JsString(v)),
-        o.customBasemap.map(v => "customBasemap"          -> JsString(v)),
+        o.defaultBasemap.map(v => "defaultBasemap"             -> JsNumber(v)),
+        o.defaultBasemapId.map(v => "defaultBasemapId"         -> JsString(v)),
+        o.customBasemap.map(v => "customBasemap"               -> JsString(v)),
         o.exportableProperties.map(v => "exportableProperties" -> JsString(v)),
-        o.osmIdProperty.map(v => "osmIdProperty"          -> JsString(v)),
-        o.preferredTags.map(v => "preferredTags"          -> JsString(v)),
-        o.preferredReviewTags.map(v => "preferredReviewTags" -> JsString(v)),
+        o.osmIdProperty.map(v => "osmIdProperty"               -> JsString(v)),
+        o.preferredTags.map(v => "preferredTags"               -> JsString(v)),
+        o.preferredReviewTags.map(v => "preferredReviewTags"   -> JsString(v)),
         o.taskBundleIdProperty.map(v => "taskBundleIdProperty" -> JsString(v)),
-        o.taskWidgetLayout.map(v => "taskWidgetLayout"    -> v),
-        o.datasetUrl.map(v => "datasetUrl"                -> JsString(v)),
-        o.systemArchivedAt.map(dt => "systemArchivedAt"   -> Json.toJson(dt)),
-        o.presets.map(v => "presets"                      -> Json.toJson(v)),
-        o.mrTagMetrics.map(v => "mrTagMetrics"            -> v)
+        o.taskWidgetLayout.map(v => "taskWidgetLayout"         -> v),
+        o.datasetUrl.map(v => "datasetUrl"                     -> JsString(v)),
+        o.systemArchivedAt.map(dt => "systemArchivedAt"        -> Json.toJson(dt)),
+        o.presets.map(v => "presets"                           -> Json.toJson(v)),
+        o.mrTagMetrics.map(v => "mrTagMetrics"                 -> v)
       )
 
       val json = JsObject(baseFields ++ optionFields.flatten)


### PR DESCRIPTION
Resolves this error in the maproulette josm plugin introduced in backend v4.7.13: 2025-08-10 12:30:04.853 SEVERE: Handled by bug report queue: java.lang.ClassCastException: class jakarta.json.JsonValueImpl cannot be cast to class jakarta.json.JsonString (jakarta.json.JsonValueImpl and jakarta.json.JsonString are in unnamed module of loader 'app')
java.lang.ClassCastException: class jakarta.json.JsonValueImpl cannot be cast to class jakarta.json.JsonString (jakarta.json.JsonValueImpl and jakarta.json.JsonString are in unnamed module of loader 'app')
	at org.eclipse.parsson.JsonObjectBuilderImpl$JsonObjectImpl.getJsonString(JsonObjectBuilderImpl.java:244)
	at org.eclipse.parsson.JsonObjectBuilderImpl$JsonObjectImpl.getString(JsonObjectBuilderImpl.java:249)
	at org.openstreetmap.josm.plugins.maproulette.api.parsers.ParsingUtils.optionalInstant(ParsingUtils.java:69)
	at org.openstreetmap.josm.plugins.maproulette.api.ChallengeAPI.parseChallengeExtra(ChallengeAPI.java:350)
	at org.openstreetmap.josm.plugins.maproulette.api.ChallengeAPI.parseChallenge(ChallengeAPI.java:277)
	at org.openstreetmap.josm.plugins.maproulette.api.ChallengeAPI.challenge(ChallengeAPI.java:232)
	at org.openstreetmap.josm.plugins.maproulette.api_caching.ChallengeCache.challenge(ChallengeCache.java:57)
	at org.openstreetmap.josm.plugins.maproulette.api_caching.ChallengeCache.isHidden(ChallengeCache.java:36)
	at org.openstreetmap.josm.plugins.maproulette.api_caching.TaskCache.isHidden(TaskCache.java:50)
	at org.openstreetmap.josm.plugins.maproulette.gui.layer.MapRouletteClusteredPointLayer.paint(MapRouletteClusteredPointLayer.java:221)
	at org.openstreetmap.josm.gui.layer.AbstractMapViewPaintable$CompatibilityModeLayerPainter.paint(AbstractMapViewPaintable.java:27)
	at org.openstreetmap.josm.gui.MapView.paintLayer(MapView.java:487)
	at org.openstreetmap.josm.gui.MapView.drawMapContent(MapView.java:603)
	at org.openstreetmap.josm.gui.MapView.paint(MapView.java:509)
	at java.desktop@21.0.7/javax.swing.JComponent.paintChildren(Unknown Source)
	at java.desktop@21.0.7/javax.swing.JComponent.paint(Unknown Source)
	at java.desktop@21.0.7/javax.swing.JComponent.paintToOffscreen(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager$PaintManager.paintDoubleBufferedImpl(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager$PaintManager.paintDoubleBuffered(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager$PaintManager.paint(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager.paint(Unknown Source)
	at java.desktop@21.0.7/javax.swing.JComponent._paintImmediately(Unknown Source)
	at java.desktop@21.0.7/javax.swing.JComponent.paintImmediately(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager$4.run(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager$4.run(Unknown Source)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager.paintDirtyRegions(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager.paintDirtyRegions(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager.prePaintDirtyRegions(Unknown Source)
	at java.desktop@21.0.7/javax.swing.RepaintManager$ProcessingRunnable.run(Unknown Source)
	at java.desktop@21.0.7/java.awt.event.InvocationEvent.dispatch(Unknown Source)
	at java.desktop@21.0.7/java.awt.EventQueue.dispatchEventImpl(Unknown Source)