### PR TITLE
Ensure that challenge.bounding is always a Polygon

### DIFF
--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -209,7 +209,7 @@ class SchedulerActor @Inject() (
                   SET location = (SELECT ST_Centroid(ST_Collect(ST_Makevalid(location)))
                                  FROM tasks
                                  WHERE parent_id = ${id}),
-                      bounding = (SELECT ST_SetSRID(ST_Extent(location)::geometry, 4326)
+                      bounding = (SELECT ST_Envelope(ST_Expand(ST_SetSRID(ST_Extent(location), 4326), 0.0001))
                                  FROM tasks
                                  WHERE parent_id = ${id}),
                       last_updated = NOW(),


### PR DESCRIPTION
In #1236, @CollinBeczak originally proposed this change:

```diff
- bounding = (SELECT ST_Envelope(ST_Buffer((ST_SetSRID(ST_Extent(location), 4326))::geography,2)::geometry)
+ bounding = (SELECT ST_Envelope(ST_Expand(ST_SetSRID(ST_Extent(location), 4326), 0.0001))
```

I wrote this in a review comment:

> This change looks reasonable (ST_Expand is faster than casting to geography and bufferring in spherical coordinates, and the result is similar). But I think we can go further: why should `bounding` be buffered at all? It's faster and more correct to just have `bounding` be the exact `ST_Extent` of the task's geometry (`location`). If the geometry is a point, this will be a degenerate bounding box, but that's still valid and can still be tested for intersection using `&&` with other bounding boxes (e.g. to get all tasks within the viewport for the explore page).

I was wrong about this. I forgot that `bounding` has a column type of `POLYGON`, and casting a `box2d` (returned by `ST_Extent`) to a geometry can return a point or linestring in degenerate cases:

```
# SELECT ST_Extent('POINT(1 3)'::geometry);
  st_extent
--------------
 BOX(1 3,1 3)
(1 row)

# SELECT ST_AsText(ST_Extent('POINT(1 3)'::geometry));
 st_astext
------------
 POINT(1 3)
(1 row)
```

The consequence of this is that challenges containing a single task would not be updated by this scheduled job.

This PR reverses the suggestion I made and uses `ST_Envelope` to ensure a small but nonzero area for all challenge bounding boxes.