### PR TITLE
Add batch endpoint for fetching challenge tags by id

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -151,6 +151,23 @@ class ChallengeController @Inject() (
   }
 
   /**
+    * Gets a json object of tags for a batch of challenges, keyed by challenge id.
+    * Allows clients (e.g. the map view) to fetch tags for many challenges in a single
+    * request instead of issuing one request per challenge.
+    *
+    * @param challengeIds A comma separated list of challenge ids
+    * @return The html Result containing a json object mapping challenge id to a json array of tags
+    */
+  def getTagsForChallenges(challengeIds: String): Action[AnyContent] = Action.async {
+    implicit request =>
+      this.sessionManager.userAwareRequest { implicit user =>
+        val ids               = Utils.toLongList(challengeIds).getOrElse(List.empty)
+        val tagsByChallengeId = this.serviceManager.tag.listByChallenges(ids)
+        Ok(Json.toJson(tagsByChallengeId.map { case (id, tags) => id.toString -> tags }))
+      }
+  }
+
+  /**
     * Gets the geo json for all the tasks associated with the challenge
     *
     * @param challengeId  The challenge with the geojson

--- a/conf/v2_route/challenge.api
+++ b/conf/v2_route/challenge.api
@@ -559,6 +559,28 @@ POST     /challenges/project/:projectId           @org.maproulette.controllers.a
 GET     /challenge/:id/tags                         @org.maproulette.controllers.api.ChallengeController.getTagsForChallenge(id:Long)
 ###
 # tags: [ Challenge ]
+# operationId: challenge_getTagsForChallenges
+# summary: Retrieve tags for a batch of Challenges
+# description: Retrieves all the Tags that have been added to each of the specified Challenges, keyed by challenge id
+# responses:
+#   '200':
+#     description: A json object mapping challenge id to a list of Tags associated with that Challenge
+#     content:
+#       application/json:
+#         schema:
+#           type: object
+#           additionalProperties:
+#             type: array
+#             items:
+#               $ref: '#/components/schemas/org.maproulette.framework.model.Tag'
+# parameters:
+#   - name: challengeIds
+#     in: query
+#     description: A comma separated list of Challenge ids
+###
+GET     /challenges/tags/batch                      @org.maproulette.controllers.api.ChallengeController.getTagsForChallenges(challengeIds:String)
+###
+# tags: [ Challenge ]
 # operationId: challenge_getItemsBasedOnTags
 # summary: Retrieve challenges based on provided tags
 # description: Retrieves all the challenges that contain at least one of the supplied tags.


### PR DESCRIPTION
The explore-challenges map was firing one GET /challenge/{id}/tags request per distinct challenge visible on screen, refetching on every pan/zoom. Add GET /challenges/tags/batch, backed by the existing TagService.listByChallenges, so clients can fetch tags for many challenges in a single request.

Required for next mr4 deployment, used instead to limit amount of requests and boost performance.

relavant commit: https://github.com/maproulette/maproulette3/commit/aadd1c2a90c25059b0367938a256282d93e695a8