### PR TITLE
Improve error logging when a task fails to be created

### DIFF
--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -660,7 +660,10 @@ class ChallengeProvider @Inject() (
                     } catch {
                       case e: Exception =>
                         partial = true
-                        logger.error(e.getMessage, e)
+                        logger.error(
+                          s"Failed to build overpass task for challenge ${challenge.id}: ${e.getMessage}",
+                          e
+                        )
                     }
                   }
                   partial match {
@@ -801,7 +804,7 @@ class ChallengeProvider @Inject() (
     } catch {
       // this task could fail on unique key violation, we need to ignore them
       case e: Exception =>
-        logger.error(e.getMessage)
+        logger.error(s"Failed to create task '$name' in challenge ${parent.id}: ${e.getMessage}", e)
         None
     }
   }


### PR DESCRIPTION
There are some errors showing up in the production logs after #1240 and #1241 which are likely caused by clients trying to create tasks with invalid or missing GeoJSON. But the existing log messages don't provide a stack trace or error class name (just the message, which is `null`). This PR improves the log messages which should help narrow in on the cause.