### PR TITLE
Bypass challenge cache when recalculating task priorities to ensure updated rules and bounds are always applied.

### DIFF
--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -928,7 +928,9 @@ class ChallengeDAL @Inject() (
   )(implicit id: Long, c: Option[Connection] = None): Unit = {
     this.permission.hasWriteAccess(ChallengeType(), user)
     this.withMRConnection { implicit c =>
-      val challenge = this.retrieveById(id) match {
+      // Bypass the challenge cache so freshly-updated priority rules/bounds are
+      // always used when recalculating task priorities.
+      val challenge = this._retrieveById(caching = false)(id, Some(c)) match {
         case Some(c) => c
         case None =>
           throw new NotFoundException(


### PR DESCRIPTION
resolves: https://github.com/maproulette/maproulette3/issues/2800