### PR TITLE
Implement bulk task creation for create/update challenge workflows

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -35,6 +35,7 @@ import play.api.libs.json.JodaReads._
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{Future, Promise}
 import scala.util.control.Exception.allCatch
@@ -361,10 +362,26 @@ class TaskDAL @Inject() (
     // Chunk so the progress poll sees the count climb step-by-step instead of
     // jumping from 0 to N at the final commit, and so very large challenges
     // don't push a single multi-MB parameter through one statement.
-    tasks.grouped(BulkInsertChunkSize).flatMap(bulkInsertChunk(_, parent)).toList
+    dedupeTasksByName(tasks).grouped(BulkInsertChunkSize).flatMap(bulkInsertChunk(_, parent)).toList
   }
 
   private val BulkInsertChunkSize = 5000
+
+  /**
+    * If the same (case-insensitive) name appears more than once in a batch, keep
+    * only the last occurrence. The bulk INSERT below uses
+    * ON CONFLICT (parent_id, lower(name)) DO NOTHING rather than an upsert,
+    * because Postgres rejects a single statement's ON CONFLICT DO UPDATE
+    * touching the same conflict target twice — so duplicates within one batch
+    * must be resolved in Scala first. This also matches the last-write-wins
+    * semantics create_update_task gave us previously (each duplicate would
+    * overwrite the last via its own upsert).
+    */
+  private[dal] def dedupeTasksByName(tasks: List[Task]): List[Task] = {
+    val lastByName = mutable.LinkedHashMap.empty[String, Task]
+    tasks.foreach(t => lastByName(t.name.toLowerCase) = t)
+    lastByName.values.toList
+  }
 
   /** Recursive lookup; geometries is already a parsed JsObject so this is cheap. */
   def looksCooperative(geometries: JsObject): Boolean =

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -317,6 +317,181 @@ class TaskDAL @Inject() (
     * @param c       A connection to execute against
     * @return
     */
+  /**
+    * Per-task bulk insert via create_update_task. Used for tasks whose JSON
+    * contains cooperativeWork or per-feature maproulette markers (those need
+    * the side effects baked into create_update_task / extractCooperativeWork
+    * and we don't replicate them in the all-SQL bulkInsertNewTasks path).
+    */
+  def bulkMergeNewTasks(
+      tasks: List[Task],
+      user: User,
+      parent: Challenge
+  )(implicit c: Option[Connection] = None): List[Task] = {
+    tasks.headOption.foreach(this.permission.hasObjectWriteAccess(_, user))
+    tasks.flatMap { task =>
+      try this.withMRTransaction { implicit c =>
+        Some(insertViaCreateUpdateTask(task, parent))
+      } catch {
+        case e: Exception =>
+          logger.error(s"Failed to insert task '${task.name}' in challenge ${parent.id}", e)
+          None
+      }
+    }
+  }
+
+  /**
+    * Insert every task in a single SQL statement, bypassing create_update_task.
+    * PostGIS computes ST_Collect / ST_Centroid inline per row from each task's
+    * geojson features. Inserts at the challenge's defaultPriority; the
+    * post-build updateTaskPriorities recompute (single SQL UPDATE) re-applies
+    * any priority rules / bounds afterwards.
+    *
+    * Caller (ChallengeProvider) must NOT route tasks here if any contain
+    * cooperativeWork or per-feature maproulette markers — those still need
+    * the per-task create_update_task path so cooperative_type detection and
+    * geometry-stripping run.
+    */
+  def bulkInsertNewTasks(
+      tasks: List[Task],
+      user: User,
+      parent: Challenge
+  )(implicit c: Option[Connection] = None): List[Task] = {
+    tasks.headOption.foreach(this.permission.hasObjectWriteAccess(_, user))
+    // Chunk so the progress poll sees the count climb step-by-step instead of
+    // jumping from 0 to N at the final commit, and so very large challenges
+    // don't push a single multi-MB parameter through one statement.
+    tasks.grouped(BulkInsertChunkSize).flatMap(bulkInsertChunk(_, parent)).toList
+  }
+
+  private val BulkInsertChunkSize = 5000
+
+  /** Recursive lookup; geometries is already a parsed JsObject so this is cheap. */
+  def looksCooperative(geometries: JsObject): Boolean =
+    (geometries \\ "cooperativeWork").nonEmpty || (geometries \\ "maproulette").nonEmpty
+
+  private def bulkInsertChunk(
+      tasks: List[Task],
+      parent: Challenge
+  )(implicit c: Option[Connection]): List[Task] = {
+    val inputJson = Json.stringify(JsArray(tasks.map { t =>
+      val instruction: String = t.instruction.getOrElse("")
+      Json.obj(
+        "name"        -> t.name,
+        "instruction" -> instruction,
+        "status"      -> t.status,
+        "geojson"     -> t.geometries
+      )
+    }))
+
+    val query =
+      """
+      WITH input AS (
+        SELECT
+          (item->>'name')                        AS name,
+          (item->>'instruction')                 AS instruction,
+          COALESCE((item->>'status')::int, 0)    AS status,
+          item->'geojson'                        AS geojson
+        FROM jsonb_array_elements({input}::jsonb) AS item
+      ), with_geom AS (
+        SELECT
+          i.*,
+          (SELECT ST_COLLECT(ST_SETSRID(ST_MAKEVALID(ST_GEOMFROMGEOJSON(f->>'geometry')), 4326))
+           FROM jsonb_array_elements(i.geojson->'features') AS f) AS combined_geom
+        FROM input i
+      )
+      INSERT INTO tasks (name, parent_id, status, instruction, priority, geojson, location, geom)
+      SELECT
+        name,
+        {parentId}::bigint,
+        status,
+        instruction,
+        {defaultPriority}::int,
+        geojson,
+        ST_Centroid(combined_geom),
+        combined_geom
+      FROM with_geom
+      ON CONFLICT (parent_id, lower(name)) DO NOTHING
+      RETURNING id, name
+      """
+
+    this.withMRTransaction { implicit c =>
+      val inserted: List[(Long, String)] = SQL(query)
+        .on(
+          NamedParameter("input", inputJson),
+          NamedParameter("parentId", parent.id),
+          NamedParameter("defaultPriority", parent.priority.defaultPriority)
+        )
+        .as((long("id") ~ str("name")).map(SqlParser.flatten).*)
+      val idByName: Map[String, Long] = inserted.map { case (id, name) => name -> id }.toMap
+      tasks.flatMap(t => idByName.get(t.name).map(id => t.copy(id = id)))
+    }
+  }
+
+  private def insertViaCreateUpdateTask(
+      task: Task,
+      parent: Challenge
+  )(implicit c: Connection): Task = {
+    val (geometries, cooperativeWork) =
+      extractCooperativeWork(task.parent, task.geometries, task.cooperativeWork)
+    val newId = SQL(createUpdateTaskQuery)
+      .on(createUpdateTaskParams(task, parent, geometries, cooperativeWork): _*)
+      .as(long("create_update_task").*)
+      .head
+    this.cacheManager.cache.remove(newId)
+    task.copy(id = newId)
+  }
+
+  private val createUpdateTaskQuery =
+    """SELECT create_update_task({name}, {parentId}, {instruction},
+                {status}, {geojson}::JSONB, {cooperativeWorkJson}::JSONB, {id}, {priority}, {changesetId},
+                {reset}, {mappedOn}, {reviewStatus}, CAST({reviewRequestedBy} AS INTEGER),
+                CAST({reviewedBy} AS INTEGER), {reviewedAt})"""
+
+  private def createUpdateTaskParams(
+      task: Task,
+      parent: Challenge,
+      geometries: String,
+      cooperativeWork: Option[String]
+  ): Seq[NamedParameter] = Seq(
+    NamedParameter("name", ToParameterValue.apply[String].apply(task.name)),
+    NamedParameter("parentId", ToParameterValue.apply[Long].apply(task.parent)),
+    NamedParameter(
+      "instruction",
+      ToParameterValue.apply[String].apply(task.instruction.getOrElse(""))
+    ),
+    NamedParameter("status", ToParameterValue.apply[Option[Int]].apply(task.status)),
+    NamedParameter("geojson", ToParameterValue.apply[String].apply(geometries)),
+    NamedParameter(
+      "cooperativeWorkJson",
+      ToParameterValue.apply[String].apply(cooperativeWork.orNull)
+    ),
+    NamedParameter("id", ToParameterValue.apply[Long].apply(task.id)),
+    NamedParameter("priority", ToParameterValue.apply[Int].apply(task.getTaskPriority(parent))),
+    NamedParameter(
+      "changesetId",
+      ToParameterValue.apply[Long].apply(task.changesetId.getOrElse(-1L))
+    ),
+    NamedParameter("reset", ToParameterValue.apply[String].apply(s"${config.taskReset} days")),
+    NamedParameter("mappedOn", ToParameterValue.apply[Option[DateTime]].apply(task.mappedOn)),
+    NamedParameter(
+      "reviewStatus",
+      ToParameterValue.apply[Option[Int]].apply(task.review.reviewStatus)
+    ),
+    NamedParameter(
+      "reviewRequestedBy",
+      ToParameterValue.apply[Option[Long]].apply(task.review.reviewRequestedBy)
+    ),
+    NamedParameter(
+      "reviewedBy",
+      ToParameterValue.apply[Option[Long]].apply(task.review.reviewedBy)
+    ),
+    NamedParameter(
+      "reviewedAt",
+      ToParameterValue.apply[Option[DateTime]].apply(task.review.reviewedAt)
+    )
+  )
+
   override def mergeUpdate(
       element: Task,
       user: User
@@ -342,67 +517,10 @@ class TaskDAL @Inject() (
         Some(cachedItem)
     }(id, true, true)
     this.withMRTransaction { implicit c =>
-      val result =
+      val (geometries, cooperativeWork) =
         extractCooperativeWork(element.parent, geoJson, element.cooperativeWork)
-      val geometries      = result._1
-      var cooperativeWork = result._2
-
-      val query =
-        """SELECT create_update_task({name}, {parentId}, {instruction},
-                    {status}, {geojson}::JSONB, {cooperativeWorkJson}::JSONB, {id}, {priority}, {changesetId},
-                    {reset}, {mappedOn}, {reviewStatus}, CAST({reviewRequestedBy} AS INTEGER),
-                    CAST({reviewedBy} AS INTEGER), {reviewedAt})"""
-      val updatedTaskId = SQL(query)
-        .on(
-          NamedParameter("name", ToParameterValue.apply[String].apply(element.name)),
-          NamedParameter("parentId", ToParameterValue.apply[Long].apply(element.parent)),
-          NamedParameter(
-            "instruction",
-            ToParameterValue.apply[String].apply(element.instruction.getOrElse(""))
-          ),
-          NamedParameter(
-            "status",
-            ToParameterValue.apply[Option[Int]].apply(element.status)
-          ),
-          NamedParameter("geojson", ToParameterValue.apply[String].apply(geometries)),
-          NamedParameter(
-            "cooperativeWorkJson",
-            ToParameterValue.apply[String].apply(cooperativeWork.orNull)
-          ),
-          NamedParameter("id", ToParameterValue.apply[Long].apply(element.id)),
-          NamedParameter(
-            "priority",
-            ToParameterValue.apply[Int].apply(element.getTaskPriority(parentChallenge))
-          ),
-          NamedParameter(
-            "changesetId",
-            ToParameterValue.apply[Long].apply(element.changesetId.getOrElse(-1L))
-          ),
-          NamedParameter(
-            "reset",
-            ToParameterValue.apply[String].apply(s"${config.taskReset} days")
-          ),
-          NamedParameter(
-            "mappedOn",
-            ToParameterValue.apply[Option[DateTime]].apply(element.mappedOn)
-          ),
-          NamedParameter(
-            "reviewStatus",
-            ToParameterValue.apply[Option[Int]].apply(element.review.reviewStatus)
-          ),
-          NamedParameter(
-            "reviewRequestedBy",
-            ToParameterValue.apply[Option[Long]].apply(element.review.reviewRequestedBy)
-          ),
-          NamedParameter(
-            "reviewedBy",
-            ToParameterValue.apply[Option[Long]].apply(element.review.reviewedBy)
-          ),
-          NamedParameter(
-            "reviewedAt",
-            ToParameterValue.apply[Option[DateTime]].apply(element.review.reviewedAt)
-          )
-        )
+      val updatedTaskId = SQL(createUpdateTaskQuery)
+        .on(createUpdateTaskParams(element, parentChallenge, geometries, cooperativeWork): _*)
         .as(long("create_update_task").*)
         .head
 

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -783,7 +783,12 @@ class ChallengeProvider @Inject() (
       geometry: JsObject,
       properties: JsValue
   ): Option[Task] = {
-    this._createNewTask(user, name, parent, buildTaskFromFeature(parent, name, geometry, properties))
+    this._createNewTask(
+      user,
+      name,
+      parent,
+      buildTaskFromFeature(parent, name, geometry, properties)
+    )
   }
 
   // Construct an in-memory Task for a single Feature without hitting the DB.

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -428,18 +428,31 @@ class ChallengeProvider @Inject() (
           )
         }
       } else {
-        val createdTasks = featureList.flatMap { value =>
-          if (!single) {
-            this.createNewTask(
-              user,
-              taskNameFromJsValue(value, parent),
+        val createdTasks = if (!single) {
+          val newTasks = featureList.map { value =>
+            buildTaskFromFeature(
               parent,
+              taskNameFromJsValue(value, parent),
               (value \ "geometry").as[JsObject],
               Utils.getProperties(value, "properties")
             )
-          } else {
-            None
           }
+          // Cooperative tasks need the per-task path so create_update_task /
+          // extractCooperativeWork can run their per-row side effects.
+          if (newTasks.exists(t => this.taskDAL.looksCooperative(t.geometries))) {
+            this.taskDAL.bulkMergeNewTasks(newTasks, user, parent)
+          } else {
+            val inserted = this.taskDAL.bulkInsertNewTasks(newTasks, user, parent)
+            // bulkInsertNewTasks writes every row at the challenge's defaultPriority
+            // (skipping the per-task rule evaluation create_update_task normally does),
+            // so priority rules/bounds need to be reapplied across the challenge now.
+            if (inserted.nonEmpty) {
+              this.challengeDAL.updateTaskPriorities(user)(parent.id)
+            }
+            inserted
+          }
+        } else {
+          List.empty
         }
 
         this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(parent.id)
@@ -770,28 +783,37 @@ class ChallengeProvider @Inject() (
       geometry: JsObject,
       properties: JsValue
   ): Option[Task] = {
-    val newTask = Task(
-      -1,
-      name,
-      DateTime.now(),
-      DateTime.now(),
-      parent.id,
-      Some(""),
-      None,
-      Json.obj(
-        "type" -> "FeatureCollection",
-        "features" -> Json.arr(
-          Json.obj(
-            "id"         -> name,
-            "type"       -> "Feature",
-            "geometry"   -> geometry,
-            "properties" -> properties
-          )
+    this._createNewTask(user, name, parent, buildTaskFromFeature(parent, name, geometry, properties))
+  }
+
+  // Construct an in-memory Task for a single Feature without hitting the DB.
+  // Used by the bulk-insert path so we can hand a whole batch of Tasks to
+  // taskDAL.bulkMergeNewTasks in one go.
+  private def buildTaskFromFeature(
+      parent: Challenge,
+      name: String,
+      geometry: JsObject,
+      properties: JsValue
+  ): Task = Task(
+    -1,
+    name,
+    DateTime.now(),
+    DateTime.now(),
+    parent.id,
+    Some(""),
+    None,
+    Json.obj(
+      "type" -> "FeatureCollection",
+      "features" -> Json.arr(
+        Json.obj(
+          "id"         -> name,
+          "type"       -> "Feature",
+          "geometry"   -> geometry,
+          "properties" -> properties
         )
       )
     )
-    this._createNewTask(user, name, parent, newTask)
-  }
+  )
 
   private def _createNewTask(
       user: User,

--- a/test/org/maproulette/models/dal/TaskDALSpec.scala
+++ b/test/org/maproulette/models/dal/TaskDALSpec.scala
@@ -5,6 +5,8 @@
 
 package org.maproulette.models.dal
 
+import org.joda.time.DateTime
+import org.maproulette.framework.model.Task
 import org.maproulette.framework.repository.TaskRepository
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
@@ -20,6 +22,69 @@ class TaskDALSpec extends PlaySpec with MockitoSugar {
       .obj("type" -> "Point", "coordinates" -> Json.arr(-111.8653810, 40.7123196)),
     "properties" -> Json.obj("name" -> "900 E @ 2709 S", "highway" -> "bus_stop")
   )
+
+  private def taskWithGeometries(name: String, geometries: play.api.libs.json.JsObject): Task =
+    Task(-1, name, DateTime.now(), DateTime.now(), 1, Some(""), None, geometries)
+
+  private val featureCollection =
+    Json.obj("type" -> "FeatureCollection", "features" -> Json.arr(busStopFeature))
+
+  "looksCooperative" should {
+    "return false for a plain FeatureCollection" in {
+      taskDAL.looksCooperative(featureCollection) mustEqual false
+    }
+
+    "return true when a feature has an embedded cooperativeWork object" in {
+      val cooperativeFeature = busStopFeature ++ Json.obj(
+        "cooperativeWork" -> Json.obj("meta" -> Json.obj())
+      )
+      val geometries =
+        Json.obj("type" -> "FeatureCollection", "features" -> Json.arr(cooperativeFeature))
+
+      taskDAL.looksCooperative(geometries) mustEqual true
+    }
+
+    "return true when a feature property has an embedded maproulette marker" in {
+      val cooperativeFeature = busStopFeature ++ Json.obj(
+        "properties" -> Json.obj(
+          "name"        -> "900 E @ 2709 S",
+          "maproulette" -> Json.obj("cooperativeWork" -> Json.obj("meta" -> Json.obj()))
+        )
+      )
+      val geometries =
+        Json.obj("type" -> "FeatureCollection", "features" -> Json.arr(cooperativeFeature))
+
+      taskDAL.looksCooperative(geometries) mustEqual true
+    }
+  }
+
+  "dedupeTasksByName" should {
+    "return all tasks unchanged when names are unique" in {
+      val tasks = List(
+        taskWithGeometries("first", featureCollection),
+        taskWithGeometries("second", featureCollection)
+      )
+
+      taskDAL.dedupeTasksByName(tasks) mustEqual tasks
+    }
+
+    "keep only the last task when names collide, case-insensitively" in {
+      val first  = taskWithGeometries("Duplicate", featureCollection)
+      val second = taskWithGeometries("duplicate", featureCollection)
+
+      taskDAL.dedupeTasksByName(List(first, second)) mustEqual List(second)
+    }
+
+    "preserve the position of the first occurrence" in {
+      val firstA  = taskWithGeometries("a", featureCollection)
+      val firstB  = taskWithGeometries("b", featureCollection)
+      val secondA = taskWithGeometries("a", featureCollection)
+
+      val result = taskDAL.dedupeTasksByName(List(firstA, firstB, secondA))
+
+      result mustEqual List(secondA, firstB)
+    }
+  }
 
   "pruneMapRouletteProperties" should {
     "handle a features array built with Json.arr" in {

--- a/test/org/maproulette/provider/ChallengeProviderSpec.scala
+++ b/test/org/maproulette/provider/ChallengeProviderSpec.scala
@@ -498,4 +498,66 @@ class ChallengeProviderSpec extends PlaySpec with MockitoSugar {
       verify(taskDAL, never()).mergeUpdate(any(), any())(any(), any())
     }
   }
+
+  private val plainFeatureGeojson =
+    """{"features":[{"id":"f1","geometry":{"type":"Point","coordinates":[1,2]},"properties":{}}]}"""
+
+  private val cooperativeFeatureGeojson =
+    """{"features":[{"id":"f1","geometry":{"type":"Point","coordinates":[1,2]},
+      |"properties":{"maproulette":"{\"cooperativeWork\":{\"meta\":{\"version\":2,\"type\":1}}}"}}]}""".stripMargin
+      .replaceAll("\n", "")
+
+  private def dummyTask(name: String): Task =
+    Task(
+      1,
+      name,
+      DateTime.now(),
+      DateTime.now(),
+      challengeWithoutOsmId.id,
+      Some(""),
+      None,
+      Json.obj("type" -> "FeatureCollection", "features" -> Json.arr())
+    )
+
+  private class TaskCreationFixture {
+    val challengeDAL: ChallengeDAL = mock[ChallengeDAL]
+    val taskDAL: TaskDAL           = mock[TaskDAL]
+    val provider =
+      new ChallengeProvider(challengeDAL, taskDAL, config, mock[WSClient], mock[Database])
+  }
+
+  "createTasksFromJson" should {
+    "reapply challenge priority rules after a non-cooperative bulk insert" in new TaskCreationFixture {
+      when(taskDAL.looksCooperative(any())).thenReturn(false)
+      when(taskDAL.bulkInsertNewTasks(any(), eqM(user), eqM(challengeWithoutOsmId))(any()))
+        .thenReturn(List(dummyTask("f1")))
+
+      provider.createTasksFromJson(user, challengeWithoutOsmId, plainFeatureGeojson)
+
+      verify(taskDAL).bulkInsertNewTasks(any(), eqM(user), eqM(challengeWithoutOsmId))(any())
+      verify(taskDAL, never()).bulkMergeNewTasks(any(), any(), any())(any())
+      verify(challengeDAL)
+        .updateTaskPriorities(eqM(user), any())(eqM(challengeWithoutOsmId.id), any())
+    }
+
+    "skip the priority recompute when the bulk insert creates no new tasks" in new TaskCreationFixture {
+      when(taskDAL.looksCooperative(any())).thenReturn(false)
+      when(taskDAL.bulkInsertNewTasks(any(), any(), any())(any())).thenReturn(List.empty)
+
+      provider.createTasksFromJson(user, challengeWithoutOsmId, plainFeatureGeojson)
+
+      verify(challengeDAL, never()).updateTaskPriorities(any(), any())(any(), any())
+    }
+
+    "route cooperative tasks through bulkMergeNewTasks and skip the priority recompute" in new TaskCreationFixture {
+      when(taskDAL.looksCooperative(any())).thenReturn(true)
+      when(taskDAL.bulkMergeNewTasks(any(), any(), any())(any())).thenReturn(List(dummyTask("f1")))
+
+      provider.createTasksFromJson(user, challengeWithoutOsmId, cooperativeFeatureGeojson)
+
+      verify(taskDAL).bulkMergeNewTasks(any(), eqM(user), eqM(challengeWithoutOsmId))(any())
+      verify(taskDAL, never()).bulkInsertNewTasks(any(), any(), any())(any())
+      verify(challengeDAL, never()).updateTaskPriorities(any(), any())(any(), any())
+    }
+  }
 }


### PR DESCRIPTION
- Introduced `bulkMergeNewTasks` and `bulkInsertNewTasks` methods in TaskDAL for efficient task insertion.
- Updated ChallengeProvider to use these methods for creating tasks based on feature lists, handling cooperative tasks appropriately.
- Refactored task creation logic to streamline the process and improve performance during bulk operations.