### PR TITLE
Validate task GeoJSONs and ensure task.location and task.geom are non-NULL

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -322,6 +322,7 @@ class TaskDAL @Inject() (
       user: User
   )(implicit id: Long, c: Option[Connection] = None): Option[Task] = {
     this.permission.hasObjectWriteAccess(element, user)
+    validateGeoJson(element.geometries)
     // get the parent challenge, as we need the priority information
     val parentChallenge = this.manager.challenge.retrieveById(element.parent) match {
       case Some(c) => c
@@ -420,6 +421,41 @@ class TaskDAL @Inject() (
       val updatedElement = element.copy(id = updatedTaskId)
       this.cacheManager.cache.remove(updatedTaskId)
       Some(updatedElement)
+    }
+  }
+
+  /**
+    * Ensure that the given JSON object is a valid and non-empty GeoJSON
+    * FeatureCollection. Raises an error if not, which will be sent as
+    * a 4xx response back to the client.
+    */
+  private def validateGeoJson(json: JsObject): Unit = {
+    (json \ "type").asOpt[String] match {
+      case Some("FeatureCollection") => // ok
+      case _ =>
+        throw new InvalidException("Task GeoJSON must have type 'FeatureCollection'")
+    }
+    val features = (json \ "features").toOption match {
+      case Some(JsArray(arr)) => arr
+      case _ =>
+        throw new InvalidException("Task GeoJSON must contain a 'features' array")
+    }
+    if (features.isEmpty) {
+      throw new InvalidException("Task GeoJSON 'features' array must not be empty")
+    }
+    features.zipWithIndex.foreach {
+      case (feature: JsObject, i) =>
+        (feature \ "geometry").toOption match {
+          case Some(_: JsObject) => // ok
+          case _ =>
+            throw new InvalidException(
+              s"Task GeoJSON feature at index $i must have a 'geometry' field"
+            )
+        }
+      case (_, i) =>
+        throw new InvalidException(
+          s"Task GeoJSON feature at index $i must be a JSON object"
+        )
     }
   }
 

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -323,6 +323,9 @@ class TaskDAL @Inject() (
   )(implicit id: Long, c: Option[Connection] = None): Option[Task] = {
     this.permission.hasObjectWriteAccess(element, user)
     validateGeoJson(element.geometries)
+    // Add type: FeatureCollection (some legacy clients omit it, but we want
+    // to make sure GeoJSONs we store in the database are well formed and valid).
+    val geoJson = element.geometries + ("type" -> JsString("FeatureCollection"))
     // get the parent challenge, as we need the priority information
     val parentChallenge = this.manager.challenge.retrieveById(element.parent) match {
       case Some(c) => c
@@ -340,7 +343,7 @@ class TaskDAL @Inject() (
     }(id, true, true)
     this.withMRTransaction { implicit c =>
       val result =
-        extractCooperativeWork(element.parent, element.geometries, element.cooperativeWork)
+        extractCooperativeWork(element.parent, geoJson, element.cooperativeWork)
       val geometries      = result._1
       var cooperativeWork = result._2
 
@@ -430,8 +433,11 @@ class TaskDAL @Inject() (
     * a 4xx response back to the client.
     */
   private def validateGeoJson(json: JsObject): Unit = {
-    (json \ "type").asOpt[String] match {
-      case Some("FeatureCollection") => // ok
+    (json \ "type").toOption match {
+      // Some legacy clients omit 'type' on the FeatureCollection; let's be
+      // nice to them and normalize it for them instead of returning 400
+      case None                                => // ok
+      case Some(JsString("FeatureCollection")) => // ok
       case _ =>
         throw new InvalidException("Task GeoJSON must have type 'FeatureCollection'")
     }

--- a/conf/evolutions/default/116.sql
+++ b/conf/evolutions/default/116.sql
@@ -1,0 +1,25 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+
+-- Add NOT NULL to tasks.geom and tasks.location. Both columns are derived
+-- from tasks.geojson at insert time, and a NULL value here would mean the
+-- row's GeoJSON could not be parsed into a PostGIS geometry.
+--
+-- Adding these constraints only locks the tasks table briefly.
+-- See https://dba.stackexchange.com/questions/267947/
+ALTER TABLE tasks
+  ADD CONSTRAINT tasks_geom_not_null CHECK (geom IS NOT NULL) NOT VALID;;
+ALTER TABLE tasks VALIDATE CONSTRAINT tasks_geom_not_null;;
+ALTER TABLE tasks ALTER COLUMN geom SET NOT NULL;;
+ALTER TABLE tasks DROP CONSTRAINT tasks_geom_not_null;;
+
+ALTER TABLE tasks
+  ADD CONSTRAINT tasks_location_not_null CHECK (location IS NOT NULL) NOT VALID;;
+ALTER TABLE tasks VALIDATE CONSTRAINT tasks_location_not_null;;
+ALTER TABLE tasks ALTER COLUMN location SET NOT NULL;;
+ALTER TABLE tasks DROP CONSTRAINT tasks_location_not_null;;
+
+# --- !Downs
+ALTER TABLE tasks ALTER COLUMN geom DROP NOT NULL;;
+ALTER TABLE tasks ALTER COLUMN location DROP NOT NULL;;


### PR DESCRIPTION
Followup on top of #1240, which ensures that task GeoJSONs are not null.

By applying additional validations at insert time, we can ensure that:
- task.geojson is not only non-null, but is actually a well formed GeoJSON FeatureCollection
- task.geom and task.location (which are computed from that GeoJSON) are also non-null

This PR does both. It adds some basic validation on the task GeoJSON (to make sure it's a valid and non-empty FeatureCollection) at insert/update time, and it adds an evolution to apply NOT NULL constraints to the geom and location columns.

Before deploying this, I will need to do some minor manual database maintenance, because there are about 1,000 tasks (mostly very old) that have null locations or geoms. I plan to delete these tasks, since they are not actionable without this info (a few have comments attached to them by mappers, and the comments are universally by confused users wondering why MapRoulette sent them to [Null Island](https://en.wikipedia.org/wiki/Null_Island) and there isn't anything available to fix).