### PR TITLE
Use a separate DB connection pool and execution context for task rebuilding

### DIFF
--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -536,185 +536,181 @@ class ChallengeProvider @Inject() (
                 )
               }
 
-              this.db.withTransaction { implicit c =>
-                var partial          = false
-                val payload          = result.json
-                var targetTypeFailed = false
+              var partial          = false
+              val payload          = result.json
+              var targetTypeFailed = false
 
-                // parse the results. Overpass has its own format and is not geojson
-                val elements = (payload \ "elements").as[List[JsValue]]
-                try {
-                  elements.foreach { element =>
-                    // Verify target type if we are given one.
-                    challenge.creation.overpassTargetType match {
-                      case Some(targetType) if StringUtils.isNotEmpty(targetType) =>
-                        (element \ "type").asOpt[String] match {
-                          case Some("way") =>
-                            if (targetType != "way") {
-                              targetTypeFailed = true
-                              throw new InvalidException(
-                                "Element type 'way' does not match target type of '" + targetType + "'"
-                              )
-                            }
-                          case Some("relation") =>
-                            if (targetType != "relation") {
-                              targetTypeFailed = true
-                              throw new InvalidException(
-                                "Element type 'relation' does not match target type of '" + targetType + "'"
-                              )
-                            }
-                          case Some("node") =>
-                            if (targetType != "node") {
-                              targetTypeFailed = true
-                              throw new InvalidException(
-                                "Element type 'node' does not match target type of '" + targetType + "'"
-                              )
-                            }
-                          case x =>
+              // parse the results. Overpass has its own format and is not geojson
+              val elements = (payload \ "elements").as[List[JsValue]]
+              try {
+                elements.foreach { element =>
+                  // Verify target type if we are given one.
+                  challenge.creation.overpassTargetType match {
+                    case Some(targetType) if StringUtils.isNotEmpty(targetType) =>
+                      (element \ "type").asOpt[String] match {
+                        case Some("way") =>
+                          if (targetType != "way") {
                             targetTypeFailed = true
                             throw new InvalidException(
-                              "Element type " + x + " does not match target type of '" + targetType + "'"
+                              "Element type 'way' does not match target type of '" + targetType + "'"
                             )
-                        }
-                      case _ => // do not validate
-                    }
+                          }
+                        case Some("relation") =>
+                          if (targetType != "relation") {
+                            targetTypeFailed = true
+                            throw new InvalidException(
+                              "Element type 'relation' does not match target type of '" + targetType + "'"
+                            )
+                          }
+                        case Some("node") =>
+                          if (targetType != "node") {
+                            targetTypeFailed = true
+                            throw new InvalidException(
+                              "Element type 'node' does not match target type of '" + targetType + "'"
+                            )
+                          }
+                        case x =>
+                          targetTypeFailed = true
+                          throw new InvalidException(
+                            "Element type " + x + " does not match target type of '" + targetType + "'"
+                          )
+                      }
+                    case _ => // do not validate
+                  }
 
-                    try {
-                      val geometry = (element \ "center").asOpt[JsObject] match {
-                        case Some(center) =>
-                          Some(
-                            Json.obj(
-                              "type" -> "Point",
-                              "coordinates" -> List(
-                                (center \ "lon").as[Double],
-                                (center \ "lat").as[Double]
-                              )
+                  try {
+                    val geometry = (element \ "center").asOpt[JsObject] match {
+                      case Some(center) =>
+                        Some(
+                          Json.obj(
+                            "type" -> "Point",
+                            "coordinates" -> List(
+                              (center \ "lon").as[Double],
+                              (center \ "lat").as[Double]
                             )
                           )
-                        case None =>
-                          (element \ "type").asOpt[String] match {
-                            case Some("way") =>
-                              // TODO: ways do not have a "geometry" property, instead they have a list of "nodes"
-                              // referencing other elements in the array. So this code does not do the job.
-                              val points = (element \ "geometry").as[List[JsValue]].map { geom =>
-                                List((geom \ "lon").as[Double], (geom \ "lat").as[Double])
-                              }
-                              Some(Json.obj("type" -> "LineString", "coordinates" -> points))
-                            case Some("relation") =>
-                              // Function to recursively extract geometries from relations
-                              def extractGeometries(member: JsValue): Option[JsObject] = {
-                                (member \ "type").asOpt[String] match {
-                                  case Some("way") =>
-                                    val points = (member \ "geometry").as[List[JsValue]].map {
-                                      geom =>
-                                        List((geom \ "lon").as[Double], (geom \ "lat").as[Double])
-                                    }
-                                    Some(Json.obj("type" -> "LineString", "coordinates" -> points))
+                        )
+                      case None =>
+                        (element \ "type").asOpt[String] match {
+                          case Some("way") =>
+                            // TODO: ways do not have a "geometry" property, instead they have a list of "nodes"
+                            // referencing other elements in the array. So this code does not do the job.
+                            val points = (element \ "geometry").as[List[JsValue]].map { geom =>
+                              List((geom \ "lon").as[Double], (geom \ "lat").as[Double])
+                            }
+                            Some(Json.obj("type" -> "LineString", "coordinates" -> points))
+                          case Some("relation") =>
+                            // Function to recursively extract geometries from relations
+                            def extractGeometries(member: JsValue): Option[JsObject] = {
+                              (member \ "type").asOpt[String] match {
+                                case Some("way") =>
+                                  val points = (member \ "geometry").as[List[JsValue]].map { geom =>
+                                    List((geom \ "lon").as[Double], (geom \ "lat").as[Double])
+                                  }
+                                  Some(Json.obj("type" -> "LineString", "coordinates" -> points))
 
-                                  case Some("node") =>
-                                    Some(
-                                      Json.obj(
-                                        "type" -> "Point",
-                                        "coordinates" -> List(
-                                          (member \ "lon").as[Double],
-                                          (member \ "lat").as[Double]
-                                        )
+                                case Some("node") =>
+                                  Some(
+                                    Json.obj(
+                                      "type" -> "Point",
+                                      "coordinates" -> List(
+                                        (member \ "lon").as[Double],
+                                        (member \ "lat").as[Double]
                                       )
                                     )
-
-                                  case Some("relation") =>
-                                    // If it's another relation, recursively extract geometries from it
-                                    val geometries = (member \ "members").as[List[JsValue]].map {
-                                      member =>
-                                        extractGeometries(member)
-                                    }
-                                    val geometryCollection = Json.obj(
-                                      "type"       -> "GeometryCollection",
-                                      "geometries" -> geometries
-                                    )
-
-                                    Some(geometryCollection)
-
-                                  case _ =>
-                                    None
-                                }
-                              }
-
-                              // Extract geometries from each member of the relation
-                              val geometries = (element \ "members").as[List[JsValue]].map {
-                                member =>
-                                  extractGeometries(member)
-                              }
-
-                              // Create a GeometryCollection
-                              val geometryCollection = Json.obj(
-                                "type"       -> "GeometryCollection",
-                                "geometries" -> geometries
-                              )
-
-                              Some(geometryCollection)
-
-                            case Some("node") =>
-                              Some(
-                                Json.obj(
-                                  "type" -> "Point",
-                                  "coordinates" -> List(
-                                    (element \ "lon").as[Double],
-                                    (element \ "lat").as[Double]
                                   )
+
+                                case Some("relation") =>
+                                  // If it's another relation, recursively extract geometries from it
+                                  val geometries = (member \ "members").as[List[JsValue]].map {
+                                    member =>
+                                      extractGeometries(member)
+                                  }
+                                  val geometryCollection = Json.obj(
+                                    "type"       -> "GeometryCollection",
+                                    "geometries" -> geometries
+                                  )
+
+                                  Some(geometryCollection)
+
+                                case _ =>
+                                  None
+                              }
+                            }
+
+                            // Extract geometries from each member of the relation
+                            val geometries = (element \ "members").as[List[JsValue]].map { member =>
+                              extractGeometries(member)
+                            }
+
+                            // Create a GeometryCollection
+                            val geometryCollection = Json.obj(
+                              "type"       -> "GeometryCollection",
+                              "geometries" -> geometries
+                            )
+
+                            Some(geometryCollection)
+
+                          case Some("node") =>
+                            Some(
+                              Json.obj(
+                                "type" -> "Point",
+                                "coordinates" -> List(
+                                  (element \ "lon").as[Double],
+                                  (element \ "lat").as[Double]
                                 )
                               )
-                            case _ => None
-                          }
-                      }
-
-                      geometry match {
-                        case Some(geom) =>
-                          this.createNewTask(
-                            user,
-                            s"${(element \ "id").as[Long]}",
-                            challenge,
-                            geom,
-                            Utils.getProperties(element, "tags")
-                          )
-                        case None => None
-                      }
-                    } catch {
-                      case e: Exception =>
-                        partial = true
-                        logger.error(
-                          s"Failed to build overpass task for challenge ${challenge.id}: ${e.getMessage}",
-                          e
-                        )
+                            )
+                          case _ => None
+                        }
                     }
-                  }
-                  partial match {
-                    case true =>
-                      this.challengeDAL.update(
-                        Json.obj("status" -> Challenge.STATUS_PARTIALLY_LOADED),
-                        user
-                      )(challenge.id)
-                    case false =>
-                      this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(
-                        challenge.id
+
+                    geometry match {
+                      case Some(geom) =>
+                        this.createNewTask(
+                          user,
+                          s"${(element \ "id").as[Long]}",
+                          challenge,
+                          geom,
+                          Utils.getProperties(element, "tags")
+                        )
+                      case None => None
+                    }
+                  } catch {
+                    case e: Exception =>
+                      partial = true
+                      logger.error(
+                        s"Failed to build overpass task for challenge ${challenge.id}: ${e.getMessage}",
+                        e
                       )
-                      this.challengeDAL.markTasksRefreshed(true)(challenge.id)
-                      this.challengeDAL.updateBoundingBox()(challenge.id)
-                      // If no tasks were created by this overpass query or all tasks are
-                      // fixed, then we need to update the status to finished.
-                      this.challengeDAL.updateFinishedStatus(true, user = user)(challenge.id)
                   }
-                } catch {
-                  case e: Exception =>
+                }
+                partial match {
+                  case true =>
                     this.challengeDAL.update(
-                      Json.obj(
-                        "status"        -> Challenge.STATUS_FAILED,
-                        "statusMessage" -> s"${e.getMessage}"
-                      ),
+                      Json.obj("status" -> Challenge.STATUS_PARTIALLY_LOADED),
                       user
                     )(challenge.id)
-                    throw e
+                  case false =>
+                    this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(
+                      challenge.id
+                    )
+                    this.challengeDAL.markTasksRefreshed(true)(challenge.id)
+                    this.challengeDAL.updateBoundingBox()(challenge.id)
+                    // If no tasks were created by this overpass query or all tasks are
+                    // fixed, then we need to update the status to finished.
+                    this.challengeDAL.updateFinishedStatus(true, user = user)(challenge.id)
                 }
+              } catch {
+                case e: Exception =>
+                  this.challengeDAL.update(
+                    Json.obj(
+                      "status"        -> Challenge.STATUS_FAILED,
+                      "statusMessage" -> s"${e.getMessage}"
+                    ),
+                    user
+                  )(challenge.id)
+                  throw e
               }
             } else {
               // Handle non-OK responses (timeouts, errors, etc.)

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -4,6 +4,7 @@
  */
 package org.maproulette.provider
 
+import java.sql.Connection
 import java.util.UUID
 import javax.inject.{Inject, Singleton}
 import org.apache.commons.lang3.StringUtils
@@ -14,7 +15,7 @@ import org.maproulette.framework.model.{Challenge, Task, User}
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
 import org.maproulette.utils.Utils
 import org.slf4j.LoggerFactory
-import play.api.db.Database
+import play.api.db.{Database, NamedDatabase}
 import play.api.http.Status
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -32,14 +33,25 @@ class ChallengeProvider @Inject() (
     taskDAL: TaskDAL,
     config: Config,
     ws: WSClient,
-    db: Database
-) extends DefaultReads {
-
-  import scala.concurrent.ExecutionContext.Implicits.global
+    db: Database,
+    @NamedDatabase("background") backgroundDb: Database
+)(implicit ec: TaskBuilderExecutionContext)
+    extends DefaultReads {
 
   private val RS = 0x1E.toChar // RS (record separator) control character
 
   private val logger = LoggerFactory.getLogger(this.getClass)
+
+  /**
+    * Runs a block using a connection borrowed from the dedicated background
+    * pool so that heavy, long-held build operations (e.g. bulk task deletes,
+    * recomputing task priorities) don't draw from the default pool, which can
+    * starve normal HTTP requests and cause 503 errors.
+    */
+  private def withBackgroundPool[T](block: Option[Connection] => T): T =
+    this.backgroundDb.withConnection { c =>
+      block(Some(c))
+    }
 
   def rebuildTasks(user: User, challenge: Challenge, removeUnmatched: Boolean = false): Boolean =
     this.buildTasks(user, challenge, None, removeUnmatched)
@@ -55,7 +67,9 @@ class ChallengeProvider @Inject() (
       Future {
         logger.debug("Creating tasks for overpass query: " + challenge.creation.overpassQL.get)
         if (removeUnmatched) {
-          this.challengeDAL.removeIncompleteTasks(user)(challenge.id)
+          this.withBackgroundPool { c =>
+            this.challengeDAL.removeIncompleteTasks(user)(challenge.id, c)
+          }
         }
 
         this.buildOverpassQLTasks(challenge, user)
@@ -77,7 +91,9 @@ class ChallengeProvider @Inject() (
           )
           Future {
             if (removeUnmatched) {
-              this.challengeDAL.removeIncompleteTasks(user)(challenge.id)
+              this.withBackgroundPool { c =>
+                this.challengeDAL.removeIncompleteTasks(user)(challenge.id, c)
+              }
             }
 
             if (isLineByLineGeoJson(splitJson)) {
@@ -117,8 +133,10 @@ class ChallengeProvider @Inject() (
 
             //we need to reapply task priority rules since task locations were updated
             Future {
-              this.challengeDAL.updateTaskPriorities(user)(challenge.id)
-              this.challengeDAL.updateBoundingBox()(challenge.id)
+              this.withBackgroundPool { c =>
+                this.challengeDAL.updateTaskPriorities(user)(challenge.id, c)
+                this.challengeDAL.updateBoundingBox()(challenge.id, c)
+              }
             }
           }.recover {
             case e: Exception =>
@@ -218,7 +236,9 @@ class ChallengeProvider @Inject() (
   ): Unit = {
     this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_BUILDING), user)(challenge.id)
     if (removeUnmatched) {
-      this.challengeDAL.removeIncompleteTasks(user)(challenge.id)
+      this.withBackgroundPool { c =>
+        this.challengeDAL.removeIncompleteTasks(user)(challenge.id, c)
+      }
     }
 
     val url     = filePrefix.replace("{x}", fileNumber.toString)
@@ -283,8 +303,10 @@ class ChallengeProvider @Inject() (
 
           //we need to reapply task priority rules since task locations were updated
           Future {
-            this.challengeDAL.updateTaskPriorities(user)(challenge.id)
-            this.challengeDAL.updateBoundingBox()(challenge.id)
+            this.withBackgroundPool { c =>
+              this.challengeDAL.updateTaskPriorities(user)(challenge.id, c)
+              this.challengeDAL.updateBoundingBox()(challenge.id, c)
+            }
           }
         }
       case Failure(f) =>
@@ -800,7 +822,9 @@ class ChallengeProvider @Inject() (
       newTask: Task
   ): Option[Task] = {
     try {
-      this.taskDAL.mergeUpdate(newTask, user)(newTask.id)
+      this.withBackgroundPool { c =>
+        this.taskDAL.mergeUpdate(newTask, user)(newTask.id, c)
+      }
     } catch {
       // this task could fail on unique key violation, we need to ignore them
       case e: Exception =>

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -43,13 +43,13 @@ class ChallengeProvider @Inject() (
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   /**
-    * Runs a block using a connection borrowed from the dedicated background
-    * pool so that heavy, long-held build operations (e.g. bulk task deletes,
-    * recomputing task priorities) don't draw from the default pool, which can
-    * starve normal HTTP requests and cause 503 errors.
+    * Runs a block in a transaction on a connection borrowed from the dedicated
+    * background pool so that heavy, long-held build operations (e.g. bulk task
+    * deletes, recomputing task priorities) don't draw from the default pool,
+    * which can starve normal HTTP requests and cause 503 errors.
     */
   private def withBackgroundPool[T](block: Option[Connection] => T): T =
-    this.backgroundDb.withConnection { c =>
+    this.backgroundDb.withTransaction { c =>
       block(Some(c))
     }
 

--- a/app/org/maproulette/provider/TaskBuilderExecutionContext.scala
+++ b/app/org/maproulette/provider/TaskBuilderExecutionContext.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2026 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+package org.maproulette.provider
+
+import akka.actor.ActorSystem
+import javax.inject.{Inject, Singleton}
+import play.api.libs.concurrent.CustomExecutionContext
+
+/**
+  * Execution context for challenge task-building work. Using a separate dispatcher/EC
+  * means that bursts of requests to POST /challenge/:id/rebuild will queue up and use
+  * a fixed number of DB connections, rather than potentially exhausting the pool and
+  * preventing other requests from being served.
+  */
+@Singleton
+class TaskBuilderExecutionContext @Inject() (system: ActorSystem)
+    extends CustomExecutionContext(system, "akka.task-builder-dispatcher")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -50,6 +50,11 @@ db {
       maximumPoolSize = 30
     }
   }
+
+  # Connection pool for background (non-request) database work.
+  background = ${db.default} # inherit connection params from main db pool
+  background.hikaricp.maximumPoolSize = 8
+  background.hikaricp.maximumPoolSize = ${?MR_BACKGROUND_POOL_SIZE}
 }
 
 akka {
@@ -84,6 +89,18 @@ akka {
     }
   }
 
+  # Dedicated dispatcher for challenge task building (POST /challenge/:id/rebuild etc),
+  # used to cap the number of parallel task rebuild jobs that can be running at once.
+  task-builder-dispatcher {
+    type = Dispatcher
+    executor = "thread-pool-executor"
+    thread-pool-executor {
+      fixed-pool-size = 8
+      fixed-pool-size = ${?MR_TASK_BUILDER_THREADS}
+    }
+    throughput = 1
+  }
+
   remote.artery {
     canonical {
       hostname = "127.0.0.1"
@@ -99,6 +116,9 @@ play {
     autoApply = true
     autoApplyDowns = false
   }
+  # Migrations run automatically on the default pool; we need to disable them
+  # on other pools so that they don't run twice.
+  evolutions.db.background.enabled = false
   server {
     netty.transport = "native"
     https {

--- a/test/org/maproulette/provider/ChallengeProviderSpec.scala
+++ b/test/org/maproulette/provider/ChallengeProviderSpec.scala
@@ -2,7 +2,7 @@ import org.joda.time.DateTime
 import org.maproulette.Config
 import org.maproulette.framework.model._
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
-import org.maproulette.provider.ChallengeProvider
+import org.maproulette.provider.{ChallengeProvider, TaskBuilderExecutionContext}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, eq => eqM}
 import org.mockito.Mockito.{doAnswer, never, timeout, verify, when}
@@ -390,12 +390,14 @@ class ChallengeProviderSpec extends PlaySpec with MockitoSugar {
       contentType: Option[String] = Some("application/json"),
       responseBody: String = ""
   ) {
-    val ws: WSClient               = mock[WSClient]
-    val wsRequest: WSRequest       = mock[WSRequest]
-    val wsResponse: WSResponse     = mock[WSResponse]
-    val challengeDAL: ChallengeDAL = mock[ChallengeDAL]
-    val taskDAL: TaskDAL           = mock[TaskDAL]
-    val db: Database               = mock[Database]
+    val ws: WSClient                             = mock[WSClient]
+    val wsRequest: WSRequest                     = mock[WSRequest]
+    val wsResponse: WSResponse                   = mock[WSResponse]
+    val challengeDAL: ChallengeDAL               = mock[ChallengeDAL]
+    val taskDAL: TaskDAL                         = mock[TaskDAL]
+    val db: Database                             = mock[Database]
+    val backgroundDb: Database                   = mock[Database]
+    implicit val ec: TaskBuilderExecutionContext = mock[TaskBuilderExecutionContext]
 
     when(ws.url(any[String])).thenReturn(wsRequest)
     when(wsRequest.withRequestTimeout(any[Duration])).thenReturn(wsRequest)
@@ -408,8 +410,14 @@ class ChallengeProviderSpec extends PlaySpec with MockitoSugar {
     doAnswer { (invocation: InvocationOnMock) =>
       invocation.getArgument(0).asInstanceOf[Connection => Any](mock[Connection])
     }.when(db).withTransaction(any[Connection => Any])
+    doAnswer { (invocation: InvocationOnMock) =>
+      invocation.getArgument(0).asInstanceOf[Connection => Any](mock[Connection])
+    }.when(backgroundDb).withConnection(any[Connection => Any])
+    doAnswer { (invocation: InvocationOnMock) =>
+      invocation.getArgument(0).asInstanceOf[Runnable].run()
+    }.when(ec).execute(any[Runnable])
 
-    val provider = new ChallengeProvider(challengeDAL, taskDAL, config, ws, db)
+    val provider = new ChallengeProvider(challengeDAL, taskDAL, config, ws, db, backgroundDb)
   }
 
   "buildTasks with an overpass query" should {

--- a/test/org/maproulette/provider/ChallengeProviderSpec.scala
+++ b/test/org/maproulette/provider/ChallengeProviderSpec.scala
@@ -433,7 +433,7 @@ class ChallengeProviderSpec extends PlaySpec with MockitoSugar with BeforeAndAft
     }.when(db).withTransaction(any[Connection => Any])
     doAnswer { (invocation: InvocationOnMock) =>
       invocation.getArgument(0).asInstanceOf[Connection => Any](mock[Connection])
-    }.when(backgroundDb).withConnection(any[Connection => Any])
+    }.when(backgroundDb).withTransaction(any[Connection => Any])
 
     val provider = new ChallengeProvider(challengeDAL, taskDAL, config, ws, db, backgroundDb)
   }

--- a/test/org/maproulette/provider/ChallengeProviderSpec.scala
+++ b/test/org/maproulette/provider/ChallengeProviderSpec.scala
@@ -20,7 +20,8 @@ import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 
 class ChallengeProviderSpec extends PlaySpec with MockitoSugar {
-  val repository: ChallengeProvider = new ChallengeProvider(null, null, null, null, null)
+  val repository: ChallengeProvider =
+    new ChallengeProvider(null, null, null, null, null, null)(null)
 
   val challengeWithOsmId = Challenge(
     1,

--- a/test/org/maproulette/provider/ChallengeProviderSpec.scala
+++ b/test/org/maproulette/provider/ChallengeProviderSpec.scala
@@ -1,3 +1,5 @@
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import org.maproulette.Config
 import org.maproulette.framework.model._
@@ -7,6 +9,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, eq => eqM}
 import org.mockito.Mockito.{doAnswer, never, timeout, verify, when}
 import org.mockito.invocation.InvocationOnMock
+import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
@@ -19,9 +22,27 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 
-class ChallengeProviderSpec extends PlaySpec with MockitoSugar {
+class ChallengeProviderSpec extends PlaySpec with MockitoSugar with BeforeAndAfterAll {
+  private val actorSystem = ActorSystem(
+    "ChallengeProviderSpec",
+    ConfigFactory.parseString("""
+      |akka.task-builder-dispatcher {
+      |  type = Dispatcher
+      |  executor = "thread-pool-executor"
+      |  thread-pool-executor.fixed-pool-size = 4
+      |  throughput = 1
+      |}
+      |""".stripMargin)
+  )
+  private val testEc = new TaskBuilderExecutionContext(actorSystem)
+
+  override def afterAll(): Unit = {
+    actorSystem.terminate()
+    super.afterAll()
+  }
+
   val repository: ChallengeProvider =
-    new ChallengeProvider(null, null, null, null, null, null)(null)
+    new ChallengeProvider(null, null, null, null, null, null)(testEc)
 
   val challengeWithOsmId = Challenge(
     1,
@@ -397,7 +418,7 @@ class ChallengeProviderSpec extends PlaySpec with MockitoSugar {
     val taskDAL: TaskDAL                         = mock[TaskDAL]
     val db: Database                             = mock[Database]
     val backgroundDb: Database                   = mock[Database]
-    implicit val ec: TaskBuilderExecutionContext = mock[TaskBuilderExecutionContext]
+    implicit val ec: TaskBuilderExecutionContext = testEc
 
     when(ws.url(any[String])).thenReturn(wsRequest)
     when(wsRequest.withRequestTimeout(any[Duration])).thenReturn(wsRequest)
@@ -413,9 +434,6 @@ class ChallengeProviderSpec extends PlaySpec with MockitoSugar {
     doAnswer { (invocation: InvocationOnMock) =>
       invocation.getArgument(0).asInstanceOf[Connection => Any](mock[Connection])
     }.when(backgroundDb).withConnection(any[Connection => Any])
-    doAnswer { (invocation: InvocationOnMock) =>
-      invocation.getArgument(0).asInstanceOf[Runnable].run()
-    }.when(ec).execute(any[Runnable])
 
     val provider = new ChallengeProvider(challengeDAL, taskDAL, config, ws, db, backgroundDb)
   }


### PR DESCRIPTION
As discussed in Slack. This introduces a new DB connection pool called `background`, and a new thread pool / execution context called `task-builder-dispatcher` which are used for building (or rebuilding) challenge tasks. The separate DB pool means that the default pool won't be exhausted so requests can still be served, and the separate thread pool means that if a burst of rebuilds are requested at once, only a fixed number will be allowed to progress (equal to the pool size) and the rest will queue up rather than entering a fail-and-retry loop.

This should hopefully help alleviate the issue we've been seeing where API requests time out periodically during times when some user is requesting a whole bunch of challenges be rebuilt in a short burst.