### PR TITLE
Fix Swagger API docs to correctly describe types of embedded JSON values

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -133,46 +133,21 @@ class TaskController @Inject() (
     this.updateGeometryData(super.updateUpdateBody(body, user))
 
   private def updateGeometryData(body: JsValue): JsValue = {
-    val updatedBody = (body \ "geometries").asOpt[String] match {
-      case Some(value) =>
-        // if it is a string, then it is either GeoJSON or a WKB
-        // just check to see if { is the first character and then we can assume it is GeoJSON
-        if (value.charAt(0) != '{') {
-          // TODO:
-          body
-        } else {
-          // just return the body because it handles this case correctly
-          body
-        }
-      case None =>
-        // if it maps to None then it simply could be that it is a JSON object
-        (body \ "geometries").asOpt[JsValue] match {
-          case Some(value) =>
-            // need to convert to a string for the case class otherwise validation will fail
-            Utils.insertIntoJson(body, "geometries", value.toString(), true)
-          case None =>
-            // if the geometries are not supplied then just leave it
-            body
-        }
-    }
-    (updatedBody \ "location").asOpt[String] match {
-      case Some(value) => updatedBody
-      case None =>
-        (updatedBody \ "location").asOpt[JsValue] match {
-          case Some(value) =>
-            Utils.insertIntoJson(updatedBody, "location", value.toString(), true)
-          case None => updatedBody
-        }
-    }
-    (updatedBody \ "cooperativeWork").asOpt[String] match {
-      case Some(value) => updatedBody
-      case None =>
-        (updatedBody \ "cooperativeWork").asOpt[JsValue] match {
-          case Some(value) =>
-            Utils.insertIntoJson(updatedBody, "cooperativeWork", value.toString(), true)
-          case None => updatedBody
-        }
-    }
+    // Detect JsValues that are strings containing embedded JSON objects,
+    // and parse them to real JsValues instead. This is so that old clients
+    // which submit task geometries, location, etc as stringified JSON instead
+    // of proper nested objects still work.
+    def normalize(json: JsValue, key: String): JsValue =
+      (json \ key).toOption match {
+        case Some(JsString(value)) if value.nonEmpty && value.charAt(0) == '{' =>
+          Utils.insertIntoJson(json, key, Json.parse(value), true)
+        case _ => json
+      }
+
+    val withGeometries      = normalize(body, "geometries")
+    val withLocation        = normalize(withGeometries, "location")
+    val withCooperativeWork = normalize(withLocation, "cooperativeWork")
+    withCooperativeWork
   }
 
   /**

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -299,8 +299,7 @@ class TaskController @Inject() (
 
       val xml = task.cooperativeWork match {
         case Some(cw) =>
-          val cooperativeWork = Json.parse(cw)
-          (cooperativeWork \ "file" \ "content").asOpt[String] match {
+          (cw \ "file" \ "content").asOpt[String] match {
             case Some(base64EncodedXML) =>
               new String(java.util.Base64.getDecoder.decode(base64EncodedXML))
             case None => throw new NotFoundException(s"Task $taskId does not offer change XML.")
@@ -538,7 +537,7 @@ class TaskController @Inject() (
       if (request.getQueryString("mapillary").getOrElse("false").toBoolean) {
         // build the envelope for the task geometries
         val taskFeatureCollection =
-          GeoJSONFactory.create(obj.geometries).asInstanceOf[FeatureCollection]
+          GeoJSONFactory.create(Json.stringify(obj.geometries)).asInstanceOf[FeatureCollection]
         val reader   = new GeoJSONReader()
         val envelope = new Envelope()
         taskFeatureCollection.getFeatures.foreach(f => {

--- a/app/org/maproulette/exception/StatusMessage.scala
+++ b/app/org/maproulette/exception/StatusMessage.scala
@@ -14,6 +14,9 @@ trait StatusMessages {
   implicit val statusMessageReads  = StatusMessage.statusMessageReads
 }
 
+// TODO: `message` is JsValue because callers pass both JsString and JsObject.
+// We should fix this polymorphism so that we can make the Swagger type for it
+// stricter/more accurate.
 case class StatusMessage(status: String, message: JsValue)
 
 object StatusMessage {

--- a/app/org/maproulette/framework/graphql/schemas/MRSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/MRSchema.scala
@@ -75,3 +75,7 @@ case object DateTimeCoerceViolation extends Violation {
 case object ArrayLongCoerceViolation extends Violation {
   override def errorMessage: String = "Error during parsing Array[Long]"
 }
+
+case object JsonCoerceViolation extends Violation {
+  override def errorMessage: String = "Not valid JSON"
+}

--- a/app/org/maproulette/framework/graphql/schemas/MRSchemaTypes.scala
+++ b/app/org/maproulette/framework/graphql/schemas/MRSchemaTypes.scala
@@ -41,6 +41,28 @@ trait MRSchemaTypes {
     }
   )
 
+  // GraphQL doesn't have a native JSON type, so we expose embedded JSON
+  // fields as custom scalars. Scalar names were chosen to be compatible
+  // with https://www.npmjs.com/package/graphql-type-json
+  implicit val graphQLJsObject: ScalarType[JsObject] = ScalarType[JsObject](
+    "JSONObject",
+    coerceOutput = (value, _) => value,
+    coerceUserInput = {
+      case v: JsObject => Right(v)
+      case _           => Left(JsonCoerceViolation)
+    },
+    coerceInput = _ => Left(JsonCoerceViolation)
+  )
+  implicit val graphQLJsArray: ScalarType[JsArray] = ScalarType[JsArray](
+    "JSONArray",
+    coerceOutput = (value, _) => value,
+    coerceUserInput = {
+      case v: JsArray => Right(v)
+      case _          => Left(JsonCoerceViolation)
+    },
+    coerceInput = _ => Left(JsonCoerceViolation)
+  )
+
   implicit val CompletionMetricsType: ObjectType[Unit, CompletionMetrics] =
     deriveObjectType[Unit, CompletionMetrics](ObjectTypeName("CompletionMetrics"))
   // Project Types
@@ -106,14 +128,6 @@ trait MRSchemaTypes {
               userContext.services.follow.getUserFollowers(context.value.id, userContext.user).toSeq
             )
           }
-        )
-      ),
-      ReplaceField(
-        "properties",
-        Field(
-          "properties",
-          OptionType(StringType),
-          resolve = ctx => ctx.value.properties.map(Json.stringify)
         )
       )
     )
@@ -215,33 +229,7 @@ trait MRSchemaTypes {
     deriveObjectType[Unit, Comment](ObjectTypeName("Comment"))
   // Task Types
   implicit val TaskType: ObjectType[Unit, Task] =
-    deriveObjectType[Unit, Task](
-      ObjectTypeName("Task"),
-      ReplaceField(
-        "geometries",
-        Field(
-          "geometries",
-          StringType,
-          resolve = ctx => Json.stringify(ctx.value.geometries)
-        )
-      ),
-      ReplaceField(
-        "location",
-        Field(
-          "location",
-          OptionType(StringType),
-          resolve = ctx => ctx.value.location.map(Json.stringify)
-        )
-      ),
-      ReplaceField(
-        "cooperativeWork",
-        Field(
-          "cooperativeWork",
-          OptionType(StringType),
-          resolve = ctx => ctx.value.cooperativeWork.map(Json.stringify)
-        )
-      )
-    )
+    deriveObjectType[Unit, Task](ObjectTypeName("Task"))
   implicit val TaskReviewFieldsType: ObjectType[Unit, TaskReviewFields] =
     deriveObjectType[Unit, TaskReviewFields](ObjectTypeName("TaskReviewFields"))
   implicit val MapillaryImageType: ObjectType[Unit, MapillaryImage] =

--- a/app/org/maproulette/framework/graphql/schemas/MRSchemaTypes.scala
+++ b/app/org/maproulette/framework/graphql/schemas/MRSchemaTypes.scala
@@ -107,6 +107,14 @@ trait MRSchemaTypes {
             )
           }
         )
+      ),
+      ReplaceField(
+        "properties",
+        Field(
+          "properties",
+          OptionType(StringType),
+          resolve = ctx => ctx.value.properties.map(Json.stringify)
+        )
       )
     )
   implicit lazy val ActionItemType: ObjectType[Unit, ActionItem] =
@@ -207,7 +215,33 @@ trait MRSchemaTypes {
     deriveObjectType[Unit, Comment](ObjectTypeName("Comment"))
   // Task Types
   implicit val TaskType: ObjectType[Unit, Task] =
-    deriveObjectType[Unit, Task](ObjectTypeName("Task"))
+    deriveObjectType[Unit, Task](
+      ObjectTypeName("Task"),
+      ReplaceField(
+        "geometries",
+        Field(
+          "geometries",
+          StringType,
+          resolve = ctx => Json.stringify(ctx.value.geometries)
+        )
+      ),
+      ReplaceField(
+        "location",
+        Field(
+          "location",
+          OptionType(StringType),
+          resolve = ctx => ctx.value.location.map(Json.stringify)
+        )
+      ),
+      ReplaceField(
+        "cooperativeWork",
+        Field(
+          "cooperativeWork",
+          OptionType(StringType),
+          resolve = ctx => ctx.value.cooperativeWork.map(Json.stringify)
+        )
+      )
+    )
   implicit val TaskReviewFieldsType: ObjectType[Unit, TaskReviewFields] =
     deriveObjectType[Unit, TaskReviewFields](ObjectTypeName("TaskReviewFields"))
   implicit val MapillaryImageType: ObjectType[Unit, MapillaryImage] =

--- a/app/org/maproulette/framework/mixins/TaskJSONMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskJSONMixin.scala
@@ -129,8 +129,8 @@ trait TaskJSONMixin {
         }
 
         if (includeGeometries) {
-          val geometries = Json.parse(taskDetailsMap(task.id).geometries)
-          updated = Utils.insertIntoJson(updated, "geometries", geometries, true)
+          updated =
+            Utils.insertIntoJson(updated, "geometries", taskDetailsMap(task.id).geometries, true)
         }
 
         if (includeTags) {

--- a/app/org/maproulette/framework/mixins/TaskParserMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskParserMixin.scala
@@ -7,7 +7,7 @@ package org.maproulette.framework.mixins
 import anorm.SqlParser.get
 import anorm.{RowParser, ~}
 import org.joda.time.DateTime
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 
 import org.maproulette.framework.model.{TaskReview, TaskReviewFields, TaskWithReview, Task}
 
@@ -81,9 +81,9 @@ trait TaskParserMixin {
           modified,
           parent_id,
           instruction,
-          values._2.map(Json.parse),
-          Json.parse(values._1),
-          values._3.map(Json.parse),
+          values._2.map(Json.parse(_).as[JsObject]),
+          Json.parse(values._1).as[JsObject],
+          values._3.map(Json.parse(_).as[JsObject]),
           status,
           mappedOn,
           completedTimeSpent,
@@ -179,9 +179,9 @@ trait TaskParserMixin {
             modified,
             parent_id,
             instruction,
-            values._2.map(Json.parse),
-            Json.parse(values._1),
-            values._3.map(Json.parse),
+            values._2.map(Json.parse(_).as[JsObject]),
+            Json.parse(values._1).as[JsObject],
+            values._3.map(Json.parse(_).as[JsObject]),
             status,
             mappedOn,
             completedTimeSpent,

--- a/app/org/maproulette/framework/mixins/TaskParserMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskParserMixin.scala
@@ -7,6 +7,7 @@ package org.maproulette.framework.mixins
 import anorm.SqlParser.get
 import anorm.{RowParser, ~}
 import org.joda.time.DateTime
+import play.api.libs.json.Json
 
 import org.maproulette.framework.model.{TaskReview, TaskReviewFields, TaskWithReview, Task}
 
@@ -80,9 +81,9 @@ trait TaskParserMixin {
           modified,
           parent_id,
           instruction,
-          values._2,
-          values._1,
-          values._3,
+          values._2.map(Json.parse),
+          Json.parse(values._1),
+          values._3.map(Json.parse),
           status,
           mappedOn,
           completedTimeSpent,
@@ -178,9 +179,9 @@ trait TaskParserMixin {
             modified,
             parent_id,
             instruction,
-            values._2,
-            values._1,
-            values._3,
+            values._2.map(Json.parse),
+            Json.parse(values._1),
+            values._3.map(Json.parse),
             status,
             mappedOn,
             completedTimeSpent,

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -64,7 +64,7 @@ case class PriorityRule(operator: String, key: String, value: String, valueType:
   private def locationInBounds(
       operator: String,
       value: String,
-      location: Option[JsValue]
+      location: Option[JsObject]
   ): Boolean = {
     // eg. Some({"type":"Point","coordinates":[-120.18699365,48.47991855]})
     location match {
@@ -138,12 +138,12 @@ case class ChallengeExtra(
     taskBundleIdProperty: Option[String] = None,
     isArchived: Boolean = false,
     reviewSetting: Int = Challenge.REVIEW_SETTING_NOT_REQUIRED,
-    taskWidgetLayout: Option[JsValue] = None,
+    taskWidgetLayout: Option[JsObject] = None,
     datasetUrl: Option[String] = None,
     systemArchivedAt: Option[DateTime] = None,
     presets: Option[List[String]] = None,
     requireConfirmation: Boolean = false,
-    mrTagMetrics: Option[JsValue] = None
+    mrTagMetrics: Option[JsObject] = None
 ) extends DefaultWrites
 
 case class ChallengeListing(
@@ -191,12 +191,12 @@ case class BaseChallenge(
     overpassTargetType: Option[String] = None,
     // Fields from ChallengePriority
     defaultPriority: Int = Challenge.PRIORITY_HIGH,
-    highPriorityRule: Option[JsValue] = None,
-    mediumPriorityRule: Option[JsValue] = None,
-    lowPriorityRule: Option[JsValue] = None,
-    highPriorityBounds: Option[JsValue] = None,
-    mediumPriorityBounds: Option[JsValue] = None,
-    lowPriorityBounds: Option[JsValue] = None,
+    highPriorityRule: Option[JsObject] = None,
+    mediumPriorityRule: Option[JsObject] = None,
+    lowPriorityRule: Option[JsObject] = None,
+    highPriorityBounds: Option[JsArray] = None,
+    mediumPriorityBounds: Option[JsArray] = None,
+    lowPriorityBounds: Option[JsArray] = None,
     // Fields from ChallengeExtra
     defaultZoom: Int = Challenge.DEFAULT_ZOOM,
     minZoom: Int = Challenge.MIN_ZOOM,
@@ -212,15 +212,15 @@ case class BaseChallenge(
     exportableProperties: Option[String] = None,
     osmIdProperty: Option[String] = None,
     taskBundleIdProperty: Option[String] = None,
-    taskWidgetLayout: Option[JsValue] = None,
-    taskStyles: Option[JsValue] = None,
+    taskWidgetLayout: Option[JsObject] = None,
+    taskStyles: Option[JsArray] = None,
     // Status and location fields
     status: Option[Int] = Some(0),
     statusMessage: Option[String] = None,
     lastTaskRefresh: Option[DateTime] = None,
     dataOriginDate: Option[DateTime] = None,
-    location: Option[JsValue] = None,
-    bounding: Option[JsValue] = None,
+    location: Option[JsObject] = None,
+    bounding: Option[JsObject] = None,
     completionPercentage: Option[Int] = Some(0),
     completionMetrics: CompletionMetrics = CompletionMetrics()
 ) extends DefaultWrites

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -64,14 +64,14 @@ case class PriorityRule(operator: String, key: String, value: String, valueType:
   private def locationInBounds(
       operator: String,
       value: String,
-      location: Option[String]
+      location: Option[JsValue]
   ): Boolean = {
     // eg. Some({"type":"Point","coordinates":[-120.18699365,48.47991855]})
     location match {
       case Some(loc) =>
         // MinX,MinY,MaxX,MaxY
         val bbox: List[Double] = Utils.toDoubleList(value).getOrElse(List(0, 0, 0, 0))
-        val coordinates        = (Json.parse(loc) \ "coordinates").as[List[Double]]
+        val coordinates        = (loc \ "coordinates").as[List[Double]]
         if (coordinates.length == 2) {
           val x        = coordinates(0)
           val y        = coordinates(1)
@@ -328,8 +328,7 @@ case class Challenge(
 
           // Extract coordinates from task geometries
           try {
-            val geometries = Json.parse(task.geometries)
-            val features   = (geometries \ "features").as[List[JsValue]]
+            val features = (task.geometries \ "features").as[List[JsValue]]
             if (features.nonEmpty) {
               // Check if any feature is within bounds (important for ways/relations with multiple features)
               features.exists(feature => {

--- a/app/org/maproulette/framework/model/ClusteredPoint.scala
+++ b/app/org/maproulette/framework/model/ClusteredPoint.scala
@@ -5,7 +5,7 @@
 package org.maproulette.framework.model
 
 import org.joda.time.DateTime
-import play.api.libs.json.{JsValue, Json, Reads, Writes}
+import play.api.libs.json.{JsObject, Json, Reads, Writes}
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
 
@@ -56,7 +56,7 @@ case class ClusteredPoint(
     parentId: Long,
     parentName: String,
     point: Point,
-    bounding: JsValue,
+    bounding: JsObject,
     blurb: String,
     modified: DateTime,
     difficulty: Int,

--- a/app/org/maproulette/framework/model/Task.scala
+++ b/app/org/maproulette/framework/model/Task.scala
@@ -56,9 +56,9 @@ case class Task(
     override val modified: DateTime,
     parent: Long,
     instruction: Option[String] = None,
-    location: Option[JsValue] = None,
-    geometries: JsValue,
-    cooperativeWork: Option[JsValue] = None,
+    location: Option[JsObject] = None,
+    geometries: JsObject,
+    cooperativeWork: Option[JsObject] = None,
     status: Option[Int] = None,
     mappedOn: Option[DateTime] = None,
     completedTimeSpent: Option[Long] = None,
@@ -178,9 +178,9 @@ object Task extends CommonField {
       modified            <- (json \ "modified").validate[DateTime]
       parent              <- (json \ "parent").validate[Long]
       instruction         <- (json \ "instruction").validateOpt[String]
-      location            <- (json \ "location").validateOpt[JsValue]
-      geometries          <- (json \ "geometries").validate[JsValue]
-      cooperativeWork     <- (json \ "cooperativeWork").validateOpt[JsValue]
+      location            <- (json \ "location").validateOpt[JsObject]
+      geometries          <- (json \ "geometries").validate[JsObject]
+      cooperativeWork     <- (json \ "cooperativeWork").validateOpt[JsObject]
       status              <- (json \ "status").validateOpt[Int]
       mappedOn            <- (json \ "mappedOn").validateOpt[DateTime]
       completedTimeSpent  <- (json \ "completedTimeSpent").validateOpt[Long]

--- a/app/org/maproulette/framework/model/Task.scala
+++ b/app/org/maproulette/framework/model/Task.scala
@@ -4,7 +4,6 @@
  */
 package org.maproulette.framework.model
 
-import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import org.maproulette.data.{ItemType, TaskType}
 import org.maproulette.framework.model.{Challenge, Identifiable, MapillaryImage}
@@ -57,9 +56,9 @@ case class Task(
     override val modified: DateTime,
     parent: Long,
     instruction: Option[String] = None,
-    location: Option[String] = None,
-    geometries: String,
-    cooperativeWork: Option[String] = None,
+    location: Option[JsValue] = None,
+    geometries: JsValue,
+    cooperativeWork: Option[JsValue] = None,
     status: Option[Int] = None,
     mappedOn: Option[DateTime] = None,
     completedTimeSpent: Option[Long] = None,
@@ -112,13 +111,11 @@ case class Task(
   }
 
   def getGeometryProperties(): List[Map[String, String]] = {
-    if (StringUtils.isNotEmpty(this.geometries)) {
-      val geojson = Json.parse(this.geometries)
-      (geojson \ "features")
-        .as[List[JsValue]]
-        .map(json => Utils.getProperties(json, "properties").as[Map[String, String]])
-    } else {
-      List.empty
+    (this.geometries \ "features").asOpt[List[JsValue]] match {
+      case Some(features) =>
+        features.map(json => Utils.getProperties(json, "properties").as[Map[String, String]])
+      case None =>
+        List.empty
     }
   }
 }
@@ -181,9 +178,9 @@ object Task extends CommonField {
       modified            <- (json \ "modified").validate[DateTime]
       parent              <- (json \ "parent").validate[Long]
       instruction         <- (json \ "instruction").validateOpt[String]
-      location            <- (json \ "location").validateOpt[String]
-      geometries          <- (json \ "geometries").validate[String]
-      cooperativeWork     <- (json \ "cooperativeWork").validateOpt[String]
+      location            <- (json \ "location").validateOpt[JsValue]
+      geometries          <- (json \ "geometries").validate[JsValue]
+      cooperativeWork     <- (json \ "cooperativeWork").validateOpt[JsValue]
       status              <- (json \ "status").validateOpt[Int]
       mappedOn            <- (json \ "mappedOn").validateOpt[DateTime]
       completedTimeSpent  <- (json \ "completedTimeSpent").validateOpt[Long]
@@ -229,24 +226,12 @@ object Task extends CommonField {
       implicit val mapillaryWrites: Writes[MapillaryImage] = Json.writes[MapillaryImage]
       implicit val reviewWrites: Writes[TaskReviewFields]  = Json.writes[TaskReviewFields]
       implicit val taskWrites: Writes[Task]                = Writes(taskObjectWrites)
-      var original                                         = Json.toJson(o)(taskWrites)
-      var updatedLocation = o.location match {
-        case Some(l) => Utils.insertIntoJson(original, "location", Json.parse(l), true)
-        case None    => original
-      }
-
-      original = Utils.insertIntoJson(updatedLocation, "geometries", Json.parse(o.geometries), true)
-      var updated = o.cooperativeWork match {
-        case Some(cw) => Utils.insertIntoJson(original, "cooperativeWork", Json.parse(cw), true)
-        case None     => original
-      }
+      var updated                                          = Json.toJson(o)(taskWrites)
 
       // Move review fields up to top level
       updated = o.review.reviewStatus match {
-        case Some(r) => {
-          Utils.insertIntoJson(updated, "reviewStatus", r, true)
-        }
-        case None => updated
+        case Some(r) => Utils.insertIntoJson(updated, "reviewStatus", r, true)
+        case None    => updated
       }
       updated = o.review.reviewRequestedBy match {
         case Some(r) => Utils.insertIntoJson(updated, "reviewRequestedBy", r, true)
@@ -261,10 +246,8 @@ object Task extends CommonField {
         case None    => updated
       }
       updated = o.review.metaReviewStatus match {
-        case Some(r) => {
-          Utils.insertIntoJson(updated, "metaReviewStatus", r, true)
-        }
-        case None => updated
+        case Some(r) => Utils.insertIntoJson(updated, "metaReviewStatus", r, true)
+        case None    => updated
       }
       updated = o.review.metaReviewedBy match {
         case Some(r) => Utils.insertIntoJson(updated, "metaReviewedBy", r, true)
@@ -287,7 +270,7 @@ object Task extends CommonField {
         case None    => updated
       }
 
-      Utils.insertIntoJson(updated, "geometries", Json.parse(o.geometries), true)
+      updated
     }
 
     override def reads(json: JsValue): JsResult[Task] = {
@@ -485,5 +468,5 @@ object Task extends CommonField {
     }
 
   def emptyTask(parentId: Long): Task =
-    Task(-1, "", DateTime.now(), DateTime.now(), parentId, Some(""), None, "")
+    Task(-1, "", DateTime.now(), DateTime.now(), parentId, Some(""), None, Json.obj())
 }

--- a/app/org/maproulette/framework/model/TaskCluster.scala
+++ b/app/org/maproulette/framework/model/TaskCluster.scala
@@ -20,9 +20,9 @@ case class TaskCluster(
     taskPriority: Option[Int],
     params: SearchParameters,
     point: Point,
-    bounding: JsValue = Json.toJson("{}"),
+    bounding: JsObject = Json.obj(),
     challengeIds: List[Long],
-    geometries: Option[JsValue] = None
+    geometries: Option[JsObject] = None
 ) extends DefaultWrites
 
 object TaskCluster {

--- a/app/org/maproulette/framework/model/TaskClusterSummary.scala
+++ b/app/org/maproulette/framework/model/TaskClusterSummary.scala
@@ -23,7 +23,7 @@ case class TaskClusterSummary(
     taskId: Option[Long],
     taskStatus: Option[Int],
     point: Point,
-    bounding: JsValue = Json.toJson("{}")
+    bounding: JsObject = Json.obj()
 ) extends DefaultWrites
 
 object TaskClusterSummary {

--- a/app/org/maproulette/framework/model/User.scala
+++ b/app/org/maproulette/framework/model/User.scala
@@ -12,7 +12,7 @@ import org.joda.time.format.DateTimeFormat
 import org.maproulette.Config
 import org.maproulette.cache.CacheObject
 import org.maproulette.framework.psql.CommonField
-import org.maproulette.utils.{Crypto, Utils}
+import org.maproulette.utils.Crypto
 import org.maproulette.data._
 import org.slf4j.LoggerFactory
 import play.api.libs.json._
@@ -226,7 +226,7 @@ case class User(
     apiKey: Option[String] = None,
     guest: Boolean = false,
     settings: UserSettings = UserSettings(),
-    properties: Option[String] = None,
+    properties: Option[JsValue] = None,
     score: Option[Int] = None,
     followingGroupId: Option[Long] = None,
     followersGroupId: Option[Long] = None,
@@ -301,30 +301,9 @@ object User extends CommonField {
   val FIELD_NEEDS_REVIEW        = "needs_review"
   val FIELD_IS_REVIEWER         = "is_reviewer"
 
-  implicit object UserFormat extends Format[User] {
-    override def writes(o: User): JsValue = {
-      implicit val taskWrites: Writes[User] = Json.writes[User]
-      val original                          = Json.toJson(o)(Json.writes[User])
-      val updated = o.properties match {
-        case Some(p) => Utils.insertIntoJson(original, "properties", Json.parse(p), true)
-        case None    => original
-      }
-      Utils.insertIntoJson(updated, "properties", Json.parse(o.properties.getOrElse("{}")), true)
-    }
-
-    override def reads(json: JsValue): JsResult[User] = {
-      val modifiedJson: JsValue = (json \ "properties").toOption match {
-        case Some(p) =>
-          p match {
-            case props: JsString => json
-            case _ =>
-              json.as[JsObject] ++ Json.obj("properties" -> p.toString())
-          }
-        case None => json
-      }
-      Json.fromJson[User](modifiedJson)(Json.reads[User])
-    }
-  }
+  implicit val userWrites: Writes[User] = Json.writes[User]
+  implicit val userReads: Reads[User]   = Json.reads[User]
+  implicit val UserFormat: Format[User] = Format(userReads, userWrites)
 
   val DEFAULT_GUEST_USER_ID = -998
   val DEFAULT_SUPER_USER_ID = -999

--- a/app/org/maproulette/framework/model/User.scala
+++ b/app/org/maproulette/framework/model/User.scala
@@ -226,7 +226,7 @@ case class User(
     apiKey: Option[String] = None,
     guest: Boolean = false,
     settings: UserSettings = UserSettings(),
-    properties: Option[JsValue] = None,
+    properties: Option[JsObject] = None,
     score: Option[Int] = None,
     followingGroupId: Option[Long] = None,
     followersGroupId: Option[Long] = None,

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -16,7 +16,7 @@ import org.maproulette.framework.model._
 import org.maproulette.framework.psql.{GroupField, Grouping, OR, Query}
 import org.maproulette.framework.psql.filter._
 import play.api.db.Database
-import play.api.libs.json.JsValue
+import play.api.libs.json.{JsObject, JsValue}
 
 /**
   * The challenge repository handles all the querying with the databases related to challenge objects
@@ -351,7 +351,7 @@ object ChallengeRepository {
             taskBundleIdProperty,
             isArchived,
             reviewSetting,
-            taskWidgetLayout,
+            taskWidgetLayout.map(_.as[JsObject]),
             datasetUrl,
             systemArchivedAt
           ),

--- a/app/org/maproulette/framework/repository/ProjectRepository.scala
+++ b/app/org/maproulette/framework/repository/ProjectRepository.scala
@@ -20,7 +20,7 @@ import org.maproulette.framework.service.GrantService
 import org.maproulette.session.SearchParameters
 import org.maproulette.utils.Readers
 import play.api.db.Database
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 
 /**
   * Repository to handle all database actionns related to Projects, no business logic should be
@@ -364,7 +364,7 @@ object ProjectRepository extends Readers {
         val coordinates  = (locationJSON \ "coordinates").as[List[Double]]
         val point        = Point(coordinates(1), coordinates.head)
         val pointReview  = PointReview(None, None, None, None, None, None, None, None, None)
-        val boundingJSON = Json.parse(bounding)
+        val boundingJSON = Json.parse(bounding).as[JsObject]
         ClusteredPoint(
           id,
           osm_id,

--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -309,9 +309,9 @@ class TaskClusterRepository @Inject() (
             taskPriority,
             params,
             point,
-            Json.parse(bounding),
+            Json.parse(bounding).as[JsObject],
             challengeIds,
-            geojson.map(Json.parse(_))
+            geojson.map(Json.parse(_).as[JsObject])
           )
         } else {
           None
@@ -335,7 +335,7 @@ class TaskClusterRepository @Inject() (
             taskId,
             taskStatus,
             point,
-            Json.parse(bounding)
+            Json.parse(bounding).as[JsObject]
           )
         } else {
           None

--- a/app/org/maproulette/framework/repository/UserRepository.scala
+++ b/app/org/maproulette/framework/repository/UserRepository.scala
@@ -134,7 +134,7 @@ class UserRepository @Inject() (
           Symbol("isReviewer")               -> user.settings.isReviewer,
           Symbol("theme")                    -> user.settings.theme,
           Symbol("allowFollowing")           -> user.settings.allowFollowing,
-          Symbol("properties")               -> user.properties,
+          Symbol("properties")               -> user.properties.map(Json.stringify),
           Symbol("seeTagFixSuggestions")     -> user.settings.seeTagFixSuggestions,
           Symbol("disableTaskConfirm")       -> user.settings.disableTaskConfirm,
           Symbol("showPriorityMarkerColors") -> user.settings.showPriorityMarkerColors
@@ -577,7 +577,7 @@ object UserRepository {
             showPriorityMarkerColors,
             plugins.flatten
           ),
-          properties,
+          properties.map(Json.parse),
           score,
           followingGroupId,
           followersGroupId,

--- a/app/org/maproulette/framework/repository/UserRepository.scala
+++ b/app/org/maproulette/framework/repository/UserRepository.scala
@@ -17,7 +17,7 @@ import org.maproulette.framework.psql.{Query, SQLUtils}
 import org.maproulette.framework.service.{GrantService, ServiceManager}
 import org.maproulette.models.dal.ChallengeDAL
 import play.api.db.Database
-import play.api.libs.json.{JsResultException, Json}
+import play.api.libs.json.{JsObject, JsResultException, Json}
 
 import java.sql.Connection
 import javax.inject.{Inject, Singleton}
@@ -577,7 +577,7 @@ object UserRepository {
             showPriorityMarkerColors,
             plugins.flatten
           ),
-          properties.map(Json.parse),
+          properties.map(Json.parse(_).as[JsObject]),
           score,
           followingGroupId,
           followersGroupId,

--- a/app/org/maproulette/framework/service/UserService.scala
+++ b/app/org/maproulette/framework/service/UserService.scala
@@ -24,7 +24,7 @@ import org.maproulette.permissions.Permission
 import org.maproulette.session.SearchParameters
 import org.maproulette.utils.{Crypto, Utils, Writers}
 import org.slf4j.LoggerFactory
-import play.api.libs.json.{JsString, JsValue, Json}
+import play.api.libs.json.{JsValue, Json}
 
 /**
   * @author mcuthbert
@@ -388,7 +388,7 @@ class UserService @Inject() (
   ): Option[User] = {
     val updateBody = Utils.insertIntoJson(Json.parse("{}"), "settings", Json.toJson(settings))
     this.update(id, properties match {
-      case Some(p) => Utils.insertIntoJson(updateBody, "properties", JsString(p.toString()))
+      case Some(p) => Utils.insertIntoJson(updateBody, "properties", p)
       case None    => updateBody
     }, user)
   }
@@ -468,8 +468,8 @@ class UserService @Inject() (
       val theme = (value \ "settings" \ "theme")
         .asOpt[Int]
         .getOrElse(cachedItem.settings.theme.getOrElse(-1))
-      val properties =
-        (value \ "properties").asOpt[String].getOrElse(cachedItem.properties.getOrElse("{}"))
+      val properties: JsValue =
+        (value \ "properties").toOption.getOrElse(cachedItem.properties.getOrElse(Json.obj()))
 
       val customBasemaps = (value \ "settings" \ "customBasemaps").asOpt[List[CustomBasemap]]
       val plugins = (value \ "settings" \ "plugins")

--- a/app/org/maproulette/framework/service/UserService.scala
+++ b/app/org/maproulette/framework/service/UserService.scala
@@ -24,7 +24,7 @@ import org.maproulette.permissions.Permission
 import org.maproulette.session.SearchParameters
 import org.maproulette.utils.{Crypto, Utils, Writers}
 import org.slf4j.LoggerFactory
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsObject, JsValue, Json}
 
 /**
   * @author mcuthbert
@@ -468,8 +468,10 @@ class UserService @Inject() (
       val theme = (value \ "settings" \ "theme")
         .asOpt[Int]
         .getOrElse(cachedItem.settings.theme.getOrElse(-1))
-      val properties: JsValue =
-        (value \ "properties").toOption.getOrElse(cachedItem.properties.getOrElse(Json.obj()))
+      val properties: JsObject =
+        (value \ "properties")
+          .asOpt[JsObject]
+          .getOrElse(cachedItem.properties.getOrElse(Json.obj()))
 
       val customBasemaps = (value \ "settings" \ "customBasemaps").asOpt[List[CustomBasemap]]
       val plugins = (value \ "settings" \ "plugins")

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -30,7 +30,7 @@ import org.maproulette.utils.Utils
 import org.maproulette.framework.psql.SQLUtils
 import play.api.db.Database
 import play.api.libs.json.JodaReads._
-import play.api.libs.json.{JsString, JsValue, Json}
+import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
@@ -143,31 +143,6 @@ class ChallengeDAL @Inject() (
             limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~ dataOriginDate ~ location ~ bounding ~
             requiresLocal ~ deleted ~ isGlobal ~ isArchived ~ reviewSetting ~ datasetUrl ~ taskWidgetLayout ~
             completionPercentage ~ tasksRemaining ~ requireConfirmation ~ requireRejectReason ~ completionMetricsJson =>
-        val hpr = highPriorityRule match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
-          case r                                                                => r
-        }
-        val mpr = mediumPriorityRule match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
-          case r                                                                => r
-        }
-        val lpr = lowPriorityRule match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
-          case r                                                                => r
-        }
-        val hpb = highPriorityBounds match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "[]") => None
-          case r                                                                => r
-        }
-        val mpb = mediumPriorityBounds match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "[]") => None
-          case r                                                                => r
-        }
-        val lpb = lowPriorityBounds match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "[]") => None
-          case r                                                                => r
-        }
-
         new Challenge(
           id,
           name,
@@ -195,7 +170,15 @@ class ChallengeDAL @Inject() (
             requiresLocal
           ),
           ChallengeCreation(overpassql, remoteGeoJson, overpassTargetType),
-          ChallengePriority(defaultPriority, hpr, mpr, lpr, hpb, mpb, lpb),
+          ChallengePriority(
+            defaultPriority,
+            highPriorityRule,
+            mediumPriorityRule,
+            lowPriorityRule,
+            highPriorityBounds,
+            mediumPriorityBounds,
+            lowPriorityBounds
+          ),
           ChallengeExtra(
             defaultZoom,
             minZoom,
@@ -214,7 +197,7 @@ class ChallengeDAL @Inject() (
             taskBundleIdProperty,
             isArchived,
             reviewSetting,
-            taskWidgetLayout,
+            taskWidgetLayout.map(_.as[JsObject]),
             datasetUrl,
             None, // systemArchivedAt
             None, // presets
@@ -311,31 +294,6 @@ class ChallengeDAL @Inject() (
             dataOriginDate ~ location ~ bounding ~ requiresLocal ~ deleted ~ isGlobal ~ virtualParents ~
             presets ~ isArchived ~ reviewSetting ~ datasetUrl ~ taskWidgetLayout ~ systemArchivedAt ~ completionPercentage ~
             tasksRemaining ~ requireConfirmation ~ requireRejectReason ~ completionMetricsJson =>
-        val hpr = highPriorityRule match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
-          case r                                                                => r
-        }
-        val mpr = mediumPriorityRule match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
-          case r                                                                => r
-        }
-        val lpr = lowPriorityRule match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
-          case r                                                                => r
-        }
-        val hpb = highPriorityBounds match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "[]") => None
-          case r                                                                => r
-        }
-        val mpb = mediumPriorityBounds match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "[]") => None
-          case r                                                                => r
-        }
-        val lpb = lowPriorityBounds match {
-          case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "[]") => None
-          case r                                                                => r
-        }
-
         new Challenge(
           id,
           name,
@@ -363,7 +321,15 @@ class ChallengeDAL @Inject() (
             requiresLocal
           ),
           ChallengeCreation(overpassql, remoteGeoJson, overpassTargetType),
-          ChallengePriority(defaultPriority, hpr, mpr, lpr, hpb, mpb, lpb),
+          ChallengePriority(
+            defaultPriority,
+            highPriorityRule,
+            mediumPriorityRule,
+            lowPriorityRule,
+            highPriorityBounds,
+            mediumPriorityBounds,
+            lowPriorityBounds
+          ),
           ChallengeExtra(
             defaultZoom,
             minZoom,
@@ -382,7 +348,7 @@ class ChallengeDAL @Inject() (
             taskBundleIdProperty,
             isArchived,
             reviewSetting,
-            taskWidgetLayout,
+            taskWidgetLayout.map(_.as[JsObject]),
             datasetUrl,
             systemArchivedAt,
             presets,
@@ -469,26 +435,13 @@ class ChallengeDAL @Inject() (
             exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ taskWidgetLayout ~ taskStyles ~ status ~
             statusMessage ~ lastTaskRefresh ~ dataOriginDate ~ location ~ bounding ~ completionPercentage ~
             completionMetricsJson =>
-        // Parse JSON strings for priority rules and bounds
-        val hpr = highPriorityRule.flatMap(r =>
-          if (StringUtils.isEmpty(r) || StringUtils.equals(r, "{}")) None else Some(Json.parse(r))
-        )
-        val mpr = mediumPriorityRule.flatMap(r =>
-          if (StringUtils.isEmpty(r) || StringUtils.equals(r, "{}")) None else Some(Json.parse(r))
-        )
-        val lpr = lowPriorityRule.flatMap(r =>
-          if (StringUtils.isEmpty(r) || StringUtils.equals(r, "{}")) None else Some(Json.parse(r))
-        )
-        val hpb = highPriorityBounds.flatMap(b =>
-          if (StringUtils.isEmpty(b) || StringUtils.equals(b, "[]")) None else Some(Json.parse(b))
-        )
-        val mpb = mediumPriorityBounds.flatMap(b =>
-          if (StringUtils.isEmpty(b) || StringUtils.equals(b, "[]")) None else Some(Json.parse(b))
-        )
-        val lpb = lowPriorityBounds.flatMap(b =>
-          if (StringUtils.isEmpty(b) || StringUtils.equals(b, "[]")) None else Some(Json.parse(b))
-        )
-        val ts = taskStyles.flatMap(s => if (StringUtils.isEmpty(s)) None else Some(Json.parse(s)))
+        val hpr = highPriorityRule.map(Json.parse(_).as[JsObject])
+        val mpr = mediumPriorityRule.map(Json.parse(_).as[JsObject])
+        val lpr = lowPriorityRule.map(Json.parse(_).as[JsObject])
+        val hpb = highPriorityBounds.map(Json.parse(_).as[JsArray])
+        val mpb = mediumPriorityBounds.map(Json.parse(_).as[JsArray])
+        val lpb = lowPriorityBounds.map(Json.parse(_).as[JsArray])
+        val ts  = taskStyles.map(Json.parse(_).as[JsArray])
 
         new BaseChallenge(
           id,
@@ -537,14 +490,14 @@ class ChallengeDAL @Inject() (
           exportableProperties,
           osmIdProperty,
           taskBundleIdProperty,
-          taskWidgetLayout,
+          taskWidgetLayout.map(_.as[JsObject]),
           ts,
           status,
           statusMessage,
           lastTaskRefresh,
           dataOriginDate,
-          location.map(Json.parse),
-          bounding.map(Json.parse),
+          location.map(Json.parse(_).as[JsObject]),
+          bounding.map(Json.parse(_).as[JsObject]),
           completionPercentage,
           completionMetricsJson
             .flatMap(_.asOpt[CompletionMetrics])
@@ -630,7 +583,7 @@ class ChallengeDAL @Inject() (
           parentId,
           parentName.getOrElse(orParentName.get),
           point,
-          JsString(""),
+          Json.obj(),
           instruction,
           DateTime.now(),
           -1,
@@ -750,7 +703,7 @@ class ChallengeDAL @Inject() (
                       ${challenge.extra.preferredTags}, ${challenge.extra.preferredReviewTags}, ${challenge.extra.limitTags},
                       ${challenge.extra.limitReviewTags}, ${challenge.extra.taskStyles}, ${challenge.general.requiresLocal}, ${challenge.extra.isArchived},
                       ${challenge.extra.reviewSetting}, ${challenge.extra.datasetUrl}, ${challenge.requireConfirmation}, ${challenge.requireRejectReason},
-                      ${asJson(challenge.extra.taskWidgetLayout.getOrElse(Json.parse("{}")))}
+                      ${asJson(challenge.extra.taskWidgetLayout.getOrElse(Json.obj()))}
                       ) RETURNING #${this.retrieveColumns}"""
             .as(this.parser.*)
             .headOption
@@ -1003,8 +956,8 @@ class ChallengeDAL @Inject() (
             .getOrElse(cachedItem.requireRejectReason)
 
           val taskWidgetLayout = (updates \ "taskWidgetLayout")
-            .asOpt[JsValue]
-            .getOrElse(cachedItem.extra.taskWidgetLayout.getOrElse(Json.parse("{}")))
+            .asOpt[JsObject]
+            .getOrElse(cachedItem.extra.taskWidgetLayout.getOrElse(Json.obj()))
 
           val presets: List[String] = (updates \ "presets")
             .asOpt[List[String]]

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -678,6 +678,22 @@ class ChallengeDAL @Inject() (
       }
     }
 
+    // Normalize legacy encodings of 'no value ("" / "{}" / "[]") that some
+    // callers (e.g. the Java client) still send. Empty values are stored as
+    // NULL in the database.
+    def normalizeNullValues(value: Option[String], emptyMarker: String): Option[String] =
+      value match {
+        case Some(v) if StringUtils.isEmpty(v) || StringUtils.equals(v, emptyMarker) => None
+        case other                                                                   => other
+      }
+
+    val highPriorityRule     = normalizeNullValues(challenge.priority.highPriorityRule, "{}")
+    val mediumPriorityRule   = normalizeNullValues(challenge.priority.mediumPriorityRule, "{}")
+    val lowPriorityRule      = normalizeNullValues(challenge.priority.lowPriorityRule, "{}")
+    val highPriorityBounds   = normalizeNullValues(challenge.priority.highPriorityBounds, "[]")
+    val mediumPriorityBounds = normalizeNullValues(challenge.priority.mediumPriorityBounds, "[]")
+    val lowPriorityBounds    = normalizeNullValues(challenge.priority.lowPriorityBounds, "[]")
+
     this.cacheManager.withOptionCaching { () =>
       val insertedChallenge =
         this.withMRTransaction { implicit c =>
@@ -689,13 +705,13 @@ class ChallengeDAL @Inject() (
                                       osm_id_property, task_bundle_id_property, last_task_refresh, data_origin_date, preferred_tags, preferred_review_tags,
                                       limit_tags, limit_review_tags, task_styles, requires_local, is_archived, review_setting, dataset_url, require_confirmation, require_reject_reason, task_widget_layout)
               VALUES (${challenge.name}, ${challenge.general.owner}, ${challenge.general.parent},
-                      ${challenge.general.difficulty}, 
+                      ${challenge.general.difficulty},
                       ${challenge.description}, ${challenge.infoLink}, ${challenge.general.blurb}, ${challenge.general.instruction},
                       ${challenge.general.enabled}, ${challenge.general.featured},
                       ${challenge.general.checkinComment}, ${challenge.general.checkinSource}, ${challenge.creation.overpassQL}, ${challenge.creation.remoteGeoJson},
                       ${challenge.creation.overpassTargetType}, ${challenge.status},
-                      ${challenge.statusMessage}, ${challenge.priority.defaultPriority}, ${challenge.priority.highPriorityRule},
-                      ${challenge.priority.mediumPriorityRule}, ${challenge.priority.lowPriorityRule}, ${challenge.priority.highPriorityBounds}, ${challenge.priority.mediumPriorityBounds}, ${challenge.priority.lowPriorityBounds}, ${challenge.extra.defaultZoom}, ${challenge.extra.minZoom},
+                      ${challenge.statusMessage}, ${challenge.priority.defaultPriority}, ${highPriorityRule},
+                      ${mediumPriorityRule}, ${lowPriorityRule}, ${highPriorityBounds}, ${mediumPriorityBounds}, ${lowPriorityBounds}, ${challenge.extra.defaultZoom}, ${challenge.extra.minZoom},
                       ${challenge.extra.maxZoom}, ${challenge.extra.defaultBasemap}, ${challenge.extra.defaultBasemapId}, ${challenge.extra.customBasemap}, ${challenge.extra.updateTasks},
                       ${challenge.extra.exportableProperties}, ${challenge.extra.osmIdProperty}, ${challenge.extra.taskBundleIdProperty},
                       ${challenge.lastTaskRefresh.getOrElse(DateTime.now()).toString}::timestamptz,

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -196,10 +196,10 @@ class TaskDAL @Inject() (
         )
       }
       val priority = (value \ "priority").asOpt[Int].getOrElse(cachedItem.priority)
-      val geometries: JsValue =
-        (value \ "geometries").toOption.getOrElse(cachedItem.geometries)
-      val cooperativeWork: Option[JsValue] =
-        (value \ "cooperativeWork").toOption.filter(_ != JsNull)
+      val geometries: JsObject =
+        (value \ "geometries").asOpt[JsObject].getOrElse(cachedItem.geometries)
+      val cooperativeWork: Option[JsObject] =
+        (value \ "cooperativeWork").asOpt[JsObject]
       val changesetId =
         (value \ "changesetId").asOpt[Long].getOrElse(cachedItem.changesetId.getOrElse(-1L))
 
@@ -432,20 +432,19 @@ class TaskDAL @Inject() (
     */
   private def extractCooperativeWork(
       parentId: Long,
-      geometries: JsValue,
-      cooperativeWork: Option[JsValue]
+      geometries: JsObject,
+      cooperativeWork: Option[JsObject]
   )(
       implicit c: Option[Connection] = None
   ): (String, Option[String]) = {
     this.withMRTransaction { implicit c =>
       var cooperativeWorkJson: Option[String] = cooperativeWork.map(Json.stringify)
 
-      val geoJson   = geometries
-      var workMatch = (geoJson \\ "cooperativeWork")
+      var workMatch = (geometries \\ "cooperativeWork")
       if (workMatch.isEmpty) {
         // Check to see if our cooperative work JSON was changed into a string due
         // to being a feature property (which are always converted to strings)
-        val parentMatch = (geoJson \\ "maproulette")
+        val parentMatch = (geometries \\ "maproulette")
         if (!parentMatch.isEmpty) {
           workMatch = (Json.parse(Utils.unescapeStringifiedJSON(parentMatch.head.toString())) \\ "cooperativeWork")
         }
@@ -455,10 +454,10 @@ class TaskDAL @Inject() (
         cooperativeWorkJson = Some(workMatch.head.toString())
       }
 
-      val attachments   = (geoJson \ "attachments").toOption
+      val attachments   = (geometries \ "attachments").toOption
       val mrTransformer = (__ \ "properties" \ "maproulette").json.prune
       val extractedGeometries = JsArray(
-        (geoJson \ "features")
+        (geometries \ "features")
           .as[JsArray]
           .value
           .map {

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -11,7 +11,6 @@ import anorm.JodaParameterMetaData._
 import anorm.SqlParser._
 import anorm._
 import javax.inject.{Inject, Provider, Singleton}
-import org.apache.commons.lang3.StringUtils
 import org.joda.time.{DateTime, DateTimeZone}
 import org.locationtech.jts.geom.Envelope
 import org.maproulette.Config
@@ -196,9 +195,11 @@ class TaskDAL @Inject() (
             s"progression from ${cachedItem.status.getOrElse(0)} to $status not valid."
         )
       }
-      val priority                  = (value \ "priority").asOpt[Int].getOrElse(cachedItem.priority)
-      val geometries                = (value \ "geometries").asOpt[String].getOrElse(cachedItem.geometries)
-      val cooperativeWorkGeometries = (value \ "cooperativeWork").asOpt[String].getOrElse("")
+      val priority = (value \ "priority").asOpt[Int].getOrElse(cachedItem.priority)
+      val geometries: JsValue =
+        (value \ "geometries").toOption.getOrElse(cachedItem.geometries)
+      val cooperativeWork: Option[JsValue] =
+        (value \ "cooperativeWork").toOption.filter(_ != JsNull)
       val changesetId =
         (value \ "changesetId").asOpt[Long].getOrElse(cachedItem.changesetId.getOrElse(-1L))
 
@@ -241,11 +242,7 @@ class TaskDAL @Inject() (
             reviewedAt = reviewedAt
           ),
           geometries = geometries,
-          cooperativeWork = if (StringUtils.isEmpty(cooperativeWorkGeometries)) {
-            None
-          } else {
-            Some(cooperativeWorkGeometries)
-          },
+          cooperativeWork = cooperativeWork,
           priority = priority,
           changesetId = Some(changesetId)
         ),
@@ -435,15 +432,15 @@ class TaskDAL @Inject() (
     */
   private def extractCooperativeWork(
       parentId: Long,
-      geometries: String,
-      cooperativeWork: Option[String]
+      geometries: JsValue,
+      cooperativeWork: Option[JsValue]
   )(
       implicit c: Option[Connection] = None
   ): (String, Option[String]) = {
     this.withMRTransaction { implicit c =>
-      var cooperativeWorkJson = cooperativeWork
+      var cooperativeWorkJson: Option[String] = cooperativeWork.map(Json.stringify)
 
-      val geoJson   = Json.parse(geometries)
+      val geoJson   = geometries
       var workMatch = (geoJson \\ "cooperativeWork")
       if (workMatch.isEmpty) {
         // Check to see if our cooperative work JSON was changed into a string due
@@ -897,7 +894,9 @@ class TaskDAL @Inject() (
                       true
                     } else {
                       val feature =
-                        GeoJSONFactory.create(task.geometries).asInstanceOf[FeatureCollection]
+                        GeoJSONFactory
+                          .create(Json.stringify(task.geometries))
+                          .asInstanceOf[FeatureCollection]
                       val reader   = new GeoJSONReader()
                       val envelope = new Envelope()
                       feature.getFeatures.foreach(f => {

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -22,7 +22,7 @@ import org.maproulette.permissions.Permission
 import org.maproulette.session.{SearchLocation, SearchParameters}
 import play.api.db.Database
 import play.api.libs.json.JodaReads._
-import play.api.libs.json.{JsString, JsValue, Json}
+import play.api.libs.json.{JsValue, Json}
 
 import org.maproulette.framework.mixins.Locking
 import org.maproulette.framework.repository.RepositoryMixin
@@ -562,7 +562,7 @@ class VirtualChallengeDAL @Inject() (
             -1,
             "",
             point,
-            JsString(""),
+            Json.obj(),
             instruction,
             DateTime.now(),
             -1,

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -169,13 +169,13 @@ trait ChallengeReads extends DefaultReads {
             reviewSetting = (jsonWithExtras \ "reviewSetting")
               .asOpt[Int]
               .getOrElse(Challenge.REVIEW_SETTING_NOT_REQUIRED),
-            taskWidgetLayout = (jsonWithExtras \ "taskWidgetLayout").asOpt[JsValue],
+            taskWidgetLayout = (jsonWithExtras \ "taskWidgetLayout").asOpt[JsObject],
             datasetUrl = (jsonWithExtras \ "datasetUrl").asOpt[String],
             systemArchivedAt = (jsonWithExtras \ "systemArchivedAt").asOpt[DateTime],
             presets = (jsonWithExtras \ "presets").asOpt[List[String]],
             requireConfirmation =
               (jsonWithExtras \ "requireConfirmation").asOpt[Boolean].getOrElse(false),
-            mrTagMetrics = (jsonWithExtras \ "mrTagMetrics").asOpt[JsValue]
+            mrTagMetrics = (jsonWithExtras \ "mrTagMetrics").asOpt[JsObject]
           )
         )
       } catch {

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -756,7 +756,7 @@ class ChallengeProvider @Inject() (
       user,
       name,
       parent,
-      Task(-1, name, DateTime.now(), DateTime.now(), parent.id, Some(""), None, json)
+      Task(-1, name, DateTime.now(), DateTime.now(), parent.id, Some(""), None, json.as[JsObject])
     )
   }
 

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -756,7 +756,7 @@ class ChallengeProvider @Inject() (
       user,
       name,
       parent,
-      Task(-1, name, DateTime.now(), DateTime.now(), parent.id, Some(""), None, json.toString)
+      Task(-1, name, DateTime.now(), DateTime.now(), parent.id, Some(""), None, json)
     )
   }
 
@@ -775,19 +775,17 @@ class ChallengeProvider @Inject() (
       parent.id,
       Some(""),
       None,
-      Json
-        .obj(
-          "type" -> "FeatureCollection",
-          "features" -> Json.arr(
-            Json.obj(
-              "id"         -> name,
-              "type"       -> "Feature",
-              "geometry"   -> geometry,
-              "properties" -> properties
-            )
+      Json.obj(
+        "type" -> "FeatureCollection",
+        "features" -> Json.arr(
+          Json.obj(
+            "id"         -> name,
+            "type"       -> "Feature",
+            "geometry"   -> geometry,
+            "properties" -> properties
           )
         )
-        .toString
+      )
     )
     this._createNewTask(user, name, parent, newTask)
   }

--- a/app/org/maproulette/provider/KeepRightProvider.scala
+++ b/app/org/maproulette/provider/KeepRightProvider.scala
@@ -18,7 +18,7 @@ import org.maproulette.utils.Utils
 import org.slf4j.LoggerFactory
 import play.api.db.Database
 import play.api.http.Status
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.duration.Duration
@@ -178,7 +178,7 @@ class KeepRightProvider @Inject() (
                   this.withMRTransaction {
                     implicit c =>
                       val totalTasks = errors._2.map(kpError => {
-                        val geometry: JsValue = Json.obj(
+                        val geometry: JsObject = Json.obj(
                           "type" -> "FeatureCollection",
                           "features" -> Json.arr(
                             Json.obj(

--- a/app/org/maproulette/provider/KeepRightProvider.scala
+++ b/app/org/maproulette/provider/KeepRightProvider.scala
@@ -18,6 +18,7 @@ import org.maproulette.utils.Utils
 import org.slf4j.LoggerFactory
 import play.api.db.Database
 import play.api.http.Status
+import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.duration.Duration
@@ -177,16 +178,19 @@ class KeepRightProvider @Inject() (
                   this.withMRTransaction {
                     implicit c =>
                       val totalTasks = errors._2.map(kpError => {
-                        val geometry =
-                          s"""
-                    {"type":"FeatureCollection",
-                      "features":[{
-                        "geometry":{"type":"Point","coordinates":[${kpError.lat}, ${kpError.lon}]},
-                        "type":"Feature",
-                        "properties":{}
-                      }]
-                    }
-                  """
+                        val geometry: JsValue = Json.obj(
+                          "type" -> "FeatureCollection",
+                          "features" -> Json.arr(
+                            Json.obj(
+                              "geometry" -> Json.obj(
+                                "type"        -> "Point",
+                                "coordinates" -> Json.arr(kpError.lat, kpError.lon)
+                              ),
+                              "type"       -> "Feature",
+                              "properties" -> Json.obj()
+                            )
+                          )
+                        )
                         this.taskDAL.mergeUpdate(
                           Task(
                             -1,

--- a/conf/evolutions/default/114.sql
+++ b/conf/evolutions/default/114.sql
@@ -1,0 +1,25 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Normalize legacy no-value sentinel strings in challenge JSON columns to SQL
+-- NULL (or the column default for NOT NULL columns). This lets us simplify
+-- the read path in the code since we don't need to check for these values.
+
+UPDATE challenges
+SET task_widget_layout = '{}'::jsonb
+WHERE jsonb_typeof(task_widget_layout) = 'string'
+  AND task_widget_layout::text = '""';;
+
+UPDATE challenges SET task_styles = NULL
+WHERE task_styles IN ('', '[]', 'null');;
+
+UPDATE challenges SET high_priority_rule   = NULL WHERE high_priority_rule   IN ('', '{}');;
+UPDATE challenges SET medium_priority_rule = NULL WHERE medium_priority_rule IN ('', '{}');;
+UPDATE challenges SET low_priority_rule    = NULL WHERE low_priority_rule    IN ('', '{}');;
+
+UPDATE challenges SET high_priority_bounds   = NULL WHERE high_priority_bounds   IN ('', '[]');;
+UPDATE challenges SET medium_priority_bounds = NULL WHERE medium_priority_bounds IN ('', '[]');;
+UPDATE challenges SET low_priority_bounds    = NULL WHERE low_priority_bounds    IN ('', '[]');;
+
+# --- !Downs
+SELECT 1;;

--- a/conf/swagger-custom-mappings.yml
+++ b/conf/swagger-custom-mappings.yml
@@ -2,12 +2,10 @@
   - type: play\.api\.libs\.json\.jsvalue
     specAsParameter: []
     specAsProperty:
-      type: string
+      type: object
+      additionalProperties: true
   - type: play\.api\.libs\.json\.jsobject
     specAsParameter: []
     specAsProperty:
       type: object
-  - type: play\.api\.libs\.oauth\.requesttoken
-    specAsParameter: []
-    specAsProperty:
-      type: object
+      additionalProperties: true

--- a/conf/swagger-custom-mappings.yml
+++ b/conf/swagger-custom-mappings.yml
@@ -1,11 +1,20 @@
 ---
-  - type: play\.api\.libs\.json\.jsvalue
-    specAsParameter: []
-    specAsProperty:
-      type: object
-      additionalProperties: true
   - type: play\.api\.libs\.json\.jsobject
     specAsParameter: []
     specAsProperty:
       type: object
       additionalProperties: true
+  - type: play\.api\.libs\.json\.jsarray
+    specAsParameter: []
+    specAsProperty:
+      type: array
+      items: {}
+  # Type generic JS values as 'any'. Client libraries will treat this
+  # broadly (e.g. openapi-typescript will convert this to 'unknown'),
+  # so consumers are forced to narrow the type manually when they use
+  # it. Since the ergonomics of this aren't great, you should use a
+  # more specific type (like JsObject or JsArray) over JsValue when
+  # possible.
+  - type: play\.api\.libs\.json\.jsvalue
+    specAsParameter: []
+    specAsProperty: {}

--- a/test/org/maproulette/framework/repository/TaskRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/TaskRepositorySpec.scala
@@ -10,7 +10,7 @@ import java.util.UUID
 import org.maproulette.framework.model.{User, Task}
 import org.maproulette.framework.util.{TaskTag, FrameworkHelper}
 import play.api.Application
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 
 /**
   * @author nrotstan
@@ -46,8 +46,10 @@ class TaskRepositorySpec(implicit val application: Application) extends Framewor
       null,
       null,
       this.defaultChallenge.id,
-      geometries = Json.parse(
-        """{"features":[{"type":"Feature","geometry":{"type":"LineString","coordinates":[[-60.811801,-32.9199812],[-60.8117804,-32.9199856],[-60.8117816,-32.9199896],[-60.8117873,-32.919984]]},"properties":{"osm_id":"OSM_W_378169283_000000_000","pbfHistory":["20200110-043000"]}}], "attachments": [{"id": "74bc872f-8448-45ff-b8f2-66517a35b41e", "kind": "referenceLayer", "type": "geojson", "name": "geojson boundary", "data": {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[-121.0, 48.0],[-120.0, 48.0],[-120.0, 49.0],[-121.0, 49],[-121.0, 48.0]]]}}}]}"""
-      )
+      geometries = Json
+        .parse(
+          """{"features":[{"type":"Feature","geometry":{"type":"LineString","coordinates":[[-60.811801,-32.9199812],[-60.8117804,-32.9199856],[-60.8117816,-32.9199896],[-60.8117873,-32.919984]]},"properties":{"osm_id":"OSM_W_378169283_000000_000","pbfHistory":["20200110-043000"]}}], "attachments": [{"id": "74bc872f-8448-45ff-b8f2-66517a35b41e", "kind": "referenceLayer", "type": "geojson", "name": "geojson boundary", "data": {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[-121.0, 48.0],[-120.0, 48.0],[-120.0, 49.0],[-121.0, 49],[-121.0, 48.0]]]}}}]}"""
+        )
+        .as[JsObject]
     )
 }

--- a/test/org/maproulette/framework/repository/TaskRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/TaskRepositorySpec.scala
@@ -10,6 +10,7 @@ import java.util.UUID
 import org.maproulette.framework.model.{User, Task}
 import org.maproulette.framework.util.{TaskTag, FrameworkHelper}
 import play.api.Application
+import play.api.libs.json.Json
 
 /**
   * @author nrotstan
@@ -45,7 +46,8 @@ class TaskRepositorySpec(implicit val application: Application) extends Framewor
       null,
       null,
       this.defaultChallenge.id,
-      geometries =
+      geometries = Json.parse(
         """{"features":[{"type":"Feature","geometry":{"type":"LineString","coordinates":[[-60.811801,-32.9199812],[-60.8117804,-32.9199856],[-60.8117816,-32.9199896],[-60.8117873,-32.919984]]},"properties":{"osm_id":"OSM_W_378169283_000000_000","pbfHistory":["20200110-043000"]}}], "attachments": [{"id": "74bc872f-8448-45ff-b8f2-66517a35b41e", "kind": "referenceLayer", "type": "geojson", "name": "geojson boundary", "data": {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[-121.0, 48.0],[-120.0, 48.0],[-120.0, 49.0],[-121.0, 49],[-121.0, 48.0]]]}}}]}"""
+      )
     )
 }

--- a/test/org/maproulette/framework/util/FrameworkHelper.scala
+++ b/test/org/maproulette/framework/util/FrameworkHelper.scala
@@ -16,7 +16,7 @@ import org.scalatest.{BeforeAndAfterAll, Tag}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.Application
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 
 import org.maproulette.data.SnapshotManager
 
@@ -117,9 +117,11 @@ trait FrameworkHelper extends PlaySpec with BeforeAndAfterAll with MockitoSugar 
       null,
       null,
       parentId,
-      geometries = Json.parse(
-        "{\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[-60.811801,-32.9199812],[-60.8117804,-32.9199856],[-60.8117816,-32.9199896],[-60.8117873,-32.919984]]},\"properties\":{\"osm_id\":\"OSM_W_378169283_000000_000\",\"pbfHistory\":[\"20200110-043000\"]}}]}"
-      ),
+      geometries = Json
+        .parse(
+          "{\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[-60.811801,-32.9199812],[-60.8117804,-32.9199856],[-60.8117816,-32.9199896],[-60.8117873,-32.919984]]},\"properties\":{\"osm_id\":\"OSM_W_378169283_000000_000\",\"pbfHistory\":[\"20200110-043000\"]}}]}"
+        )
+        .as[JsObject],
       status = Some(0)
     )
   }

--- a/test/org/maproulette/framework/util/FrameworkHelper.scala
+++ b/test/org/maproulette/framework/util/FrameworkHelper.scala
@@ -16,6 +16,7 @@ import org.scalatest.{BeforeAndAfterAll, Tag}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.Application
+import play.api.libs.json.Json
 
 import org.maproulette.data.SnapshotManager
 
@@ -116,8 +117,9 @@ trait FrameworkHelper extends PlaySpec with BeforeAndAfterAll with MockitoSugar 
       null,
       null,
       parentId,
-      geometries =
-        "{\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[-60.811801,-32.9199812],[-60.8117804,-32.9199856],[-60.8117816,-32.9199896],[-60.8117873,-32.919984]]},\"properties\":{\"osm_id\":\"OSM_W_378169283_000000_000\",\"pbfHistory\":[\"20200110-043000\"]}}]}",
+      geometries = Json.parse(
+        "{\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[-60.811801,-32.9199812],[-60.8117804,-32.9199856],[-60.8117816,-32.9199896],[-60.8117873,-32.919984]]},\"properties\":{\"osm_id\":\"OSM_W_378169283_000000_000\",\"pbfHistory\":[\"20200110-043000\"]}}]}"
+      ),
       status = Some(0)
     )
   }

--- a/test/org/maproulette/models/ChallengeSpec.scala
+++ b/test/org/maproulette/models/ChallengeSpec.scala
@@ -8,6 +8,7 @@ package org.maproulette.models
 import org.maproulette.framework.model.{PriorityRule, Task}
 import org.scalatestplus.play.PlaySpec
 import org.joda.time.DateTime
+import play.api.libs.json.Json
 
 /**
   * @author cuthbertm
@@ -58,9 +59,9 @@ class ChallengeSpec() extends PlaySpec {
     }
 
     "bounds type should operate correctly" in {
-      val location = Some("{\"type\":\"Point\",\"coordinates\":[-120,50]}")
+      val location = Some(Json.parse("{\"type\":\"Point\",\"coordinates\":[-120,50]}"))
 
-      val task = Task(1, "Task1", DateTime.now(), DateTime.now(), 1, None, location, "")
+      val task = Task(1, "Task1", DateTime.now(), DateTime.now(), 1, None, location, Json.obj())
 
       // format like: bounds = "MinX,MinY,MaxX,MaxY"
       PriorityRule("contains", "location", "0,0,1,1", "bounds")

--- a/test/org/maproulette/models/ChallengeSpec.scala
+++ b/test/org/maproulette/models/ChallengeSpec.scala
@@ -8,7 +8,7 @@ package org.maproulette.models
 import org.maproulette.framework.model.{PriorityRule, Task}
 import org.scalatestplus.play.PlaySpec
 import org.joda.time.DateTime
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 
 /**
   * @author cuthbertm
@@ -59,7 +59,7 @@ class ChallengeSpec() extends PlaySpec {
     }
 
     "bounds type should operate correctly" in {
-      val location = Some(Json.parse("{\"type\":\"Point\",\"coordinates\":[-120,50]}"))
+      val location = Json.parse("{\"type\":\"Point\",\"coordinates\":[-120,50]}").asOpt[JsObject]
 
       val task = Task(1, "Task1", DateTime.now(), DateTime.now(), 1, None, location, Json.obj())
 

--- a/test/org/maproulette/utils/TestSpec.scala
+++ b/test/org/maproulette/utils/TestSpec.scala
@@ -21,6 +21,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.Configuration
 import play.api.db.Databases
+import play.api.libs.json.Json
 
 /**
   * @author mcuthbert
@@ -90,7 +91,7 @@ trait TestSpec extends PlaySpec with MockitoSugar {
     )
 
   //tasks
-  val task1               = Task(1, "Task1", DateTime.now(), DateTime.now(), 1, None, None, "")
+  val task1               = Task(1, "Task1", DateTime.now(), DateTime.now(), 1, None, None, Json.obj())
   val taskDAL             = mock[TaskDAL]
   val challengeDAL        = mock[ChallengeDAL]
   val virtualChallengeDAL = mock[VirtualChallengeDAL]


### PR DESCRIPTION
The OpenAPI spec published at `/assets/swagger.json` claimed several fields were plain strings (containing stringified JSON values) when in fact they are always serialized directly as embedded JSON. This caused the generated TS types in `openApiTypes.ts` in the maproulette4 codebase to be wrong for these fields, which required defensive workarounds like `typeof x === 'string' ? JSON.parse(x) : x` in several places.

This PR modifies the backend models and serialization code in the controllers to correct this. There were two different issues that caused this:
1. `Task.geometries`, `Task.location`, `Task.cooperativeWork`, and `User.properties` were declared as `String` / `Option[String]` on their case classes, even though the column contents are JSON. Each model's custom Play JSON `Format` called `Json.parse(...)` and re-inserted the value as a parsed object before emitting. The Swagger types are generated by reflection, which can only see the type annotations and not the custom `Format` behavior which differs from the declared types.
2. `conf/swagger-custom-mappings.yml` contained a global mapping from `play.api.libs.json.JsValue` to `string`, which is wrong. JsValue can contain any JSON type (object, array, string, number, or null).

This PR addressed these problems.
- I've refactored the code to parse JSONB values from Postgres at read time, rather than read them as strings and then parse them when serializing JSON payloads for HTTP responses. This means the models can have their actual types (JsValue, JsObject, etc) correctly annotated instead of using custom Format code, so the Swagger generator sees accurate type information.
- I've changed this to map JsValue to the "top" type (TypeScript's `any` or `unknown`).
- I've also refactored various places where JsValue was used in response types to use a more specific type (like JsObject or JsArray) instead, and I added a migration to clean up some string-typed sentinel values in the database in order to make this new code simpler.