### PR TITLE
Fix GET /user/whoami endpoint to return decrypted API key

### DIFF
--- a/app/org/maproulette/framework/controller/UserController.scala
+++ b/app/org/maproulette/framework/controller/UserController.scala
@@ -67,7 +67,7 @@ class UserController @Inject() (
 
   def whoami(): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      Ok(Json.toJson(user))
+      Ok(Json.toJson(User.withDecryptedAPIKey(user)(crypto)))
     }
   }
 


### PR DESCRIPTION
Unlike the GET /user/:id endpoint, the whoami endpoint was incorrectly returning the AES encrypted API key (i.e. the raw value from the database). This meant trying to use the key that it returned would result in a 401 error which was confusing.

MapRoulette v3 does not run into this because the user settings page happens to use GET /user/:id, so it shows the correct (decrypted) API key. But the v4 prototype uses the whoami endpoint, so its user settings page was showing an encrypted (and thus useless) key, which is how I noticed the issue.

I have not tested this change but I'm reasonably confident in it (the line I changed is now identical to several other lines in various other code paths in the same file, which correctly decrypt the key)