### PR TITLE
Update to sbt 1.12.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ as similar to production as possible. It also handles fetching x8664 and aarch64
 Follow the installation steps and install the JDK and sbt using a command similar to:
 
 * `sdk install java 17.0.15-tem`
-* `sdk install sbt 1.11.2`
+* `sdk install sbt 1.12.11`
 
 #### Validation
 

--- a/build.sbt
+++ b/build.sbt
@@ -49,8 +49,7 @@ inThisBuild(
   List(
     semanticdbEnabled := true,
     semanticdbOptions += "-P:semanticdb:synthetics:on",
-    semanticdbVersion := scalafixSemanticdb.revision,
-    scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
+    semanticdbVersion := scalafixSemanticdb.revision
   )
 )
 
@@ -136,8 +135,6 @@ val akkaSerializationJacksonOverrides = Seq(
 ).map(_ % jacksonVersion)
 
 libraryDependencies ++= jacksonDatabindOverrides ++ jacksonOverrides ++ akkaSerializationJacksonOverrides
-
-resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 // Some suggested scalac compiler options. These will print but nothing will fail the build.
 // https://gist.githubusercontent.com/tabdulradi/aa7450921756cd22db6d278100b2dac8/raw/ad80d738758f81b576bac4fe6188625646cf4ddf/scalac-compiler-flags-2.13.sbt

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # https://github.com/sbt/sbt/releases
-sbt.version=1.11.2
+sbt.version=1.12.11


### PR DESCRIPTION
Update to the latest release of sbt to prepare for other dependency updates. In build.sbt, the removal of `scalafixScalaBinaryVersion` and `resolvers` are explained by the sbt warning output:

```
- warning: value scalafixScalaBinaryVersion in object autoImport is deprecated (since 0.12.1): 
    scalafixScalaBinaryVersion now follows scalaVersion by default

- warning: method sonatypeOssRepos in class ResolverFunctions is deprecated (since 1.11.2):
    Sonatype OSS Repository Hosting (OSSRH) was sunset on 2025-06-30;
    remove this resolver. If snapshots are required, use: resolvers += Resolver.sonatypeCentralSnapshots
```