### PR TITLE
Update sbt plugins and swagger-ui dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ libraryDependencies ++= Seq(
   // NOTE: The swagger-ui package is used to obtain the static distribution of swagger-ui, the files included at runtime
   // and are served by the webserver at route '/assets/lib/swagger-ui/'. We have a few customized swagger files in dir
   // 'public/swagger'.
-  "org.webjars"             % "swagger-ui"      % "5.10.3",
+  "org.webjars"             % "swagger-ui"      % "5.32.5",
   "org.playframework.anorm" %% "anorm"          % "2.7.0",
   "org.playframework.anorm" %% "anorm-postgres" % "2.7.0",
   "org.postgresql"          % "postgresql"      % "42.7.3", // https://github.com/pgjdbc/pgjdbc/releases

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,21 +5,21 @@ addDependencyTreePlugin
 // https://github.com/playframework/playframework/releases
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.11")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
+addSbtPlugin("com.github.sbt" % "sbt-gzip" % "2.0.0")
 
 addSbtPlugin("com.beautiful-scala" %% "sbt-scalastyle" % "1.5.1")
 
-addSbtPlugin("io.github.play-swagger" % "sbt-play-swagger" % "1.6.2")
+addSbtPlugin("io.github.play-swagger" % "sbt-play-swagger" % "1.7.3")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 
-addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.4.0")
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.5.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.6")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
-addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
 // https://github.com/sbt/sbt/issues/6997
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
This is to update plugins to their latest, some of the older versions didn't list out Play 2.9 support (it worked, but it's better to have the newer versions :-) ):

  - sbt-gzip: com.typesafe.sbt 1.0.2 -> com.github.sbt 2.0.0 (groupId moved)
  - sbt-play-swagger: 1.6.2 -> 1.7.3
  - sbt-scalafmt: 2.4.6 -> 2.5.4
  - sbt-jacoco: 3.4.0 -> 3.5.0
  - sbt-buildinfo: 0.11.0 -> 0.13.1
  - sbt-git: 2.0.1 -> 2.1.0
  - swagger-ui webjar: 5.10.3 -> 5.32.5