### PR TITLE
Add tests for service info, user auth, task geometry pruning, and overpass task building

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -496,16 +496,8 @@ class TaskDAL @Inject() (
         cooperativeWorkJson = Some(workMatch.head.toString())
       }
 
-      val attachments   = (geometries \ "attachments").toOption
-      val mrTransformer = (__ \ "properties" \ "maproulette").json.prune
-      val extractedGeometries = JsArray(
-        (geometries \ "features")
-          .as[JsArray]
-          .value
-          .collect {
-            case value: JsObject => value.transform(mrTransformer).getOrElse(value)
-          }
-      )
+      val attachments         = (geometries \ "attachments").toOption
+      val extractedGeometries = this.pruneMapRouletteProperties(geometries)
 
       // Set the correct cooperative type on the parent challenge
       cooperativeWorkJson match {
@@ -541,6 +533,26 @@ class TaskDAL @Inject() (
         cooperativeWorkJson
       )
     }
+  }
+
+  /**
+    * Extracts the features from a FeatureCollection, removing any embedded
+    * "maproulette" object from each feature's properties. Non-object entries
+    * in the features array are dropped.
+    *
+    * @param geometries The geojson FeatureCollection containing the features
+    * @return The features with any maproulette properties pruned
+    */
+  private[dal] def pruneMapRouletteProperties(geometries: JsObject): JsArray = {
+    val mrTransformer = (__ \ "properties" \ "maproulette").json.prune
+    JsArray(
+      (geometries \ "features")
+        .as[JsArray]
+        .value
+        .collect {
+          case value: JsObject => value.transform(mrTransformer).getOrElse(value)
+        }
+    )
   }
 
   /**

--- a/app/org/maproulette/session/SessionManager.scala
+++ b/app/org/maproulette/session/SessionManager.scala
@@ -292,12 +292,16 @@ class SessionManager @Inject() (
           Some(User.superUser)
         } else {
           try {
-            val apiSplit        = apiKey.split("\\|")
-            val encryptedApiKey = crypto.encrypt(apiSplit(1))
-            this.serviceManager.user
-              .retrieveByAPIKey(apiSplit(0).toLong, encryptedApiKey, User.superUser) match {
-              case Some(user) => Some(user)
-              case None       => None
+            // A valid API key has the form "<userId>|<rawKey>". Anything else is malformed
+            // and should be rejected as unauthorized rather than throwing.
+            apiKey.split("\\|", 2) match {
+              case Array(userId, rawKey) =>
+                val encryptedApiKey = crypto.encrypt(rawKey)
+                this.serviceManager.user
+                  .retrieveByAPIKey(userId.toLong, encryptedApiKey, User.superUser)
+              case _ =>
+                logger.warn("Malformed API key, generally this is not an issue")
+                None
             }
           } catch {
             case _: NumberFormatException =>

--- a/test/org/maproulette/framework/controller/ServiceInfoControllerSpec.scala
+++ b/test/org/maproulette/framework/controller/ServiceInfoControllerSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.controller
+
+import org.maproulette.data.ActionManager
+import org.maproulette.models.service.info.{BuildInfo, RuntimeInfo}
+import org.maproulette.session.SessionManager
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.JsValue
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+class ServiceInfoControllerSpec extends PlaySpec with MockitoSugar {
+  val components = stubControllerComponents()
+  val controller = new ServiceInfoController(
+    mock[SessionManager],
+    mock[ActionManager],
+    components.parsers,
+    components
+  )
+
+  "GET /service/info" should {
+    val result: Future[Result] = controller.getServiceInfo(FakeRequest(GET, "/service/info"))
+
+    "return 200 OK with a JSON body" in {
+      status(result) mustEqual OK
+      contentType(result) mustEqual Some("application/json")
+    }
+
+    "return the compiletime build information" in {
+      val compiletime: JsValue = contentAsJson(result) \ "compiletime" getOrElse fail(
+        "missing compiletime object"
+      )
+      (compiletime \ "name").validate[String].get mustEqual BuildInfo.get.name
+      (compiletime \ "version").validate[String].get mustEqual BuildInfo.get.version
+      (compiletime \ "scalaVersion").validate[String].get mustEqual BuildInfo.get.scalaVersion
+      (compiletime \ "sbtVersion").validate[String].get mustEqual BuildInfo.get.sbtVersion
+      (compiletime \ "buildDate").validate[String].get mustEqual BuildInfo.get.buildDate
+      (compiletime \ "javaVersion").validate[String].get mustEqual BuildInfo.get.javaVersion
+      (compiletime \ "javaVendor").validate[String].get mustEqual BuildInfo.get.javaVendor
+    }
+
+    "return the runtime information" in {
+      val runtimeInfo = RuntimeInfo()
+      val runtime: JsValue = contentAsJson(result) \ "runtime" getOrElse fail(
+        "missing runtime object"
+      )
+      (runtime \ "javaVersion").validate[String].get mustEqual runtimeInfo.javaVersion
+      (runtime \ "javaVendor").validate[String].get mustEqual runtimeInfo.javaVendor
+    }
+  }
+}

--- a/test/org/maproulette/framework/controller/UserControllerSpec.scala
+++ b/test/org/maproulette/framework/controller/UserControllerSpec.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.controller
+
+import org.joda.time.DateTime
+import org.maproulette.Config
+import org.maproulette.framework.model.{Location, OSMProfile, User}
+import org.maproulette.framework.service.{ServiceManager, UserService}
+import org.maproulette.models.dal.DALManager
+import org.maproulette.permissions.Permission
+import org.maproulette.session.SessionManager
+import org.maproulette.utils.Crypto
+import org.mockito.ArgumentMatchers.{any, eq => eqM}
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import play.api.Configuration
+import play.api.db.Database
+import play.api.libs.ws.WSClient
+import play.api.mvc.ControllerComponents
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class UserControllerSpec extends PlaySpec with MockitoSugar {
+  implicit val configuration: Configuration = Configuration.from(
+    Map(
+      "maproulette.secret.key"         -> "test-secret-key",
+      Config.KEY_OSM_SERVER            -> "http://localhost",
+      Config.KEY_OSM_USER_DETAILS_URL  -> "/api/0.6/user/details",
+      Config.KEY_OSM_REQUEST_TOKEN_URL -> "/oauth/request_token",
+      Config.KEY_OSM_ACCESS_TOKEN_URL  -> "/oauth/access_token",
+      Config.KEY_OSM_AUTHORIZATION_URL -> "/oauth/authorize",
+      Config.KEY_OSM_CONSUMER_KEY      -> "test",
+      Config.KEY_OSM_CONSUMER_SECRET   -> "test",
+      Config.KEY_OSM_OAUTH2_SCOPE      -> "read_prefs"
+    )
+  )
+  val config: Config = new Config()
+  val crypto: Crypto = new Crypto(config)
+
+  val rawApiKey: String       = "test-api-key"
+  val encryptedApiKey: String = crypto.encrypt(rawApiKey)
+  val testUser: User = User(
+    12345,
+    DateTime.now(),
+    DateTime.now(),
+    OSMProfile(54321, "TestUser", "Test User", "", Location(1.0, 2.0), DateTime.now(), "token"),
+    List.empty,
+    Some(encryptedApiKey)
+  )
+
+  // The oauth2 access token as found in the "token" field of the PLAY_SESSION cookie
+  val sessionToken: String = "3mxmGvQeLOg6YmT5rXo4Arx081-4N_xaYMYEVfM898U"
+
+  val userService: UserService       = mock[UserService]
+  val serviceManager: ServiceManager = mock[ServiceManager]
+  when(serviceManager.user).thenReturn(userService)
+  when(userService.retrieveByAPIKey(any[Long], any[String], any[User])).thenReturn(None)
+  when(userService.retrieveByAPIKey(eqM(testUser.id), eqM(encryptedApiKey), any[User]))
+    .thenReturn(Some(testUser))
+  when(userService.matchByRequestToken(any[Long], any[String], any[User])).thenReturn(None)
+  when(userService.matchByRequestToken(eqM(testUser.id), eqM(sessionToken), any[User]))
+    .thenReturn(Some(testUser))
+
+  val permission: Permission = mock[Permission]
+  val sessionManager: SessionManager = new SessionManager(
+    mock[WSClient],
+    mock[DALManager],
+    serviceManager,
+    config,
+    mock[Database],
+    crypto,
+    permission
+  )
+
+  val components: ControllerComponents = stubControllerComponents()
+  val controller = new UserController(
+    serviceManager,
+    sessionManager,
+    components,
+    components.parsers,
+    crypto,
+    permission
+  )
+
+  // Builds a request carrying the session attributes that Play would decode from the
+  // PLAY_SESSION cookie's data block: {token, userId, osmId, userTick}
+  private def sessionRequest(
+      token: String,
+      tick: Long = DateTime.now().getMillis
+  ) =
+    FakeRequest(GET, "/user/whoami").withSession(
+      SessionManager.KEY_TOKEN     -> token,
+      SessionManager.KEY_USER_ID   -> testUser.id.toString,
+      SessionManager.KEY_OSM_ID    -> testUser.osmProfile.id.toString,
+      SessionManager.KEY_USER_TICK -> tick.toString
+    )
+
+  "GET /user/whoami" should {
+    "return 401 when no credentials are provided" in {
+      val result = controller.whoami()(FakeRequest(GET, "/user/whoami"))
+      status(result) mustEqual UNAUTHORIZED
+      (contentAsJson(result) \ "status").validate[String].get mustEqual "NotAuthorized"
+    }
+
+    "return 401 when the apiKey does not match a user" in {
+      val request =
+        FakeRequest(GET, "/user/whoami").withHeaders("apiKey" -> s"${testUser.id}|unknown-key")
+      status(controller.whoami()(request)) mustEqual UNAUTHORIZED
+    }
+
+    "return 401 when the apiKey has the wrong user id" in {
+      val request =
+        FakeRequest(GET, "/user/whoami").withHeaders("apiKey" -> s"99999|$rawApiKey")
+      status(controller.whoami()(request)) mustEqual UNAUTHORIZED
+    }
+
+    "return 401 when the apiKey is malformed" in {
+      val missingSeparator =
+        FakeRequest(GET, "/user/whoami").withHeaders("apiKey" -> "no-separator")
+      status(controller.whoami()(missingSeparator)) mustEqual UNAUTHORIZED
+
+      val nonNumericId =
+        FakeRequest(GET, "/user/whoami").withHeaders("apiKey" -> s"not-a-number|$rawApiKey")
+      status(controller.whoami()(nonNumericId)) mustEqual UNAUTHORIZED
+    }
+
+    "return 200 with the user when a valid apiKey is provided" in {
+      val request = FakeRequest(GET, "/user/whoami")
+        .withHeaders("apiKey" -> s"${testUser.id}|$rawApiKey")
+      val result = controller.whoami()(request)
+
+      status(result) mustEqual OK
+      contentType(result) mustEqual Some("application/json")
+      val json = contentAsJson(result)
+      (json \ "id").validate[Long].get mustEqual testUser.id
+      (json \ "osmProfile" \ "id").validate[Long].get mustEqual testUser.osmProfile.id
+      (json \ "osmProfile" \ "displayName").validate[String].get mustEqual
+        testUser.osmProfile.displayName
+      // whoami returns the user's api key in decrypted form
+      (json \ "apiKey").validate[String].get mustEqual s"${testUser.id}|$rawApiKey"
+    }
+
+    "return 200 with the user when a valid session is provided" in {
+      val result = controller.whoami()(sessionRequest(sessionToken))
+
+      status(result) mustEqual OK
+      val json = contentAsJson(result)
+      (json \ "id").validate[Long].get mustEqual testUser.id
+      (json \ "osmProfile" \ "id").validate[Long].get mustEqual testUser.osmProfile.id
+    }
+
+    "return 401 when the session token does not match a user" in {
+      val result = controller.whoami()(sessionRequest("unknown-session-token"))
+      status(result) mustEqual UNAUTHORIZED
+    }
+
+    "return 401 when the session userTick has expired" in {
+      val expiredTick = DateTime.now().minusHours(2).getMillis
+      val result      = controller.whoami()(sessionRequest(sessionToken, expiredTick))
+      status(result) mustEqual UNAUTHORIZED
+    }
+  }
+}

--- a/test/org/maproulette/framework/service/UserServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserServiceSpec.scala
@@ -445,8 +445,10 @@ class UserServiceSpec(implicit val application: Application) extends FrameworkHe
     "get user mappers for challenge" in {
       val result = this.userService.getChallengeMappers(randomChallenge.id)
 
+      // getChallengeMappers makes no ordering guarantee, so assert membership rather
+      // than relying on a specific row order (which differs across Postgres instances).
       result.size mustEqual 2
-      result.head.id mustEqual randomUser.id
+      result.map(_.id) must contain(randomUser.id)
     }
 
     "complex query" in {

--- a/test/org/maproulette/models/dal/TaskDALSpec.scala
+++ b/test/org/maproulette/models/dal/TaskDALSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.models.dal
+
+import org.maproulette.framework.repository.TaskRepository
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsString, Json}
+
+class TaskDALSpec extends PlaySpec with MockitoSugar {
+  val taskDAL: TaskDAL =
+    new TaskDAL(null, null, null, null, mock[TaskRepository], null, null, null, null)
+
+  private val busStopFeature = Json.obj(
+    "type" -> "Feature",
+    "geometry" -> Json
+      .obj("type" -> "Point", "coordinates" -> Json.arr(-111.8653810, 40.7123196)),
+    "properties" -> Json.obj("name" -> "900 E @ 2709 S", "highway" -> "bus_stop")
+  )
+
+  "pruneMapRouletteProperties" should {
+    "handle a features array built with Json.arr" in {
+      // Regression test for #1243: Json.arr is array-backed rather than
+      // ArrayBuffer-backed, and the previous implementation cast the mapped
+      // sequence to ArrayBuffer, throwing ClassCastException
+      val geometries =
+        Json.obj("type" -> "FeatureCollection", "features" -> Json.arr(busStopFeature))
+
+      val result = taskDAL.pruneMapRouletteProperties(geometries)
+
+      result.value.size mustEqual 1
+      result.value.head mustEqual busStopFeature
+    }
+
+    "handle a features array parsed from a JSON string" in {
+      val geometries = Json
+        .parse(
+          s"""{"type": "FeatureCollection", "features": [${Json.stringify(busStopFeature)}]}"""
+        )
+        .as[play.api.libs.json.JsObject]
+
+      val result = taskDAL.pruneMapRouletteProperties(geometries)
+
+      result.value.size mustEqual 1
+      result.value.head mustEqual busStopFeature
+    }
+
+    "prune the maproulette object from feature properties" in {
+      val cooperativeFeature = busStopFeature ++ Json.obj(
+        "properties" -> Json.obj(
+          "name"        -> "900 E @ 2709 S",
+          "maproulette" -> Json.obj("cooperativeWork" -> Json.obj("meta" -> Json.obj()))
+        )
+      )
+      val geometries =
+        Json.obj("type" -> "FeatureCollection", "features" -> Json.arr(cooperativeFeature))
+
+      val result = taskDAL.pruneMapRouletteProperties(geometries)
+
+      result.value.size mustEqual 1
+      (result.value.head \ "properties" \ "maproulette").toOption mustEqual None
+      (result.value.head \ "properties" \ "name").as[String] mustEqual "900 E @ 2709 S"
+    }
+
+    "drop non-object entries from the features array" in {
+      val geometries = Json.obj(
+        "type"     -> "FeatureCollection",
+        "features" -> Json.arr(JsString("not-a-feature"), busStopFeature)
+      )
+
+      val result = taskDAL.pruneMapRouletteProperties(geometries)
+
+      result.value.size mustEqual 1
+      result.value.head mustEqual busStopFeature
+    }
+
+    "return an empty array when there are no features" in {
+      val geometries = Json.obj("type" -> "FeatureCollection", "features" -> Json.arr())
+      taskDAL.pruneMapRouletteProperties(geometries).value mustBe empty
+    }
+  }
+}

--- a/test/org/maproulette/provider/ChallengeProviderSpec.scala
+++ b/test/org/maproulette/provider/ChallengeProviderSpec.scala
@@ -1,10 +1,23 @@
 import org.joda.time.DateTime
+import org.maproulette.Config
 import org.maproulette.framework.model._
+import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
 import org.maproulette.provider.ChallengeProvider
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.{any, eq => eqM}
+import org.mockito.Mockito.{doAnswer, never, timeout, verify, when}
+import org.mockito.invocation.InvocationOnMock
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
+import play.api.db.Database
 import play.api.libs.json._
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
+import java.sql.Connection
 import java.util.UUID
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.jdk.CollectionConverters._
 
 class ChallengeProviderSpec extends PlaySpec with MockitoSugar {
   val repository: ChallengeProvider = new ChallengeProvider(null, null, null, null, null)
@@ -220,6 +233,269 @@ class ChallengeProviderSpec extends PlaySpec with MockitoSugar {
       val json   = Json.obj("features" -> Json.arr(Json.obj("name" -> ""), Json.obj("name" -> null)))
       val result = repository.taskNameFromJsValue(json, challengeWithoutOsmId)
       assert(UUID.fromString(result).toString == result)
+    }
+  }
+
+  private val providerURL = "https://overpass.example/api/interpreter"
+  implicit val configuration: Configuration = Configuration.from(
+    Map(Config.KEY_OSM_QL_PROVIDER -> providerURL)
+  )
+  val config: Config = new Config()
+
+  val overpassQuery: String =
+    """[out:json]
+      |area[name="Salt Lake City"]->.a;
+      |node[highway=bus_stop](area.a);
+      |out 5;""".stripMargin
+
+  val overpassResponse: JsValue = Json.parse(
+    """
+    {
+      "version": 0.6,
+      "generator": "Overpass API 0.7.62.11 87bfad18",
+      "osm3s": {
+        "timestamp_osm_base": "2026-06-10T08:49:00Z",
+        "timestamp_areas_base": "2026-05-12T07:36:16Z",
+        "copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."
+      },
+      "elements": [
+        {
+          "type": "node",
+          "id": 566529047,
+          "lat": 40.7123196,
+          "lon": -111.8653810,
+          "tags": {
+            "bench": "no",
+            "bin": "no",
+            "bus": "yes",
+            "highway": "bus_stop",
+            "lit": "yes",
+            "name": "900 E @ 2709 S",
+            "network": "UTA",
+            "network:wikidata": "Q7902494",
+            "operator": "UTA",
+            "public_transport": "platform",
+            "ref": "137020",
+            "shelter": "no",
+            "tactile_paving": "no"
+          }
+        },
+        {
+          "type": "node",
+          "id": 946351389,
+          "lat": 40.7752891,
+          "lon": -111.8776585,
+          "tags": {
+            "bench": "no",
+            "bin": "no",
+            "bus": "yes",
+            "highway": "bus_stop",
+            "lit": "no",
+            "name": "E Street / 5th Avenue (SB)",
+            "network": "UTA",
+            "network:wikidata": "Q7902494",
+            "operator": "Utah Transit Authority",
+            "public_transport": "platform",
+            "ref": "102138",
+            "shelter": "yes",
+            "tactile_paving": "no"
+          }
+        },
+        {
+          "type": "node",
+          "id": 1226596568,
+          "lat": 40.7628224,
+          "lon": -111.9081310,
+          "tags": {
+            "bench": "no",
+            "bin": "yes",
+            "bus": "yes",
+            "fixme": "ref? location? stop does not exist in UTA data",
+            "highway": "bus_stop",
+            "name": "300 S / 600 W",
+            "network": "UTA",
+            "network:wikidata": "Q7902494",
+            "operator": "UTA",
+            "public_transport": "platform",
+            "route_ref": "220",
+            "shelter": "no",
+            "tactile_paving": "no"
+          }
+        },
+        {
+          "type": "node",
+          "id": 1399278912,
+          "lat": 40.7727570,
+          "lon": -111.8582420,
+          "tags": {
+            "bench": "no",
+            "bus": "yes",
+            "highway": "bus_stop",
+            "name": "3rd Avenue / R Street (EB)",
+            "network": "UTA",
+            "network:wikidata": "Q7902494",
+            "operator": "Utah Transit Authority",
+            "public_transport": "platform",
+            "ref": "118030",
+            "shelter": "no",
+            "tactile_paving": "no"
+          }
+        },
+        {
+          "type": "node",
+          "id": 1399429828,
+          "lat": 40.7805895,
+          "lon": -111.8604573,
+          "tags": {
+            "bench": "no",
+            "bus": "yes",
+            "highway": "bus_stop",
+            "name": "11th Avenue / Cemetery Center Street (EB)",
+            "network": "UTA",
+            "network:wikidata": "Q7902494",
+            "operator": "Utah Transit Authority",
+            "public_transport": "platform",
+            "ref": "118189",
+            "shelter": "no"
+          }
+        }
+      ]
+    }
+    """
+  )
+
+  val overpassChallenge: Challenge = Challenge(
+    100,
+    "OverpassBusStops",
+    DateTime.now(),
+    DateTime.now(),
+    None,
+    false,
+    false,
+    false,
+    false,
+    None,
+    ChallengeGeneral(101, 1, ""),
+    ChallengeCreation(overpassQL = Some(overpassQuery)),
+    ChallengePriority(),
+    ChallengeExtra()
+  )
+
+  val user: User = User.superUser
+
+  // Fresh mocks per test so the async verifications cannot interfere with each other
+  private class OverpassFixture(
+      status: Int = 200,
+      contentType: Option[String] = Some("application/json"),
+      responseBody: String = ""
+  ) {
+    val ws: WSClient               = mock[WSClient]
+    val wsRequest: WSRequest       = mock[WSRequest]
+    val wsResponse: WSResponse     = mock[WSResponse]
+    val challengeDAL: ChallengeDAL = mock[ChallengeDAL]
+    val taskDAL: TaskDAL           = mock[TaskDAL]
+    val db: Database               = mock[Database]
+
+    when(ws.url(any[String])).thenReturn(wsRequest)
+    when(wsRequest.withRequestTimeout(any[Duration])).thenReturn(wsRequest)
+    when(wsRequest.post(any[String])(any())).thenReturn(Future.successful(wsResponse))
+    when(wsResponse.status).thenReturn(status)
+    when(wsResponse.statusText).thenReturn("statusText")
+    when(wsResponse.header("Content-Type")).thenReturn(contentType)
+    when(wsResponse.json).thenReturn(overpassResponse)
+    when(wsResponse.body).thenReturn(responseBody)
+    doAnswer { (invocation: InvocationOnMock) =>
+      invocation.getArgument(0).asInstanceOf[Connection => Any](mock[Connection])
+    }.when(db).withTransaction(any[Connection => Any])
+
+    val provider = new ChallengeProvider(challengeDAL, taskDAL, config, ws, db)
+  }
+
+  "buildTasks with an overpass query" should {
+    "post the query unmodified to the configured overpass provider" in new OverpassFixture {
+      provider.buildTasks(user, overpassChallenge) mustEqual true
+
+      val queryCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+      verify(wsRequest, timeout(5000)).post(queryCaptor.capture())(any())
+      // this query already contains [out:json], so rewriteQuery must pass it through untouched
+      queryCaptor.getValue mustEqual overpassQuery
+
+      verify(ws).url(providerURL)
+      // no [timeout:N] in the query, so the configured default applies
+      verify(wsRequest).withRequestTimeout(Duration(Config.DEFAULT_OSM_QL_TIMEOUT, "seconds"))
+    }
+
+    "create a task for each element in the overpass response" in new OverpassFixture {
+      provider.buildTasks(user, overpassChallenge)
+
+      val taskCaptor: ArgumentCaptor[Task] = ArgumentCaptor.forClass(classOf[Task])
+      verify(taskDAL, timeout(5000).times(5))
+        .mergeUpdate(taskCaptor.capture(), eqM(user))(any[Long], any[Option[Connection]])
+
+      val tasks = taskCaptor.getAllValues.asScala
+      tasks.map(_.name) must contain theSameElementsAs List(
+        "566529047",
+        "946351389",
+        "1226596568",
+        "1399278912",
+        "1399429828"
+      )
+      tasks.foreach(_.parent mustEqual overpassChallenge.id)
+
+      val feature = (tasks.find(_.name == "566529047").get.geometries \ "features")(0)
+      (feature \ "geometry" \ "type").as[String] mustEqual "Point"
+      (feature \ "geometry" \ "coordinates").as[List[Double]] mustEqual
+        List(-111.8653810, 40.7123196)
+      (feature \ "properties" \ "name").as[String] mustEqual "900 E @ 2709 S"
+      (feature \ "properties" \ "highway").as[String] mustEqual "bus_stop"
+      (feature \ "properties" \ "osmid").as[String] mustEqual "566529047"
+    }
+
+    "mark the challenge as ready once all tasks are built" in new OverpassFixture {
+      provider.buildTasks(user, overpassChallenge)
+
+      val updateCaptor: ArgumentCaptor[JsValue] = ArgumentCaptor.forClass(classOf[JsValue])
+      verify(challengeDAL, timeout(5000).times(3))
+        .update(updateCaptor.capture(), eqM(user))(eqM(overpassChallenge.id), any())
+      val statuses = updateCaptor.getAllValues.asScala.map(json => (json \ "status").as[Int])
+      statuses.take(2) mustEqual List(Challenge.STATUS_BUILDING, Challenge.STATUS_BUILDING)
+      statuses.last mustEqual Challenge.STATUS_READY
+
+      verify(challengeDAL).markTasksRefreshed(eqM(true), any())(eqM(overpassChallenge.id), any())
+      verify(challengeDAL).updateBoundingBox()(eqM(overpassChallenge.id), any())
+      verify(challengeDAL)
+        .updateFinishedStatus(eqM(true), eqM(user))(eqM(overpassChallenge.id), any())
+    }
+
+    "fail the challenge when overpass returns a non-JSON content type" in new OverpassFixture(
+      contentType = Some("text/csv")
+    ) {
+      provider.buildTasks(user, overpassChallenge)
+
+      val updateCaptor: ArgumentCaptor[JsValue] = ArgumentCaptor.forClass(classOf[JsValue])
+      verify(challengeDAL, timeout(5000).times(3))
+        .update(updateCaptor.capture(), eqM(user))(eqM(overpassChallenge.id), any())
+      val lastUpdate = updateCaptor.getAllValues.asScala.last
+      (lastUpdate \ "status").as[Int] mustEqual Challenge.STATUS_FAILED
+      (lastUpdate \ "statusMessage").as[String] must include("Content-Type: text/csv")
+
+      verify(taskDAL, never()).mergeUpdate(any(), any())(any(), any())
+    }
+
+    "fail the challenge with a friendly message when overpass is too busy" in new OverpassFixture(
+      status = 504,
+      responseBody = "<html><strong>Error</strong>runtime error</html>"
+    ) {
+      provider.buildTasks(user, overpassChallenge)
+
+      val updateCaptor: ArgumentCaptor[JsValue] = ArgumentCaptor.forClass(classOf[JsValue])
+      verify(challengeDAL, timeout(5000).times(3))
+        .update(updateCaptor.capture(), eqM(user))(eqM(overpassChallenge.id), any())
+      val lastUpdate = updateCaptor.getAllValues.asScala.last
+      (lastUpdate \ "status").as[Int] mustEqual Challenge.STATUS_FAILED
+      (lastUpdate \ "statusMessage").as[String] must include("too busy or timed out")
+
+      verify(taskDAL, never()).mergeUpdate(any(), any())(any(), any())
     }
   }
 }


### PR DESCRIPTION
Create a few test cases to get familiar with the framework and a more complex test to start validating overpass (via a mocked request).

- Service info endpoint: verify build and runtime info is returned
- User whoami: cover valid apiKey, session, and rejection auth paths
- Task geometry pruning: regression test for ClassCastException on Json.arr-backed arrays (#1243)
- Overpass challenge building: success, wrong content-type, and 504 busy-server failure paths