### PR TITLE
Drop unused task_geometries table and lazy migration in read path

### DIFF
--- a/app/org/maproulette/framework/mixins/TaskParserMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskParserMixin.scala
@@ -28,13 +28,7 @@ trait TaskParserMixin {
       "task_review.review_claimed_by, task_review.review_claimed_at, task_review.additional_reviewers, task_review.error_tags "
 
   // The anorm row parser to convert records from the task table to task objects
-  def getTaskParser(
-      updateAndRetrieve: (Long, Option[String], Option[String], Option[String]) => (
-          String,
-          Option[String],
-          Option[String]
-      )
-  ): RowParser[Task] = {
+  def getTaskParser(): RowParser[Task] = {
     get[Long]("tasks.id") ~
       get[String]("tasks.name") ~
       get[DateTime]("tasks.created") ~
@@ -43,7 +37,7 @@ trait TaskParserMixin {
       get[Option[String]]("tasks.instruction") ~
       get[Option[String]]("geo_location") ~
       get[Option[Int]]("tasks.status") ~
-      get[Option[String]]("geo_json") ~
+      get[String]("geo_json") ~
       get[Option[String]]("cooperative_work") ~
       get[Option[DateTime]]("tasks.mapped_on") ~
       get[Option[Long]]("tasks.completed_time_spent") ~
@@ -73,7 +67,6 @@ trait TaskParserMixin {
             metaReviewStatus ~ metaReviewedAt ~ reviewStartedAt ~ reviewClaimedBy ~ reviewClaimedAt ~
             additionalReviewers ~ priority ~ changesetId ~ responses ~ bundleId ~ isBundlePrimary ~ errorTags ~
             skipCount ~ archived =>
-        val values = updateAndRetrieve(id, geojson, location, cooperativeWork)
         Task(
           id,
           name,
@@ -81,9 +74,9 @@ trait TaskParserMixin {
           modified,
           parent_id,
           instruction,
-          values._2.map(Json.parse(_).as[JsObject]),
-          Json.parse(values._1).as[JsObject],
-          values._3.map(Json.parse(_).as[JsObject]),
+          location.map(Json.parse(_).as[JsObject]),
+          Json.parse(geojson).as[JsObject],
+          cooperativeWork.map(Json.parse(_).as[JsObject]),
           status,
           mappedOn,
           completedTimeSpent,
@@ -113,13 +106,7 @@ trait TaskParserMixin {
     }
   }
 
-  def getTaskWithReviewParser(
-      updateAndRetrieve: (Long, Option[String], Option[String], Option[String]) => (
-          String,
-          Option[String],
-          Option[String]
-      )
-  ): RowParser[TaskWithReview] = {
+  def getTaskWithReviewParser(): RowParser[TaskWithReview] = {
     // tasks fields
     get[Long]("tasks.id") ~
       get[String]("tasks.name") ~
@@ -129,7 +116,7 @@ trait TaskParserMixin {
       get[Option[String]]("tasks.instruction") ~
       get[Option[String]]("geo_location") ~
       get[Option[Int]]("tasks.status") ~
-      get[Option[String]]("geo_json") ~
+      get[String]("geo_json") ~
       get[Option[String]]("cooperative_work") ~
       get[Option[DateTime]]("tasks.mapped_on") ~
       get[Option[Long]]("tasks.completed_time_spent") ~
@@ -170,7 +157,6 @@ trait TaskParserMixin {
             skipCount ~ archived ~
             challengeName ~ projectName ~ projectId ~
             reviewRequestedByUsername ~ reviewedByUsername =>
-        val values = updateAndRetrieve(id, geojson, location, cooperativeWork)
         TaskWithReview(
           Task(
             id,
@@ -179,9 +165,9 @@ trait TaskParserMixin {
             modified,
             parent_id,
             instruction,
-            values._2.map(Json.parse(_).as[JsObject]),
-            Json.parse(values._1).as[JsObject],
-            values._3.map(Json.parse(_).as[JsObject]),
+            location.map(Json.parse(_).as[JsObject]),
+            Json.parse(geojson).as[JsObject],
+            cooperativeWork.map(Json.parse(_).as[JsObject]),
             status,
             mappedOn,
             completedTimeSpent,

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -313,7 +313,7 @@ class TaskBundleRepository @Inject() (
       query.build(s"""SELECT ${this.retrieveColumnsWithReview} FROM ${baseTable}
             INNER JOIN task_bundles tb on tasks.id = tb.task_id
             LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
-         """).as(this.getTaskParser(this.taskRepository.updateAndRetrieve).*)
+         """).as(this.getTaskParser().*)
     }
   }
 

--- a/app/org/maproulette/framework/repository/TaskRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskRepository.scala
@@ -5,7 +5,7 @@
 
 package org.maproulette.framework.repository
 
-import anorm.SqlParser.{get, scalar, str}
+import anorm.SqlParser.scalar
 import anorm.ToParameterValue
 import anorm._, postgresql._
 import javax.inject.{Inject, Singleton}
@@ -43,35 +43,9 @@ class TaskRepository @Inject() (override val db: Database, config: Config)
           "WHERE tasks.id = {id}"
         SQL(query)
           .on(Symbol("id") -> id)
-          .as(this.getTaskParser(this.updateAndRetrieve).singleOpt)
+          .as(this.getTaskParser().singleOpt)
       }
     }(id)
-  }
-
-  /**
-    * Allows us to lazy update the geojson data
-    *
-    * @param taskId The identifier of the task
-    */
-  def updateAndRetrieve(
-      taskId: Long,
-      geojson: Option[String],
-      location: Option[String],
-      cooperativeWork: Option[String]
-  ): (String, Option[String], Option[String]) = {
-    geojson match {
-      case Some(g) => (g, location, cooperativeWork)
-      case None =>
-        this.withMRTransaction { implicit c =>
-          SQL("SELECT * FROM update_geometry({id})")
-            .on(Symbol("id") -> taskId)
-            .as((str("geo") ~ get[Option[String]]("loc") ~ get[Option[String]]("fix_geo")).*)
-            .headOption match {
-            case Some(values) => (values._1._1, values._1._2, values._2)
-            case None         => throw new Exception("Failed to retrieve task data")
-          }
-        }
-    }
   }
 
   /**

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -35,8 +35,8 @@ class TaskReviewRepository @Inject() (
   implicit val baseTable: String = TaskReview.TABLE
   protected val logger           = LoggerFactory.getLogger(this.getClass)
 
-  val parser       = this.getTaskParser(this.taskRepository.updateAndRetrieve)
-  val reviewParser = this.getTaskWithReviewParser(this.taskRepository.updateAndRetrieve)
+  val parser       = this.getTaskParser()
+  val reviewParser = this.getTaskWithReviewParser()
 
   /**
     * Gets a Task object with review data

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1226,7 +1226,7 @@ class ChallengeDAL @Inject() (
   )(implicit id: Long, c: Option[Connection] = None): List[Task] = {
     // add a child caching option that will keep a list of children for the parent
     this.withMRConnection { implicit c =>
-      val geometryParser = this.taskRepository.getTaskParser(this.taskRepository.updateAndRetrieve)
+      val geometryParser = this.taskRepository.getTaskParser()
       val offset         = page * limit;
       val query =
         s"""SELECT ${taskDAL.retrieveColumns}

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -69,7 +69,7 @@ class TaskDAL @Inject() (
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  val parser = this.getTaskParser(this.taskRepository.updateAndRetrieve)
+  val parser = this.getTaskParser()
 
   // The cache manager for that tasks
   override val cacheManager = this.taskRepository.cacheManager
@@ -1486,20 +1486,6 @@ class TaskDAL @Inject() (
         }
       }
     }
-  }
-
-  /**
-    * A temporary solution that will allow us to lazy update the geojson data
-    *
-    * @param taskId The identifier of the task
-    */
-  def updateAndRetrieve(
-      taskId: Long,
-      geojson: Option[String],
-      location: Option[String],
-      cooperativeWork: Option[String]
-  )(implicit c: Option[Connection] = None): (String, Option[String], Option[String]) = {
-    this.taskRepository.updateAndRetrieve(taskId, geojson, location, cooperativeWork)
   }
 
   case class TaskSummary(

--- a/conf/evolutions/default/115.sql
+++ b/conf/evolutions/default/115.sql
@@ -1,0 +1,70 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+
+-- Drop the legacy task_geometries table and its associated update_geometry
+-- function. This table was originally used to store task geojsons, but
+-- commit b95bfe2d moved this data into the main tasks table. migration
+-- was done lazily at read time in the Scala code. today, every task in
+-- the prod database has a non-null geojson column, so the task_geometries
+-- table can safely be dropped.
+DROP FUNCTION IF EXISTS update_geometry(bigint);;
+DROP TABLE IF EXISTS task_geometries CASCADE;;
+
+-- Add NOT NULL to tasks.geojson. This only locks briefly.
+-- See https://dba.stackexchange.com/questions/267947/
+ALTER TABLE tasks
+  ADD CONSTRAINT tasks_geojson_not_null CHECK (geojson IS NOT NULL) NOT VALID;;
+ALTER TABLE tasks VALIDATE CONSTRAINT tasks_geojson_not_null;;
+ALTER TABLE tasks ALTER COLUMN geojson SET NOT NULL;;
+ALTER TABLE tasks DROP CONSTRAINT tasks_geojson_not_null;;
+
+# --- !Downs
+ALTER TABLE tasks ALTER COLUMN geojson DROP NOT NULL;;
+
+-- Restore task_geometries. Copied verbatim from evolution 1.sql (lines 293-313).
+CREATE TABLE IF NOT EXISTS task_geometries
+(
+  id SERIAL NOT NULL PRIMARY KEY,
+  task_id integer NOT NULL,
+  properties HSTORE,
+  CONSTRAINT task_geometries_task_id_fkey FOREIGN KEY (task_id)
+    REFERENCES tasks (id) MATCH SIMPLE
+    ON UPDATE CASCADE ON DELETE CASCADE
+    DEFERRABLE INITIALLY DEFERRED
+);;
+
+DO $$
+BEGIN
+  PERFORM column_name FROM information_schema.columns WHERE table_name = 'task_geometries' AND column_name = 'geom';;
+  IF NOT FOUND THEN
+    PERFORM AddGeometryColumn('task_geometries', 'geom', 4326, 'GEOMETRY', 2);;
+  END IF;;
+END$$;;
+
+CREATE INDEX IF NOT EXISTS idx_task_geometries_geom ON task_geometries USING GIST (geom);;
+SELECT create_index_if_not_exists('task_geometries', 'task_id', '(task_id)');;
+
+-- Restore update_geometry. Copied verbatim from evolution 61.sql (lines 132-153).
+DROP FUNCTION IF EXISTS update_geometry(bigint);;
+CREATE OR REPLACE FUNCTION update_geometry(task_identifier bigint)
+	RETURNS TABLE(geo TEXT, loc TEXT, fix_geo TEXT) AS $$
+BEGIN
+    UPDATE tasks t SET geojson = geoms.geometries FROM (SELECT ROW_TO_JSON(fc)::JSONB AS geometries
+                      FROM ( SELECT 'FeatureCollection' AS type, ARRAY_TO_JSON(array_agg(f)) AS features
+                               FROM ( SELECT 'Feature' AS type,
+                                              ST_AsGeoJSON(lg.geom)::JSONB AS geometry,
+                                              HSTORE_TO_JSON(lg.properties) AS properties
+                                      FROM task_geometries AS lg
+                                      WHERE task_id = task_identifier
+                                ) AS f
+                        )  AS fc) AS geoms WHERE id = task_identifier;;
+    -- Update the geometry and location columns
+    UPDATE tasks t SET geom = geoms.geometry, location = ST_CENTROID(geoms.geometry)
+    FROM (SELECT ST_COLLECT(ST_MAKEVALID(geom)) AS geometry FROM (
+            SELECT geom FROM task_geometries WHERE task_id = task_identifier
+         ) AS innerQuery) AS geoms WHERE id = task_identifier;;
+	 RETURN QUERY SELECT geojson::TEXT, ST_AsGeoJSON(location) AS geo_location, cooperative_work_json::TEXT FROM tasks
+	 WHERE id = task_identifier;;
+END
+$$ LANGUAGE plpgsql VOLATILE;;


### PR DESCRIPTION
This table was once used to store task geometries. Commit b95bfe2d moved this data into the tasks table instead, but the old table was kept and data was migrated lazily on read by Scala code.

Even though all data has been migrated and the task_geometries is completely unused now, the table and corresponding code was never removed.

This commit also adds a NOT NULL constraint to task.geometries. In the production database, this constraint is already true, so adding it is an easy way to prevent invalid tasks with no geometry from being created in the future.

Note: this PR is based on top of the `add-support-for-new-features` branch, in order to avoid merge conflicts (since both branches add new evolutions). But we don't need to merge it together with that branch. Once the upstream branch merges, GitHub will automatically change this PR's target to `main`.