### PR TITLE
include some project data in challenge queries

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -1154,7 +1154,7 @@ class ChallengeController @Inject() (
           difficulty = difficulty
         )
 
-        Ok(Json.toJson(challenges))
+        Ok(insertProjectJSON(challenges))
       }
     }
 

--- a/app/org/maproulette/framework/controller/ProjectController.scala
+++ b/app/org/maproulette/framework/controller/ProjectController.scala
@@ -10,10 +10,9 @@ import javax.inject.Inject
 import org.apache.commons.lang3.StringUtils
 import org.maproulette.data.{Created => ActionCreated, _}
 import org.maproulette.exception.{MPExceptionUtil, NotFoundException, StatusMessage}
-import org.maproulette.framework.mixins.ParentMixin
 import org.maproulette.framework.model.{Challenge, Project, User}
 import org.maproulette.framework.psql.{Paging, _}
-import org.maproulette.framework.service.{CommentService, ProjectService, ServiceManager}
+import org.maproulette.framework.service.{CommentService, ProjectService}
 import org.maproulette.models.dal.TaskDAL
 import org.maproulette.session.{SearchParameters, SessionManager}
 import org.maproulette.utils.Utils
@@ -30,11 +29,9 @@ class ProjectController @Inject() (
     projectService: ProjectService,
     commentService: CommentService,
     taskDAL: TaskDAL,
-    val serviceManager: ServiceManager,
     components: ControllerComponents
 ) extends AbstractController(components)
-    with MapRouletteController
-    with ParentMixin {
+    with MapRouletteController {
 
   // json reads for automatically reading Projects from a posted json body
   implicit val projectReads: Reads[Project] = Project.reads
@@ -54,7 +51,7 @@ class ProjectController @Inject() (
   def listChildren(id: Long, limit: Int, offset: Int): Action[AnyContent] = Action.async {
     implicit request =>
       this.sessionManager.userAwareRequest { implicit user =>
-        Ok(insertProjectJSON(this.projectService.children(id, paging = Paging(limit, offset))))
+        Ok(Json.toJson(this.projectService.children(id, paging = Paging(limit, offset))))
       }
   }
 

--- a/app/org/maproulette/framework/controller/ProjectController.scala
+++ b/app/org/maproulette/framework/controller/ProjectController.scala
@@ -10,9 +10,10 @@ import javax.inject.Inject
 import org.apache.commons.lang3.StringUtils
 import org.maproulette.data.{Created => ActionCreated, _}
 import org.maproulette.exception.{MPExceptionUtil, NotFoundException, StatusMessage}
+import org.maproulette.framework.mixins.ParentMixin
 import org.maproulette.framework.model.{Challenge, Project, User}
 import org.maproulette.framework.psql.{Paging, _}
-import org.maproulette.framework.service.{CommentService, ProjectService}
+import org.maproulette.framework.service.{CommentService, ProjectService, ServiceManager}
 import org.maproulette.models.dal.TaskDAL
 import org.maproulette.session.{SearchParameters, SessionManager}
 import org.maproulette.utils.Utils
@@ -29,9 +30,11 @@ class ProjectController @Inject() (
     projectService: ProjectService,
     commentService: CommentService,
     taskDAL: TaskDAL,
+    val serviceManager: ServiceManager,
     components: ControllerComponents
 ) extends AbstractController(components)
-    with MapRouletteController {
+    with MapRouletteController
+    with ParentMixin {
 
   // json reads for automatically reading Projects from a posted json body
   implicit val projectReads: Reads[Project] = Project.reads
@@ -51,7 +54,7 @@ class ProjectController @Inject() (
   def listChildren(id: Long, limit: Int, offset: Int): Action[AnyContent] = Action.async {
     implicit request =>
       this.sessionManager.userAwareRequest { implicit user =>
-        Ok(Json.toJson(this.projectService.children(id, paging = Paging(limit, offset))))
+        Ok(insertProjectJSON(this.projectService.children(id, paging = Paging(limit, offset))))
       }
   }
 


### PR DESCRIPTION
This is more of a hacky solution for now, i need the project name for challenge cards, and this was the cleanest solution. But i do think we should probably make a new column in the challenge table in the future to hold the name so we dont need to fetch it.