### PR TITLE
Remove updateChallengeCompletionMetrics scheduled job

### DIFF
--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -336,8 +336,6 @@ object Config {
     s"$SUB_GROUP_SCHEDULER.archiveChallenges.startTime"
   val KEY_SCHEDULER_ARCHIVE_CHALLENGES_STALE_TIME_IN_MONTHS =
     s"$SUB_GROUP_SCHEDULER.archiveChallenges.staleTimeInMonths"
-  val KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_INTERVAL =
-    s"$SUB_GROUP_SCHEDULER.updateChallengeCompletionMetrics.interval"
   // Drains the dirty-cell queue and keeps the pre-computed tile pyramid fresh.
   // Set to an empty string to disable (e.g. integration tests).
   val KEY_SCHEDULER_REBUILD_DIRTY_TILE_CELLS_INTERVAL =

--- a/app/org/maproulette/framework/model/CompletionMetrics.scala
+++ b/app/org/maproulette/framework/model/CompletionMetrics.scala
@@ -33,4 +33,15 @@ object CompletionMetrics {
     Json.using[Json.WithDefaultValues].reads[CompletionMetrics].map { m =>
       m.copy(tasksRemaining = m.available + m.skipped + m.tooHard)
     }
+
+  def completionPercentage(m: CompletionMetrics): Int = {
+    val completable = m.total - m.deleted - m.disabled
+    if (completable <= 0) 0
+    else {
+      val pct = math
+        .round((m.fixed + m.falsePositive + m.alreadyFixed).toDouble * 100 / completable)
+        .toInt
+      pct.max(0).min(100)
+    }
+  }
 }

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -158,51 +158,6 @@ class ChallengeRepository @Inject() (override val db: Database) extends Reposito
     }
   }
 
-  /**
-    * Refreshes the 'completion_percentage' metric for all active (neither deleted nor archived) challenges.
-    *
-    * <p>The 'completion_percentage' metric quantifies the ratio of completed tasks within a challenge,
-    * expressed as a percentage. It is computed by the formula:
-    * (completedTaskCount / totalTasks) * 100.
-    *
-    * <p>The PostgreSQL index 'idx_tasks_status_non_zero' was created to avoid a full table scan of the tasks table,
-    * significantly reducing query execution time.
-    */
-  def updateCompletionMetricsOfActiveChallenges()(implicit c: Option[Connection] = None): Unit = {
-    withMRConnection { implicit c =>
-      SQL(
-        s"""
-           |UPDATE challenges
-           |SET completion_percentage = new_completion_percentage, tasks_remaining = new_tasks_remaining
-           |FROM (
-           |    SELECT
-           |        challenges.id AS challenge_id,
-           |        completed_task_counts.completed_tasks * 100 / total_task_counts.total_tasks AS new_completion_percentage,
-           |        total_task_counts.total_tasks - completed_task_counts.completed_tasks AS new_tasks_remaining
-           |    FROM
-           |        challenges
-           |    JOIN (
-           |        SELECT
-           |            parent_id,
-           |            COUNT(*) AS total_tasks
-           |        FROM tasks
-           |        GROUP BY parent_id
-           |    ) AS total_task_counts ON challenges.id = total_task_counts.parent_id
-           |    JOIN (
-           |        SELECT
-           |            parent_id,
-           |            COUNT(*) AS completed_tasks
-           |        FROM tasks
-           |        WHERE status != 0
-           |        GROUP BY parent_id
-           |    ) AS completed_task_counts ON challenges.id = completed_task_counts.parent_id
-           |    WHERE NOT deleted and NOT is_archived
-           |) AS updated_challenges
-           |WHERE challenges.id = updated_challenges.challenge_id;
-        """.stripMargin
-      ).execute()
-    }
-  }
 }
 
 object ChallengeRepository {
@@ -272,14 +227,17 @@ object ChallengeRepository {
       get[Boolean]("challenges.require_confirmation") ~
       get[Boolean]("challenges.require_reject_reason") ~
       get[Option[JsValue]]("challenges.task_widget_layout") ~
-      get[Option[DateTime]]("challenges.system_archived_at") map {
+      get[Option[DateTime]]("challenges.system_archived_at") ~
+      get[Option[JsValue]]("challenges.completion_metrics") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
             difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~ checkin_comment ~
             checkin_source ~ overpassql ~ overpassTargetType ~ remoteGeoJson ~ status ~ statusMessage ~ defaultPriority ~ highPriorityRule ~
             mediumPriorityRule ~ lowPriorityRule ~ highPriorityBounds ~ mediumPriorityBounds ~ lowPriorityBounds ~ defaultZoom ~ minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~
             customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ preferredTags ~ preferredReviewTags ~
             limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~ dataOriginDate ~ requiresLocal ~ location ~ bounding ~
-            deleted ~ isGlobal ~ virtualParents ~ isArchived ~ reviewSetting ~ datasetUrl ~ requireConfirmation ~ requireRejectReason ~ taskWidgetLayout ~ systemArchivedAt =>
+            deleted ~ isGlobal ~ virtualParents ~ isArchived ~ reviewSetting ~ datasetUrl ~ requireConfirmation ~ requireRejectReason ~ taskWidgetLayout ~ systemArchivedAt ~ completionMetricsJson =>
+        val completionMetrics =
+          completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
         val hpr = highPriorityRule match {
           case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
           case r                                                                => r
@@ -360,7 +318,9 @@ object ChallengeRepository {
           lastTaskRefresh,
           dataOriginDate,
           location,
-          bounding
+          bounding,
+          Some(CompletionMetrics.completionPercentage(completionMetrics)),
+          completionMetrics
         )
     }
   }

--- a/app/org/maproulette/framework/service/ChallengeService.scala
+++ b/app/org/maproulette/framework/service/ChallengeService.scala
@@ -121,11 +121,4 @@ class ChallengeService @Inject() (
     val result = this.repository.archiveChallenge(challengeId, archiving, systemArchive)
     result
   }
-
-  /**
-    * Refreshes the 'completion_percentage' metric for all active (neither deleted nor archived) challenges.
-    */
-  def updateCompletionMetricsOfActiveChallenges(): Unit = {
-    this.repository.updateCompletionMetricsOfActiveChallenges();
-  }
 }

--- a/app/org/maproulette/jobs/Scheduler.scala
+++ b/app/org/maproulette/jobs/Scheduler.scala
@@ -109,13 +109,6 @@ class Scheduler @Inject() (
   )
 
   schedule(
-    "updateChallengeCompletionMetrics",
-    "Updating Challenge Completion Metrics",
-    5.minutes,
-    Config.KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_INTERVAL
-  )
-
-  schedule(
     "rebuildDirtyTileCells",
     "Rebuilding Dirty Tile Cells",
     30.seconds,

--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -90,8 +90,6 @@ class SchedulerActor @Inject() (
       this.handleSendCountNotificationEmails(action, UserNotification.NOTIFICATION_EMAIL_WEEKLY)
     case RunJob("archiveChallenges", action) =>
       this.handleArchiveChallenges(action)
-    case RunJob("updateChallengeCompletionMetrics", action) =>
-      this.handleUpdateChallengeCompletionMetrics(action)
     case RunJob("rebuildDirtyTileCells", action) =>
       this.rebuildDirtyTileCells(action)
   }
@@ -743,23 +741,6 @@ class SchedulerActor @Inject() (
     val totalTime = System.currentTimeMillis - start
     logger.info(
       s"Scheduled Task '$action': Finished run. Time spent: ${String.format("%1d", totalTime)}ms"
-    )
-  }
-
-  /**
-    * Updates completion metrics for all active challenges.
-    *
-    * @param action An action descriptor, providing more context for logging.
-    */
-  def handleUpdateChallengeCompletionMetrics(action: String): Unit = {
-    val startTime = System.currentTimeMillis
-    logger.info(s"Scheduled Task '$action': Starting run")
-
-    this.serviceManager.challenge.updateCompletionMetricsOfActiveChallenges()
-
-    val elapsedTime = System.currentTimeMillis - startTime
-    logger.info(
-      s"Scheduled Task '$action': Finished run. Time spent: ${String.format("%1d", elapsedTime)}ms"
     )
   }
 

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -129,8 +129,6 @@ class ChallengeDAL @Inject() (
       get[Int]("challenges.review_setting") ~
       get[Option[String]]("challenges.dataset_url") ~
       get[Option[JsValue]]("challenges.task_widget_layout") ~
-      get[Option[Int]]("challenges.completion_percentage") ~
-      get[Option[Int]]("challenges.tasks_remaining") ~
       get[Boolean]("challenges.require_confirmation") ~
       get[Boolean]("challenges.require_reject_reason") ~
       get[Option[JsValue]]("challenges.completion_metrics") map {
@@ -142,7 +140,9 @@ class ChallengeDAL @Inject() (
             exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ preferredTags ~ preferredReviewTags ~
             limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~ dataOriginDate ~ location ~ bounding ~
             requiresLocal ~ deleted ~ isGlobal ~ isArchived ~ reviewSetting ~ datasetUrl ~ taskWidgetLayout ~
-            completionPercentage ~ tasksRemaining ~ requireConfirmation ~ requireRejectReason ~ completionMetricsJson =>
+            requireConfirmation ~ requireRejectReason ~ completionMetricsJson =>
+        val completionMetrics =
+          completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
         new Challenge(
           id,
           name,
@@ -210,8 +210,8 @@ class ChallengeDAL @Inject() (
           dataOriginDate,
           location,
           bounding,
-          completionPercentage,
-          completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
+          Some(CompletionMetrics.completionPercentage(completionMetrics)),
+          completionMetrics
         )
     }
   }
@@ -279,8 +279,6 @@ class ChallengeDAL @Inject() (
       get[Option[String]]("challenges.dataset_url") ~
       get[Option[JsValue]]("challenges.task_widget_layout") ~
       get[Option[DateTime]]("challenges.system_archived_at") ~
-      get[Option[Int]]("challenges.completion_percentage") ~
-      get[Option[Int]]("challenges.tasks_remaining") ~
       get[Boolean]("challenges.require_confirmation") ~
       get[Boolean]("challenges.require_reject_reason") ~
       get[Option[JsValue]]("challenges.completion_metrics") map {
@@ -292,8 +290,10 @@ class ChallengeDAL @Inject() (
             customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ preferredTags ~
             preferredReviewTags ~ limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~
             dataOriginDate ~ location ~ bounding ~ requiresLocal ~ deleted ~ isGlobal ~ virtualParents ~
-            presets ~ isArchived ~ reviewSetting ~ datasetUrl ~ taskWidgetLayout ~ systemArchivedAt ~ completionPercentage ~
-            tasksRemaining ~ requireConfirmation ~ requireRejectReason ~ completionMetricsJson =>
+            presets ~ isArchived ~ reviewSetting ~ datasetUrl ~ taskWidgetLayout ~ systemArchivedAt ~
+            requireConfirmation ~ requireRejectReason ~ completionMetricsJson =>
+        val completionMetrics =
+          completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
         new Challenge(
           id,
           name,
@@ -360,8 +360,8 @@ class ChallengeDAL @Inject() (
           dataOriginDate,
           location,
           bounding,
-          completionPercentage,
-          completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
+          Some(CompletionMetrics.completionPercentage(completionMetrics)),
+          completionMetrics
         )
     }
   }
@@ -424,7 +424,6 @@ class ChallengeDAL @Inject() (
       get[Option[DateTime]]("challenges.data_origin_date") ~
       get[Option[String]]("locationJSON") ~
       get[Option[String]]("boundingJSON") ~
-      get[Option[Int]]("challenges.completion_percentage") ~
       get[Option[JsValue]]("challenges.completion_metrics") map {
       case id ~ name ~ created ~ modified ~ description ~ deleted ~ isGlobal ~ requireConfirmation ~ requireRejectReason ~
             infoLink ~ ownerId ~ parentId ~ instruction ~ difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~
@@ -433,8 +432,10 @@ class ChallengeDAL @Inject() (
             mediumPriorityBounds ~ lowPriorityBounds ~ defaultZoom ~ minZoom ~ maxZoom ~ updateTasks ~ limitTags ~
             limitReviewTags ~ isArchived ~ reviewSetting ~ defaultBasemap ~ defaultBasemapId ~ customBasemap ~
             exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ taskWidgetLayout ~ taskStyles ~ status ~
-            statusMessage ~ lastTaskRefresh ~ dataOriginDate ~ location ~ bounding ~ completionPercentage ~
+            statusMessage ~ lastTaskRefresh ~ dataOriginDate ~ location ~ bounding ~
             completionMetricsJson =>
+        val completionMetrics =
+          completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
         val hpr = highPriorityRule.map(Json.parse(_).as[JsObject])
         val mpr = mediumPriorityRule.map(Json.parse(_).as[JsObject])
         val lpr = lowPriorityRule.map(Json.parse(_).as[JsObject])
@@ -498,10 +499,8 @@ class ChallengeDAL @Inject() (
           dataOriginDate,
           location.map(Json.parse(_).as[JsObject]),
           bounding.map(Json.parse(_).as[JsObject]),
-          completionPercentage,
-          completionMetricsJson
-            .flatMap(_.asOpt[CompletionMetrics])
-            .getOrElse(CompletionMetrics())
+          Some(CompletionMetrics.completionPercentage(completionMetrics)),
+          completionMetrics
         )
     }
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -266,10 +266,6 @@ maproulette {
       staleTimeInMonths = 6
     }
 
-    updateChallengeCompletionMetrics {
-      interval = "20 minutes"
-    }
-
     # Drains the dirty-cell queue (marked by the task/challenge/project triggers)
     # and keeps the pre-computed tile pyramid fresh. Set the interval to an empty
     # string to disable background tile work for this instance.

--- a/conf/evolutions/default/117.sql
+++ b/conf/evolutions/default/117.sql
@@ -1,0 +1,42 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+
+-- Drop the legacy completion_percentage and tasks_remaining columns on challenges
+-- (replaced by completion_metrics JSONB column added in evolution 111).
+ALTER TABLE challenges DROP COLUMN IF EXISTS completion_percentage;;
+ALTER TABLE challenges DROP COLUMN IF EXISTS tasks_remaining;;
+
+-- These indexes were only needed to support the old scheduled stats job
+DROP INDEX IF EXISTS idx_tasks_status_non_zero;;
+DROP INDEX IF EXISTS idx_challenges_id_deleted_archived;;
+
+# --- !Downs
+
+-- Restore the indexes dropped above.
+CREATE INDEX IF NOT EXISTS idx_tasks_status_non_zero ON tasks(status) WHERE status != 0;;
+CREATE INDEX IF NOT EXISTS idx_challenges_id_deleted_archived ON challenges (id) WHERE NOT deleted AND NOT is_archived;;
+
+-- Restore the columns with their original definitions (evolution 84) and
+-- backfill from completion_metrics so existing rows have plausible values.
+ALTER TABLE challenges ADD COLUMN IF NOT EXISTS completion_percentage INTEGER DEFAULT 0;;
+ALTER TABLE challenges ADD COLUMN IF NOT EXISTS tasks_remaining INTEGER DEFAULT 0;;
+
+UPDATE challenges SET
+  completion_percentage = CASE
+    WHEN (metrics_get(completion_metrics, 'total')
+          - metrics_get(completion_metrics, 'deleted')
+          - metrics_get(completion_metrics, 'disabled')) <= 0 THEN 0
+    ELSE ROUND(
+      (metrics_get(completion_metrics, 'fixed')
+       + metrics_get(completion_metrics, 'falsePositive')
+       + metrics_get(completion_metrics, 'alreadyFixed'))::numeric
+      * 100
+      / (metrics_get(completion_metrics, 'total')
+         - metrics_get(completion_metrics, 'deleted')
+         - metrics_get(completion_metrics, 'disabled'))
+    )::int
+  END,
+  tasks_remaining = metrics_get(completion_metrics, 'available')
+                  + metrics_get(completion_metrics, 'skipped')
+                  + metrics_get(completion_metrics, 'tooHard');;

--- a/conf/evolutions/default/118.sql
+++ b/conf/evolutions/default/118.sql
@@ -1,0 +1,65 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+
+-- The completion metrics triggers added in evolution 111 fire every time a
+-- task or challenge row is inserted/updated/deleted, regardless of which
+-- columns changed. This creates unnecessary lock contention on these tables
+-- and increases latency of write operations.
+--
+-- So instead, we'll replace each with three separate triggers. INSERTs and
+-- DELETEs will always trigger metrics recalculation, but UPDATEs will only
+-- do so if a column that could affect the result was changed.
+
+
+DROP TRIGGER IF EXISTS update_challenge_completion_metrics_trigger ON tasks;;
+
+CREATE TRIGGER update_challenge_completion_metrics_insert_trigger
+  AFTER INSERT ON tasks
+  FOR EACH ROW EXECUTE PROCEDURE update_challenge_completion_metrics();;
+
+CREATE TRIGGER update_challenge_completion_metrics_delete_trigger
+  AFTER DELETE ON tasks
+  FOR EACH ROW EXECUTE PROCEDURE update_challenge_completion_metrics();;
+
+CREATE TRIGGER update_challenge_completion_metrics_update_trigger
+  AFTER UPDATE OF status, parent_id ON tasks
+  FOR EACH ROW
+  WHEN (OLD.parent_id IS DISTINCT FROM NEW.parent_id
+        OR OLD.status IS DISTINCT FROM NEW.status)
+  EXECUTE PROCEDURE update_challenge_completion_metrics();;
+
+
+DROP TRIGGER IF EXISTS update_project_completion_metrics_trigger ON challenges;;
+
+CREATE TRIGGER update_project_completion_metrics_insert_trigger
+  AFTER INSERT ON challenges
+  FOR EACH ROW EXECUTE PROCEDURE update_project_completion_metrics();;
+
+CREATE TRIGGER update_project_completion_metrics_delete_trigger
+  AFTER DELETE ON challenges
+  FOR EACH ROW EXECUTE PROCEDURE update_project_completion_metrics();;
+
+CREATE TRIGGER update_project_completion_metrics_update_trigger
+  AFTER UPDATE OF completion_metrics, deleted, parent_id ON challenges
+  FOR EACH ROW
+  WHEN (OLD.completion_metrics IS DISTINCT FROM NEW.completion_metrics
+        OR OLD.deleted IS DISTINCT FROM NEW.deleted
+        OR OLD.parent_id IS DISTINCT FROM NEW.parent_id)
+  EXECUTE PROCEDURE update_project_completion_metrics();;
+
+# --- !Downs
+
+DROP TRIGGER IF EXISTS update_challenge_completion_metrics_insert_trigger ON tasks;;
+DROP TRIGGER IF EXISTS update_challenge_completion_metrics_delete_trigger ON tasks;;
+DROP TRIGGER IF EXISTS update_challenge_completion_metrics_update_trigger ON tasks;;
+CREATE TRIGGER update_challenge_completion_metrics_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON tasks
+  FOR EACH ROW EXECUTE PROCEDURE update_challenge_completion_metrics();;
+
+DROP TRIGGER IF EXISTS update_project_completion_metrics_insert_trigger ON challenges;;
+DROP TRIGGER IF EXISTS update_project_completion_metrics_delete_trigger ON challenges;;
+DROP TRIGGER IF EXISTS update_project_completion_metrics_update_trigger ON challenges;;
+CREATE TRIGGER update_project_completion_metrics_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON challenges
+  FOR EACH ROW EXECUTE PROCEDURE update_project_completion_metrics();;


### PR DESCRIPTION
#1236 added a new `completion_metrics` JSONB column which is kept up to date by triggers, but it did not remove the scheduled job that maintains the old `completion_percentage` and `tasks_remaining` counts. Having both at once creates write contention on the challenges and projects tables and makes lots of API operations very slow while the job is running.

This PR does the following:
- drops the `completion_percentage` and `tasks_remaining` columns (and computes those fields from the `completion_metrics` data when building JSON responses)
- removes the `updateCompletionMetricsOfActiveChallenges` job which maintained those columns
- changes when the `update_challenge_completion_metrics` and `update_project_completion_metrics` SQL functions are triggered, so updating a task (or challenge) will only recompute metrics for the parent challenge (or project) if a column was modified that could affect the results.

There are still problems with the present approach which we should fix in a future PR:
- The metrics calculation SQL functions are triggered per row, not per statement. This means that a bulk operation (like inserting 10,000 new tasks) calls the function 10,000 times, when calling it once at the end would be sufficient.
- The code paths for creating a challenge or refreshing tasks build task models one at a time and then `INSERT` or `UPDATE` them in individual queries. This is an antipattern on its own (refreshing a challenge with 50k tasks means 50k DB roundtrips), but it also means that even if we switch to per-statement triggers as described above, we still won't see any benefit until these code paths are refactored to insert/update tasks in batches.