### PR TITLE
Add `?bbox=` query parameter to `/challenge/view/:id` endpoint

### DIFF
--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1167,6 +1167,7 @@ class ChallengeDAL @Inject() (
     * @param priorityFilter     To view the geojson for only challenges with a specific priority
     * @param params             SearchParameters for filtering by taskPropertySearch
     * @param timezone           The timezone offset (ie. -07:00)
+    * @param boundingBox        Optional bounding box to limit tasks (left, bottom, right, top)
     * @param c                  The implicit connection for the function
     * @return
     */
@@ -1176,7 +1177,8 @@ class ChallengeDAL @Inject() (
       reviewStatusFilter: Option[List[Int]] = None,
       priorityFilter: Option[List[Int]] = None,
       params: Option[SearchParameters] = None,
-      timezone: String = Utils.UTC_TIMEZONE
+      timezone: String = Utils.UTC_TIMEZONE,
+      boundingBox: Option[(Double, Double, Double, Double)] = None
   )(implicit c: Option[Connection] = None): String = {
     this.withMRConnection { implicit c =>
       val filters = new StringBuilder()
@@ -1254,6 +1256,15 @@ class ChallengeDAL @Inject() (
                 )""")
             case _ => // do nothing
           }
+        case None => // do nothing
+      }
+
+      // Apply bounding box filter if provided
+      boundingBox match {
+        case Some((left, bottom, right, top)) =>
+          filters.append(
+            s""" AND ST_Intersects(t.location, ST_MakeEnvelope($left, $bottom, $right, $top, 4326))"""
+          )
         case None => // do nothing
       }
 

--- a/conf/v2_route/challenge.api
+++ b/conf/v2_route/challenge.api
@@ -943,6 +943,9 @@ GET     /challenge/:cid/previousTask/:id            @org.maproulette.controllers
 #   - name: timezone
 #     in: query
 #     description: A timezone offset to apply to time fields. Format should be like '+HH:MM'. Default is GMT (+00:00)
+#   - name: bbox
+#     in: query
+#     description: Bounding box to limit the tasks returned. Format should be 'left,bottom,right,top' (comma-separated coordinates) in degrees
 #   - name: filename
 #     in: query
 #     description: Optional filename to be used for the export
@@ -956,7 +959,7 @@ GET     /challenge/:cid/previousTask/:id            @org.maproulette.controllers
 #       schema:
 #         $ref: '#/components/schemas/org.maproulette.session.TaskPropertySearch'
 ###
-GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "", filename:String ?= "")
+GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "", bbox:String ?= "", filename:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Retrieves Challenge GeoJSON
@@ -979,6 +982,9 @@ GET     /challenge/view/:id                         @org.maproulette.controllers
 #   - name: reviewStatus
 #     in: query
 #     description: Can filter the Tasks returned by the reviewStatus of the Task. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted, 4 - Disputed
+#   - name: bbox
+#     in: query
+#     description: Bounding box to limit the tasks returned. Format should be 'left,bottom,right,top' (comma-separated coordinates) in degrees
 #   - name: filename
 #     in: query
 #     description: Optional filename to be used for the export
@@ -992,7 +998,7 @@ GET     /challenge/view/:id                         @org.maproulette.controllers
 #       schema:
 #         $ref: '#/components/schemas/org.maproulette.session.TaskPropertySearch'
 ###
-POST    /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "", filename:String ?= "")
+POST    /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "", bbox:String ?= "", filename:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Retrieves clustered Task points


### PR DESCRIPTION
Closes #1037. This allows applications to retrieve the tasks for a specific challenge and within a specific bounding box. Useful for e.g. Rapid which can be configured to show a particular challenge's tasks as markers on the screen (but only needs to fetch tasks within the current viewport).