### PR TITLE
Update pull-request GH action versions

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -17,8 +17,8 @@ jobs:
   sbt_formatChecks_dependencyTree:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
@@ -51,9 +51,9 @@ jobs:
       matrix:
         java: [ 17 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -85,13 +85,13 @@ jobs:
       matrix:
         java: [17]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6
       with:
         repository: 'osmlab/maproulette-java-client'
         path: 'java-client'
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         # https://github.com/actions/setup-java?tab=readme-ov-file#install-multiple-jdks
         java-version: ${{ matrix.java }}


### PR DESCRIPTION
Keep the action versions updated to avoid issues with stale versions: checkout v4->v6, setup-java v4->v5. The deployment action file was not updated to avoid issues, it will be updated later.