### PR TITLE
Fix JsArray value type handling in TaskDAL to prevent ClassCastException

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -35,7 +35,7 @@ import play.api.libs.json.JodaReads._
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.collection.mutable.ListBuffer
 import scala.concurrent.{Future, Promise}
 import scala.util.control.Exception.allCatch
 import scala.util.{Failure, Success, Try}

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -502,11 +502,9 @@ class TaskDAL @Inject() (
         (geometries \ "features")
           .as[JsArray]
           .value
-          .map {
+          .collect {
             case value: JsObject => value.transform(mrTransformer).getOrElse(value)
-            case _               => // do nothing
           }
-          .asInstanceOf[ArrayBuffer[JsObject]]
       )
 
       // Set the correct cooperative type on the parent challenge


### PR DESCRIPTION
Updated the extraction of geometries in TaskDAL to use `collect` instead of a cast to `ArrayBuffer[JsObject]`, addressing compatibility issues introduced in [Play 2.9.11 update](https://github.com/maproulette/maproulette-backend/pull/1231). This change ensures proper filtering and transformation of geometries without runtime errors, and fixes the bug where overpass queries and large geojsons arent building.