### PR TITLE
Add 'paused' state to challenges to prevent task completion and review

### DIFF
--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -143,7 +143,8 @@ case class ChallengeExtra(
     systemArchivedAt: Option[DateTime] = None,
     presets: Option[List[String]] = None,
     requireConfirmation: Boolean = false,
-    mrTagMetrics: Option[JsObject] = None
+    mrTagMetrics: Option[JsObject] = None,
+    paused: Boolean = false
 ) extends DefaultWrites
 
 case class ChallengeListing(
@@ -222,7 +223,8 @@ case class BaseChallenge(
     location: Option[JsObject] = None,
     bounding: Option[JsObject] = None,
     completionPercentage: Option[Int] = Some(0),
-    completionMetrics: CompletionMetrics = CompletionMetrics()
+    completionMetrics: CompletionMetrics = CompletionMetrics(),
+    paused: Boolean = false
 ) extends DefaultWrites
 
 /**
@@ -505,6 +507,7 @@ object Challenge extends CommonField {
   val FIELD_PARENT_ID = "parent_id"
   val FIELD_ENABLED   = "enabled"
   val FIELD_ARCHIVED  = "is_archived"
+  val FIELD_PAUSED    = "paused"
   val FIELD_GLOBAL    = "is_global"
   val FIELD_STATUS    = "status"
   val FIELD_DELETED   = "deleted"

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -228,14 +228,15 @@ object ChallengeRepository {
       get[Boolean]("challenges.require_reject_reason") ~
       get[Option[JsValue]]("challenges.task_widget_layout") ~
       get[Option[DateTime]]("challenges.system_archived_at") ~
-      get[Option[JsValue]]("challenges.completion_metrics") map {
+      get[Option[JsValue]]("challenges.completion_metrics") ~
+      get[Boolean]("challenges.paused") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
             difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~ checkin_comment ~
             checkin_source ~ overpassql ~ overpassTargetType ~ remoteGeoJson ~ status ~ statusMessage ~ defaultPriority ~ highPriorityRule ~
             mediumPriorityRule ~ lowPriorityRule ~ highPriorityBounds ~ mediumPriorityBounds ~ lowPriorityBounds ~ defaultZoom ~ minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~
             customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ preferredTags ~ preferredReviewTags ~
             limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~ dataOriginDate ~ requiresLocal ~ location ~ bounding ~
-            deleted ~ isGlobal ~ virtualParents ~ isArchived ~ reviewSetting ~ datasetUrl ~ requireConfirmation ~ requireRejectReason ~ taskWidgetLayout ~ systemArchivedAt ~ completionMetricsJson =>
+            deleted ~ isGlobal ~ virtualParents ~ isArchived ~ reviewSetting ~ datasetUrl ~ requireConfirmation ~ requireRejectReason ~ taskWidgetLayout ~ systemArchivedAt ~ completionMetricsJson ~ paused =>
         val completionMetrics =
           completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
         val hpr = highPriorityRule match {
@@ -311,7 +312,11 @@ object ChallengeRepository {
             reviewSetting,
             taskWidgetLayout.map(_.as[JsObject]),
             datasetUrl,
-            systemArchivedAt
+            systemArchivedAt,
+            None,
+            false,
+            None,
+            paused
           ),
           status,
           statusMessage,

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -468,6 +468,14 @@ class TaskReviewService @Inject() (
       errorTags: String = "",
       notify: Boolean = true
   ): Int = {
+    this.serviceManager.challenge.retrieve(task.parent) match {
+      case Some(parentChallenge) if parentChallenge.extra.paused =>
+        throw new InvalidException(
+          "This challenge is currently paused. Tasks cannot be reviewed until it is resumed."
+        )
+      case _ => // challenge not paused, or not found (shouldn't happen) - allow
+    }
+
     if (!permission.isSuperUser(user) && !user.settings.isReviewer.get && reviewStatus != Task.REVIEW_STATUS_REQUESTED &&
         reviewStatus != Task.REVIEW_STATUS_DISPUTED && reviewStatus != Task.REVIEW_STATUS_UNNECESSARY) {
       throw new IllegalAccessException("User must be a reviewer to edit task review status.")

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -131,7 +131,8 @@ class ChallengeDAL @Inject() (
       get[Option[JsValue]]("challenges.task_widget_layout") ~
       get[Boolean]("challenges.require_confirmation") ~
       get[Boolean]("challenges.require_reject_reason") ~
-      get[Option[JsValue]]("challenges.completion_metrics") map {
+      get[Option[JsValue]]("challenges.completion_metrics") ~
+      get[Boolean]("challenges.paused") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
             difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~ checkin_comment ~
             checkin_source ~ overpassql ~ remoteGeoJson ~ overpassTargetType ~ status ~ statusMessage ~
@@ -140,7 +141,7 @@ class ChallengeDAL @Inject() (
             exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ preferredTags ~ preferredReviewTags ~
             limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~ dataOriginDate ~ location ~ bounding ~
             requiresLocal ~ deleted ~ isGlobal ~ isArchived ~ reviewSetting ~ datasetUrl ~ taskWidgetLayout ~
-            requireConfirmation ~ requireRejectReason ~ completionMetricsJson =>
+            requireConfirmation ~ requireRejectReason ~ completionMetricsJson ~ paused =>
         val completionMetrics =
           completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
         new Challenge(
@@ -202,7 +203,8 @@ class ChallengeDAL @Inject() (
             None, // systemArchivedAt
             None, // presets
             requireConfirmation,
-            None // mrTagMetrics
+            None, // mrTagMetrics
+            paused
           ),
           status,
           statusMessage,
@@ -281,7 +283,8 @@ class ChallengeDAL @Inject() (
       get[Option[DateTime]]("challenges.system_archived_at") ~
       get[Boolean]("challenges.require_confirmation") ~
       get[Boolean]("challenges.require_reject_reason") ~
-      get[Option[JsValue]]("challenges.completion_metrics") map {
+      get[Option[JsValue]]("challenges.completion_metrics") ~
+      get[Boolean]("challenges.paused") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
             difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~
             checkin_comment ~ checkin_source ~ overpassql ~ remoteGeoJson ~ overpassTargetType ~
@@ -291,7 +294,7 @@ class ChallengeDAL @Inject() (
             preferredReviewTags ~ limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~
             dataOriginDate ~ location ~ bounding ~ requiresLocal ~ deleted ~ isGlobal ~ virtualParents ~
             presets ~ isArchived ~ reviewSetting ~ datasetUrl ~ taskWidgetLayout ~ systemArchivedAt ~
-            requireConfirmation ~ requireRejectReason ~ completionMetricsJson =>
+            requireConfirmation ~ requireRejectReason ~ completionMetricsJson ~ paused =>
         val completionMetrics =
           completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
         new Challenge(
@@ -352,7 +355,9 @@ class ChallengeDAL @Inject() (
             datasetUrl,
             systemArchivedAt,
             presets,
-            requireConfirmation
+            requireConfirmation,
+            None, // mrTagMetrics
+            paused
           ),
           status,
           statusMessage,
@@ -424,7 +429,8 @@ class ChallengeDAL @Inject() (
       get[Option[DateTime]]("challenges.data_origin_date") ~
       get[Option[String]]("locationJSON") ~
       get[Option[String]]("boundingJSON") ~
-      get[Option[JsValue]]("challenges.completion_metrics") map {
+      get[Option[JsValue]]("challenges.completion_metrics") ~
+      get[Boolean]("challenges.paused") map {
       case id ~ name ~ created ~ modified ~ description ~ deleted ~ isGlobal ~ requireConfirmation ~ requireRejectReason ~
             infoLink ~ ownerId ~ parentId ~ instruction ~ difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~
             popularity ~ checkin_comment ~ checkin_source ~ requiresLocal ~ overpassQL ~ remoteGeoJson ~ overpassTargetType ~
@@ -433,7 +439,7 @@ class ChallengeDAL @Inject() (
             limitReviewTags ~ isArchived ~ reviewSetting ~ defaultBasemap ~ defaultBasemapId ~ customBasemap ~
             exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ taskWidgetLayout ~ taskStyles ~ status ~
             statusMessage ~ lastTaskRefresh ~ dataOriginDate ~ location ~ bounding ~
-            completionMetricsJson =>
+            completionMetricsJson ~ paused =>
         val completionMetrics =
           completionMetricsJson.flatMap(_.asOpt[CompletionMetrics]).getOrElse(CompletionMetrics())
         val hpr = highPriorityRule.map(Json.parse(_).as[JsObject])
@@ -500,7 +506,8 @@ class ChallengeDAL @Inject() (
           location.map(Json.parse(_).as[JsObject]),
           bounding.map(Json.parse(_).as[JsObject]),
           Some(CompletionMetrics.completionPercentage(completionMetrics)),
-          completionMetrics
+          completionMetrics,
+          paused
         )
     }
   }
@@ -702,7 +709,7 @@ class ChallengeDAL @Inject() (
                                       medium_priority_rule, low_priority_rule, high_priority_bounds, medium_priority_bounds, low_priority_bounds, default_zoom, min_zoom, max_zoom,
                                       default_basemap, default_basemap_id, custom_basemap, updatetasks, exportable_properties,
                                       osm_id_property, task_bundle_id_property, last_task_refresh, data_origin_date, preferred_tags, preferred_review_tags,
-                                      limit_tags, limit_review_tags, task_styles, requires_local, is_archived, review_setting, dataset_url, require_confirmation, require_reject_reason, task_widget_layout)
+                                      limit_tags, limit_review_tags, task_styles, requires_local, is_archived, review_setting, dataset_url, require_confirmation, require_reject_reason, task_widget_layout, paused)
               VALUES (${challenge.name}, ${challenge.general.owner}, ${challenge.general.parent},
                       ${challenge.general.difficulty},
                       ${challenge.description}, ${challenge.infoLink}, ${challenge.general.blurb}, ${challenge.general.instruction},
@@ -718,7 +725,7 @@ class ChallengeDAL @Inject() (
                       ${challenge.extra.preferredTags}, ${challenge.extra.preferredReviewTags}, ${challenge.extra.limitTags},
                       ${challenge.extra.limitReviewTags}, ${challenge.extra.taskStyles}, ${challenge.general.requiresLocal}, ${challenge.extra.isArchived},
                       ${challenge.extra.reviewSetting}, ${challenge.extra.datasetUrl}, ${challenge.requireConfirmation}, ${challenge.requireRejectReason},
-                      ${asJson(challenge.extra.taskWidgetLayout.getOrElse(Json.obj()))}
+                      ${asJson(challenge.extra.taskWidgetLayout.getOrElse(Json.obj()))}, ${challenge.extra.paused}
                       ) RETURNING #${this.retrieveColumns}"""
             .as(this.parser.*)
             .headOption
@@ -954,6 +961,10 @@ class ChallengeDAL @Inject() (
             .asOpt[Boolean]
             .getOrElse(cachedItem.extra.isArchived)
 
+          val paused = (updates \ "paused")
+            .asOpt[Boolean]
+            .getOrElse(cachedItem.extra.paused)
+
           val reviewSetting = (updates \ "reviewSetting")
             .asOpt[Int]
             .getOrElse(cachedItem.extra.reviewSetting)
@@ -1019,7 +1030,7 @@ class ChallengeDAL @Inject() (
                   custom_basemap = $customBasemap, updatetasks = $updateTasks, exportable_properties = $exportableProperties,
                   osm_id_property = $osmIdProperty, task_bundle_id_property = $taskBundleIdProperty, preferred_tags = $preferredTags, preferred_review_tags = $preferredReviewTags,
                   limit_tags = $limitTags, limit_review_tags = $limitReviewTags, task_styles = $taskStyles,
-                  requires_local = $requiresLocal, is_archived = $isArchived, review_setting = $reviewSetting, dataset_url = $datasetUrl, task_widget_layout = ${asJson(
+                  requires_local = $requiresLocal, is_archived = $isArchived, paused = $paused, review_setting = $reviewSetting, dataset_url = $datasetUrl, task_widget_layout = ${asJson(
               taskWidgetLayout
             )}
                 WHERE id = $id RETURNING #${this.retrieveColumns}""".as(parser.*).headOption

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -601,6 +601,16 @@ class TaskDAL @Inject() (
       throw new IllegalAccessException("Guest users cannot make edits to tasks.")
     }
 
+    for (task <- tasks) {
+      this.manager.challenge.retrieveById(task.parent) match {
+        case Some(parentChallenge) if parentChallenge.extra.paused =>
+          throw new InvalidException(
+            "This challenge is currently paused. Tasks cannot be completed until it is resumed."
+          )
+        case _ => // challenge not paused, or not found (shouldn't happen) - allow
+      }
+    }
+
     var primaryTask = if (isBundle) {
       primaryTaskId
         .flatMap(id => tasks.find(_.id == id))

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -56,6 +56,7 @@ trait ChallengeWrites extends DefaultWrites {
         "limitTags"           -> JsBoolean(o.limitTags),
         "limitReviewTags"     -> JsBoolean(o.limitReviewTags),
         "isArchived"          -> JsBoolean(o.isArchived),
+        "paused"              -> JsBoolean(o.paused),
         "reviewSetting"       -> JsNumber(o.reviewSetting),
         "requireConfirmation" -> JsBoolean(o.requireConfirmation)
       )
@@ -175,7 +176,8 @@ trait ChallengeReads extends DefaultReads {
             presets = (jsonWithExtras \ "presets").asOpt[List[String]],
             requireConfirmation =
               (jsonWithExtras \ "requireConfirmation").asOpt[Boolean].getOrElse(false),
-            mrTagMetrics = (jsonWithExtras \ "mrTagMetrics").asOpt[JsObject]
+            mrTagMetrics = (jsonWithExtras \ "mrTagMetrics").asOpt[JsObject],
+            paused = (jsonWithExtras \ "paused").asOpt[Boolean].getOrElse(false)
           )
         )
       } catch {
@@ -243,6 +245,7 @@ trait BaseChallengeWrites extends DefaultWrites {
         "limitTags"           -> JsBoolean(bc.limitTags),
         "limitReviewTags"     -> JsBoolean(bc.limitReviewTags),
         "isArchived"          -> JsBoolean(bc.isArchived),
+        "paused"              -> JsBoolean(bc.paused),
         "reviewSetting"       -> JsNumber(bc.reviewSetting),
         "completionMetrics"   -> Json.toJson(bc.completionMetrics)
       )

--- a/conf/evolutions/default/119.sql
+++ b/conf/evolutions/default/119.sql
@@ -5,8 +5,8 @@
 -- Pausing a challenge locks its tasks against completion/review without
 -- touching individual task statuses, unlike disabling the challenge (which
 -- leaves existing tasks fully workable via the completion widget).
-ALTER TABLE challenges ADD COLUMN paused BOOLEAN NOT NULL DEFAULT false;;
+ALTER TABLE challenges ADD COLUMN IF NOT EXISTS paused BOOLEAN NOT NULL DEFAULT false;;
 
 # --- !Downs
 
-ALTER TABLE IF EXISTS challenges DROP COLUMN paused;;
+ALTER TABLE IF EXISTS challenges DROP COLUMN IF EXISTS paused;;

--- a/conf/evolutions/default/119.sql
+++ b/conf/evolutions/default/119.sql
@@ -1,0 +1,12 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+
+-- Pausing a challenge locks its tasks against completion/review without
+-- touching individual task statuses, unlike disabling the challenge (which
+-- leaves existing tasks fully workable via the completion widget).
+ALTER TABLE challenges ADD COLUMN paused BOOLEAN NOT NULL DEFAULT false;;
+
+# --- !Downs
+
+ALTER TABLE IF EXISTS challenges DROP COLUMN paused;;

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 import play.api.libs.json.Json
 
+import org.maproulette.exception.InvalidException
 import org.maproulette.session.{SearchParameters, SearchTaskParameters}
 import org.maproulette.framework.model._
 import org.maproulette.framework.util.{TaskReviewTag, FrameworkHelper}
@@ -366,6 +367,55 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
       contestNotification.notificationType mustEqual UserNotification.NOTIFICATION_TYPE_REVIEW_AGAIN
       contestNotification.taskId.get mustEqual newTask.id
       contestNotification.fromUsername.get mustEqual randomUser.osmProfile.displayName
+    }
+
+    "prevent task completion and review while the parent challenge is paused" taggedAs (TaskReviewTag) in {
+      val pausedChallenge = this.challengeDAL
+        .insert(
+          Challenge(
+            -1,
+            "pausedChallenge",
+            null,
+            null,
+            general = ChallengeGeneral(
+              User.superUser.osmProfile.id,
+              this.defaultProject.id,
+              "TestChallengeInstruction",
+              enabled = true
+            ),
+            creation = ChallengeCreation(),
+            priority = ChallengePriority(),
+            extra = ChallengeExtra()
+          ),
+          User.superUser
+        )
+      val pausedTask = this.taskDAL.insert(
+        this.getTestTask(UUID.randomUUID().toString, pausedChallenge.id),
+        User.superUser
+      )
+
+      this.challengeDAL.update(Json.obj("paused" -> true), User.superUser)(pausedChallenge.id)
+
+      intercept[InvalidException] {
+        this.taskDAL.setTaskStatus(List(pausedTask), Task.STATUS_FIXED, randomUser, Some(true))
+      }
+
+      // Unpause to complete/claim the task, then re-pause to verify the review guard
+      this.challengeDAL.update(Json.obj("paused" -> false), User.superUser)(pausedChallenge.id)
+      this.taskDAL.setTaskStatus(List(pausedTask), Task.STATUS_FIXED, randomUser, Some(true))
+      var taskWithReview = this.serviceManager.task.retrieve(pausedTask.id).get
+      taskWithReview = this.service.startTaskReview(reviewUser, taskWithReview).get
+
+      this.challengeDAL.update(Json.obj("paused" -> true), User.superUser)(pausedChallenge.id)
+
+      intercept[InvalidException] {
+        this.service.setTaskReviewStatus(
+          taskWithReview,
+          Task.REVIEW_STATUS_APPROVED,
+          reviewUser,
+          None
+        )
+      }
     }
   }
 


### PR DESCRIPTION
This update introduces a 'paused' boolean field to the Challenge model, allowing challenges to be paused. When a challenge is paused, tasks associated with it cannot be completed or reviewed, enforcing a lock on task actions. The database schema is updated accordingly, and relevant service and data access layers have been modified to handle this new state. Tests have been added to ensure the functionality works as intended, preventing task actions while a challenge is paused.

Merge in tandom with: https://github.com/maproulette/maproulette3/pull/2868