### PR TITLE
Add liveness, readiness, and health endpoints

### DIFF
--- a/app/org/maproulette/framework/controller/HealthController.scala
+++ b/app/org/maproulette/framework/controller/HealthController.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+package org.maproulette.framework.controller
+
+import akka.actor.ActorSystem
+import akka.pattern.after
+import anorm._
+import com.zaxxer.hikari.HikariDataSource
+import play.api.db.Database
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.mvc._
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+import scala.util.control.NonFatal
+
+/**
+  * Health, liveness, and readiness probes for monitoring and orchestration.
+  *
+  * - liveness:   is the process alive? or is it stuck in a way that restarting it might fix?
+  * - readiness:  should this process recieve traffic right now? (is it ready to serve requests)
+  * - health:     is the process healthy, and if not, what is wrong with it?
+  *
+  * liveness and readiness signals are meant for use by an orchestrator or load balancer;
+  * health is meant for monitoring and alerting when the application is down.
+  */
+@Singleton
+class HealthController @Inject() (
+    db: Database,
+    system: ActorSystem,
+    components: ControllerComponents
+) extends AbstractController(components) {
+
+  private implicit val ec: ExecutionContext = components.executionContext
+
+  // How long readiness/health checks should wait for DB response. This should
+  // be set pretty low (definitely lower than the orchestrator's healthcheck
+  // timeout, so that if the DB is down the healthcheck will start failing
+  // promptly instead of just resulting in long timeouts).
+  private val ProbeTimeout: FiniteDuration = 5.seconds
+
+  def liveness: Action[AnyContent] = Action {
+    Ok(Json.obj("status" -> "pass"))
+  }
+
+  def readiness: Action[AnyContent] = Action.async {
+    probeDatabase()
+      .map(_ => Ok(Json.obj("status" -> "pass")))
+      .recover { case NonFatal(_) => ServiceUnavailable(Json.obj("status" -> "fail")) }
+  }
+
+  def health: Action[AnyContent] = Action.async {
+    probeDatabase()
+      .map(ms => buildHealth(healthy = true, Json.obj("status" -> "pass", "milliseconds" -> ms)))
+      .recover {
+        case NonFatal(e) =>
+          buildHealth(healthy = false, Json.obj("status" -> "fail", "output" -> e.getMessage))
+      }
+  }
+
+  /**
+    * Runs SELECT 1 against the default pool and returns the round-trip time in
+    * milliseconds, failing the future if it does not complete within ProbeTimeout.
+    * The timeout does not cancel the underlying JDBC call (which unwinds on its own
+    * once HikariCP gives up); it only bounds how long the caller waits.
+    */
+  private def probeDatabase(): Future[Long] = {
+    val start = System.nanoTime()
+    val query = Future {
+      db.withConnection { implicit c =>
+        SQL("SELECT 1").as(SqlParser.scalar[Int].single)
+      }
+    }
+    val timeout = after(ProbeTimeout, system.scheduler) {
+      Future.failed(new TimeoutException(s"database probe exceeded ${ProbeTimeout.toMillis}ms"))
+    }
+    Future
+      .firstCompletedOf(Seq(query, timeout))
+      .map(_ => (System.nanoTime() - start) / 1000000)
+  }
+
+  private def buildHealth(healthy: Boolean, dbCheck: JsObject): Result = {
+    val body = Json.obj(
+      "status" -> (if (healthy) "pass" else "fail"),
+      "checks" -> Json.obj(
+        "database:responseTime" -> dbCheck,
+        "database:connections"  -> poolStats()
+      )
+    )
+
+    if (healthy) Ok(body) else ServiceUnavailable(body)
+  }
+
+  /**
+    * Returns HikariCP pool utilization stats. These are application level
+    * stats so they are available even if the DB is unreachable (but if multiple
+    * backend replicas are running behind a load balancer, the stats only
+    * describe the one that happens to serve your request)
+    */
+  private def poolStats(): JsValue = {
+    db.dataSource match {
+      case h: HikariDataSource if h.getHikariPoolMXBean != null =>
+        val mx = h.getHikariPoolMXBean
+        Json.obj(
+          "status"   -> "pass",
+          "active"   -> mx.getActiveConnections,
+          "idle"     -> mx.getIdleConnections,
+          "awaiting" -> mx.getThreadsAwaitingConnection,
+          "total"    -> mx.getTotalConnections
+        )
+      case _ => Json.obj()
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -228,6 +228,7 @@ val routeFiles: Seq[String] = Seq(
   "leaderboard.api",
   "service.api",
   "search.api",
+  "health.api",
   "v2.api"
 )
 

--- a/conf/v2_route/health.api
+++ b/conf/v2_route/health.api
@@ -1,0 +1,33 @@
+###
+# tags: [ Health ]
+# summary: Liveness probe
+# description: Shallow check that the process is up and serving HTTP. Does not touch the database. Intended as a container/orchestrator liveness probe where failure means the process should be restarted.
+# responses:
+#   '200':
+#     description: Process is alive
+###
+GET /liveness @org.maproulette.framework.controller.HealthController.liveness()
+
+###
+# tags: [ Health ]
+# summary: Readiness probe
+# description: Shallow database reachability check answering whether this instance should receive traffic. In a load-balanced deployment a failure should pull the instance from rotation without restarting it.
+# responses:
+#   '200':
+#     description: Instance is ready to serve requests
+#   '503':
+#     description: Instance is not ready to serve requests
+###
+GET /readiness @org.maproulette.framework.controller.HealthController.readiness()
+
+###
+# tags: [ Health ]
+# summary: Health check
+# description: Reports whether the service and all of its hard dependencies are alive and healthy. Intended for monitoring and alerting (not orchestration).
+# responses:
+#   '200':
+#     description: Service is healthy
+#   '503':
+#     description: Service is unhealthy
+###
+GET /health @org.maproulette.framework.controller.HealthController.health()


### PR DESCRIPTION
Adds three new health checking endpoints:

- `/liveness` always returns 200 OK (useful to check if the process is alive and answering requests)
- `/readiness` answers 200 OK if the database is reachable, and 503 otherwise (a reasonable proxy for whether the instance is ready to serve traffic)
- `/health` reports on the detailed health of the service. Currently it only checks DB connectivity so the status code should always be the same as `/readiness`, but we can add additional non-critical checks here too (like checking if the osm.org API is online). This endpoint should return a 2xx code if MapRoulette is healthy (even if non-critical external dependencies are down) so we can use it for monitoring / alerting of outages.

Once we deploy this we can switch the uptime monitor to ping `/health` instead of `/service/info` (which is like `/liveness` in that it always succeeds if the process is alive, even if the DB is down) which will help detect outages that we currently miss. The orchestrator can switch to using `/liveness` and/or `/readiness` to see if the process itself is alive and ready to serve requests.