### PR TITLE
Enforce one active task lock per user; lock bundles via bundledTasks

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -14,6 +14,7 @@ import org.maproulette.controllers.CRUDController
 import org.maproulette.data._
 import org.maproulette.exception.{
   InvalidException,
+  LockConflictException,
   LockedException,
   NotFoundException,
   StatusMessage
@@ -213,6 +214,9 @@ class TaskController @Inject() (
 
   /**
     * Start on task (lock it). An error will be returned if someone else has the lock.
+    * If the calling user already holds a lock on a different task, a 409 Conflict is
+    * returned describing that lock - the client should call the release endpoint on
+    * that task before retrying to lock this one.
     *
     * @param taskId     Id of task that you wish to start
     * @return
@@ -221,7 +225,8 @@ class TaskController @Inject() (
     this.sessionManager.authenticatedRequest { implicit user =>
       val task = this.dal.retrieveById(taskId) match {
         case Some(t) => t
-        case None    => throw new NotFoundException(s"Task with $taskId not found, unable to lock.")
+        case None =>
+          throw new NotFoundException(s"Task with $taskId not found, unable to lock.")
       }
 
       val challenge = this.serviceManager.challenge.retrieve(task.parent) match {
@@ -238,24 +243,44 @@ class TaskController @Inject() (
           )
       }
 
-      val lockerId = this.dal.lockItem(user, task)
-      if (lockerId != user.id) {
-        val lockHolder = this.serviceManager.user.retrieve(lockerId) match {
-          case Some(user) => user.osmProfile.displayName
-          case None       => lockerId
+      try {
+        val lockerId = this.dal.lockItem(user, task)
+        if (lockerId != user.id) {
+          val lockHolder = this.serviceManager.user.retrieve(lockerId) match {
+            case Some(user) => user.osmProfile.displayName
+            case None       => lockerId
+          }
+          throw new IllegalAccessException(s"Task is currently locked by user ${lockHolder}")
         }
-        throw new IllegalAccessException(s"Task is currently locked by user ${lockHolder}")
-      }
 
-      webSocketProvider.sendMessage(
-        WebSocketMessages.taskClaimed(
-          task,
-          WebSocketMessages.challengeSummary(challenge),
-          WebSocketMessages.projectSummary(project),
-          WebSocketMessages.userSummary(user)
+        webSocketProvider.sendMessage(
+          WebSocketMessages.taskClaimed(
+            task,
+            WebSocketMessages.challengeSummary(challenge),
+            WebSocketMessages.projectSummary(project),
+            WebSocketMessages.userSummary(user)
+          )
         )
-      )
-      Ok(Json.toJson(task))
+        Ok(Json.toJson(task))
+      } catch {
+        case e: LockConflictException =>
+          val conflictingTaskId = e.conflictingLock.itemId
+          val conflictingParentName =
+            this.dal
+              .retrieveById(conflictingTaskId)
+              .flatMap(t => this.serviceManager.challenge.retrieve(t.parent))
+              .map(_.name)
+          Conflict(
+            Json.obj(
+              "status"       -> "Conflict",
+              "message"      -> e.getMessage,
+              "lockedTaskId" -> conflictingTaskId,
+              "parentName"   -> conflictingParentName,
+              "bundledTasks" -> e.conflictingLock.bundledTasks,
+              "startedAt"    -> e.conflictingLock.lockedTime.map(_.toString)
+            )
+          )
+      }
     }
   }
 
@@ -367,56 +392,11 @@ class TaskController @Inject() (
   }
 
   /**
-    * Locks a bundle of tasks based on the provided task IDs.
-    *
-    * @param taskIds The IDs of the tasks to lock
-    * @return
-    */
-  def lockTaskBundle(taskIds: List[Long]): Action[AnyContent] = Action.async { implicit request =>
-    this.sessionManager.authenticatedRequest { implicit user =>
-      // First retrieve all the tasks
-      val tasks = taskIds.flatMap(taskId => this.dal.retrieveById(taskId))
-
-      if (tasks.length != taskIds.length) {
-        val missingTaskIds = taskIds.filter(taskId => !tasks.map(_.id).contains(taskId))
-        // No valid tasks found
-        throw new IllegalAccessException(
-          s"Tasks not found to unlock: ${missingTaskIds.mkString(", ")}"
-        )
-      } else {
-        // Use bulk locking for better performance
-        this.dal.lockItems(user, tasks)
-
-        val tasksByChallenge = tasks.groupBy(_.parent)
-
-        Future {
-          tasksByChallenge.foreach {
-            case (challengeId, challengeTasks) =>
-              this.serviceManager.challenge.retrieve(challengeId) match {
-                case Some(challenge) =>
-                  this.serviceManager.project.retrieve(challenge.general.parent) match {
-                    case Some(project) =>
-                      webSocketProvider.sendMessage(
-                        WebSocketMessages.tasksClaimed(
-                          challengeTasks,
-                          WebSocketMessages.challengeSummary(challenge),
-                          WebSocketMessages.projectSummary(project),
-                          WebSocketMessages.userSummary(user)
-                        )
-                      )
-                    case None =>
-                  }
-                case None =>
-              }
-          }
-        }
-        Ok(Json.toJson(tasks))
-      }
-    }
-  }
-
-  /**
-    * Unlocks a bundle of tasks based on the provided task IDs.
+    * Unlocks a bundle of tasks based on the provided task IDs. Bundles are locked as a
+    * single row on the bundle's primary task (see Locking.lockBundle), so this releases
+    * that covering lock if the calling user holds it via any of the given task ids.
+    * Ids the user doesn't currently hold a lock on are silently ignored rather than
+    * erroring, since the caller may not know which id is the bundle's primary.
     *
     * @param taskIds The IDs of the tasks to unlock
     * @return
@@ -424,28 +404,28 @@ class TaskController @Inject() (
   def unlockTaskBundle(taskIds: List[Long]): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       val tasks = taskIds.flatMap(taskId => this.dal.retrieveById(taskId))
-      if (tasks.length != taskIds.length) {
-        val missingTaskIds = taskIds.filter(taskId => !tasks.map(_.id).contains(taskId))
-        // No valid tasks found
-        throw new Exception(s"Tasks not found to unlock: ${missingTaskIds.mkString(", ")}")
-      } else {
-        // Use bulk locking for better performance
-        this.dal.unlockItems(user, tasks)
 
-        val tasksByChallenge = tasks.groupBy(_.parent)
-
-        Future {
-          tasksByChallenge.foreach {
-            case (challengeId, challengeTasks) =>
-              webSocketProvider.sendMessage(
-                WebSocketMessages
-                  .tasksReleased(challengeTasks, Some(WebSocketMessages.userSummary(user)))
-              )
-          }
+      tasks.foreach { task =>
+        try {
+          this.dal.unlockItem(user, task)
+        } catch {
+          case e: Exception => logger.warn(e.getMessage)
         }
-
-        Ok(Json.toJson(tasks))
       }
+
+      val tasksByChallenge = tasks.groupBy(_.parent)
+
+      Future {
+        tasksByChallenge.foreach {
+          case (challengeId, challengeTasks) =>
+            webSocketProvider.sendMessage(
+              WebSocketMessages
+                .tasksReleased(challengeTasks, Some(WebSocketMessages.userSummary(user)))
+            )
+        }
+      }
+
+      Ok(Json.toJson(tasks))
     }
   }
 

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -261,7 +261,34 @@ class TaskController @Inject() (
             WebSocketMessages.userSummary(user)
           )
         )
-        Ok(Json.toJson(task))
+        val (lockPrimaryTaskId, lockBundledTasks) =
+          this.dal.resolveLockBundle(task).getOrElse((task.id, List.empty[Long]))
+        // The lock, not the task_bundles table, is the live source of truth for "what's
+        // bundled with this task right now" - whenever locking/relocking resolves to a
+        // covering lock that has bundle members, broadcast the full membership so any
+        // other tab/session (even one that mounted before this bundle existed) can pick
+        // it up live, the same way a bundle create/update broadcasts it.
+        if (lockBundledTasks.nonEmpty) {
+          val primaryTask =
+            if (lockPrimaryTaskId == task.id) task
+            else this.dal.retrieveById(lockPrimaryTaskId).getOrElse(task)
+          val memberTasks =
+            this.dal.retrieveListById(-1, 0)(lockBundledTasks.filterNot(_ == lockPrimaryTaskId))
+          webSocketProvider.sendMessage(
+            WebSocketMessages.tasksClaimed(
+              primaryTask :: memberTasks,
+              WebSocketMessages.challengeSummary(challenge),
+              WebSocketMessages.projectSummary(project),
+              WebSocketMessages.userSummary(user)
+            )
+          )
+        }
+        Ok(
+          Json.toJson(task).as[JsObject] ++ Json.obj(
+            "lockPrimaryTaskId" -> lockPrimaryTaskId,
+            "lockBundledTasks"  -> lockBundledTasks
+          )
+        )
       } catch {
         case e: LockConflictException =>
           val conflictingTaskId = e.conflictingLock.itemId
@@ -282,6 +309,87 @@ class TaskController @Inject() (
           )
       }
     }
+  }
+
+  /**
+    * Updates the caller's lock on the given primary task to cover exactly the given member
+    * task ids, without touching the persisted task_bundles record - the bundle itself is
+    * only created/updated when the task is actually submitted (see TaskBundleController).
+    * Used while interactively building up a bundle (e.g. lasso-select) so other tabs see the
+    * live working set without a stray task_bundles row surviving an abandoned/refreshed session.
+    *
+    * @param taskId  Id of the primary task (locks it first if the caller doesn't already)
+    * @param taskIds The full set of member task ids (excluding the primary) the lock should cover
+    */
+  def lockTaskBundle(taskId: Long, taskIds: List[Long]): Action[AnyContent] = Action.async {
+    implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        val task = this.dal.retrieveById(taskId) match {
+          case Some(t) => t
+          case None =>
+            throw new NotFoundException(s"Task with $taskId not found, unable to lock.")
+        }
+
+        val challenge = this.serviceManager.challenge.retrieve(task.parent) match {
+          case Some(c) => c
+          case None =>
+            throw new NotFoundException(s"Challenge ${task.parent} not found, unable to lock.")
+        }
+
+        val project = this.serviceManager.project.retrieve(challenge.general.parent) match {
+          case Some(c) => c
+          case None =>
+            throw new NotFoundException(
+              s"Project ${challenge.general.parent} not found, unable to lock."
+            )
+        }
+
+        try {
+          val lockerId = this.dal.lockBundle(user, task, taskIds)
+          if (lockerId != user.id) {
+            val lockHolder = this.serviceManager.user.retrieve(lockerId) match {
+              case Some(u) => u.osmProfile.displayName
+              case None    => lockerId
+            }
+            throw new IllegalAccessException(s"Task is currently locked by user ${lockHolder}")
+          }
+
+          val memberTasks = this.dal.retrieveListById(-1, 0)(taskIds)
+          webSocketProvider.sendMessage(
+            WebSocketMessages.tasksClaimed(
+              task :: memberTasks,
+              WebSocketMessages.challengeSummary(challenge),
+              WebSocketMessages.projectSummary(project),
+              WebSocketMessages.userSummary(user)
+            )
+          )
+
+          Ok(
+            Json.obj(
+              "lockPrimaryTaskId" -> task.id,
+              "lockBundledTasks"  -> taskIds
+            )
+          )
+        } catch {
+          case e: LockConflictException =>
+            val conflictingTaskId = e.conflictingLock.itemId
+            val conflictingParentName =
+              this.dal
+                .retrieveById(conflictingTaskId)
+                .flatMap(t => this.serviceManager.challenge.retrieve(t.parent))
+                .map(_.name)
+            Conflict(
+              Json.obj(
+                "status"       -> "Conflict",
+                "message"      -> e.getMessage,
+                "lockedTaskId" -> conflictingTaskId,
+                "parentName"   -> conflictingParentName,
+                "bundledTasks" -> e.conflictingLock.bundledTasks,
+                "startedAt"    -> e.conflictingLock.lockedTime.map(_.toString)
+              )
+            )
+        }
+      }
   }
 
   /**
@@ -336,10 +444,28 @@ class TaskController @Inject() (
       }
 
       try {
+        // Resolve the lock's bundle membership before releasing it - once unlocked, the
+        // covering row (and its bundled_tasks) is gone.
+        val (lockPrimaryTaskId, lockBundledTasks) =
+          this.dal.resolveLockBundle(task).getOrElse((task.id, List.empty[Long]))
         this.dal.unlockItem(user, task)
-        webSocketProvider.sendMessage(
-          WebSocketMessages.taskReleased(task, Some(WebSocketMessages.userSummary(user)))
-        )
+        if (lockBundledTasks.nonEmpty) {
+          val primaryTask =
+            if (lockPrimaryTaskId == task.id) task
+            else this.dal.retrieveById(lockPrimaryTaskId).getOrElse(task)
+          val memberTasks =
+            this.dal.retrieveListById(-1, 0)(lockBundledTasks.filterNot(_ == lockPrimaryTaskId))
+          webSocketProvider.sendMessage(
+            WebSocketMessages.tasksReleased(
+              primaryTask :: memberTasks,
+              Some(WebSocketMessages.userSummary(user))
+            )
+          )
+        } else {
+          webSocketProvider.sendMessage(
+            WebSocketMessages.taskReleased(task, Some(WebSocketMessages.userSummary(user)))
+          )
+        }
       } catch {
         case e: Exception => logger.warn(e.getMessage)
       }
@@ -360,7 +486,14 @@ class TaskController @Inject() (
         case Some(t) =>
           try {
             this.dal.refreshItemLock(user, t)
-            Ok(Json.toJson(t))
+            val (lockPrimaryTaskId, lockBundledTasks) =
+              this.dal.resolveLockBundle(t).getOrElse((t.id, List.empty[Long]))
+            Ok(
+              Json.toJson(t).as[JsObject] ++ Json.obj(
+                "lockPrimaryTaskId" -> lockPrimaryTaskId,
+                "lockBundledTasks"  -> lockBundledTasks
+              )
+            )
           } catch {
             case e: LockedException => throw new IllegalAccessException(e.getMessage)
           }

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -940,7 +940,8 @@ class TaskController @Inject() (
         )
       } else {
         webSocketProvider.sendMessage(
-          WebSocketMessages.taskReleased(releasedTasks.head, Some(WebSocketMessages.userSummary(user)))
+          WebSocketMessages
+            .taskReleased(releasedTasks.head, Some(WebSocketMessages.userSummary(user)))
         )
       }
     } catch {

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -925,7 +925,27 @@ class TaskController @Inject() (
       case None    => throw new NotFoundException(s"Task with $taskId not found, can not set status.")
     }
 
+    // Resolve the lock's bundle membership before setTaskStatus releases it as a side
+    // effect (TaskDAL#setTaskStatus), so we can broadcast the release the same way
+    // releaseTask/skipTask do - otherwise other tabs/sessions never learn this task
+    // (and any bundle members) were unlocked and keep showing it as locked-by-you.
+    val releasedTasks = this.dal.resolveLockReleaseTasks(task)
+
     this.dal.setTaskStatus(List(task), status, user, requestReview, completionResponses)
+
+    try {
+      if (releasedTasks.length > 1) {
+        webSocketProvider.sendMessage(
+          WebSocketMessages.tasksReleased(releasedTasks, Some(WebSocketMessages.userSummary(user)))
+        )
+      } else {
+        webSocketProvider.sendMessage(
+          WebSocketMessages.taskReleased(releasedTasks.head, Some(WebSocketMessages.userSummary(user)))
+        )
+      }
+    } catch {
+      case e: Exception => logger.warn(e.getMessage)
+    }
 
     val action =
       this.actionManager.setAction(Some(user), new TaskItem(task.id), actionType, task.name)

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -666,6 +666,35 @@ class TaskController @Inject() (
   }
 
   /**
+    * Reads a single task, augmenting the standard injected JSON with the current lock
+    * holder (`lockedBy`, null when unlocked) and, when locked, the covering bundle's member
+    * ids (`lockBundledTasks`). This lets a task the caller already holds - e.g. opened in a
+    * second tab - render as locked-by-me without that tab issuing its own /start. The lock
+    * lookup lives here rather than in inject() so it only runs for this single-task read, not
+    * for the batch/bounding-box paths that also call inject().
+    */
+  override def read(implicit id: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      this.dal.retrieveById match {
+        case Some(task) =>
+          val (lockedBy, lockBundledTasks) =
+            this.dal.resolveLockHolder(task) match {
+              case Some((holderId, _, bundled)) =>
+                (Some(holderId), bundled.filterNot(_ == task.id))
+              case None => (None, List.empty[Long])
+            }
+          Ok(
+            this.inject(task).as[JsObject] ++ Json.obj(
+              "lockedBy"         -> lockedBy,
+              "lockBundledTasks" -> lockBundledTasks
+            )
+          )
+        case None => NotFound
+      }
+    }
+  }
+
+  /**
     * This is the generic function that is leveraged by all the specific functions above. So it
     * sets the task status to the specific status ID's provided by those functions.
     * Must be authenticated to perform operation

--- a/app/org/maproulette/exception/MPExceptionUtil.scala
+++ b/app/org/maproulette/exception/MPExceptionUtil.scala
@@ -42,6 +42,19 @@ object MPExceptionUtil {
       case e: NotFoundException =>
         logger.error(e.getMessage, e)
         NotFound(Json.toJson(StatusMessage("NotFound", JsString(e.getMessage))))
+      case e: LockConflictException =>
+        logger.debug(e.getMessage)
+        Conflict(
+          Json.obj(
+            "status"       -> "Conflict",
+            "message"      -> e.getMessage,
+            "lockedTaskId" -> e.conflictingLock.itemId,
+            "bundledTasks" -> e.conflictingLock.bundledTasks
+          )
+        )
+      case e: LockedException =>
+        logger.error(e.getMessage)
+        Forbidden(Json.toJson(StatusMessage("Forbidden", JsString(e.getMessage))))
       case e: Exception =>
         logger.error(e.getMessage, e)
         InternalServerError(Json.toJson(StatusMessage("KO", JsString(e.getMessage))))
@@ -84,6 +97,19 @@ object MPExceptionUtil {
       case e: NotFoundException =>
         logger.warn(e.getMessage)
         NotFound(Json.toJson(StatusMessage("NotFound", JsString(e.getMessage))))
+      case e: LockConflictException =>
+        logger.debug(e.getMessage)
+        Conflict(
+          Json.obj(
+            "status"       -> "Conflict",
+            "message"      -> e.getMessage,
+            "lockedTaskId" -> e.conflictingLock.itemId,
+            "bundledTasks" -> e.conflictingLock.bundledTasks
+          )
+        )
+      case e: LockedException =>
+        logger.warn(e.getMessage)
+        Forbidden(Json.toJson(StatusMessage("Forbidden", JsString(e.getMessage))))
       case e: ChangeConflictException =>
         logger.error(e.getMessage, e)
         Conflict(Json.toJson(StatusMessage("Conflict", JsString(e.getMessage))))

--- a/app/org/maproulette/exception/MPExceptions.scala
+++ b/app/org/maproulette/exception/MPExceptions.scala
@@ -4,6 +4,7 @@
  */
 package org.maproulette.exception
 
+import org.maproulette.models.Lock
 import sangria.execution.UserFacingError
 
 /**
@@ -29,6 +30,19 @@ class NotFoundException(message: String) extends Exception(message) with UserFac
   * @param message The message to send with the exception
   */
 class LockedException(message: String) extends Exception(message) with UserFacingError
+
+/**
+  * Thrown when a user attempts to lock a task while already holding a lock on a
+  * different task. Carries the user's existing lock so callers can surface enough
+  * detail (which task/bundle is currently held) for a client to offer a
+  * confirm-and-switch flow, retrying with force=true.
+  *
+  * @param message The message to send with the exception
+  * @param conflictingLock The lock the user currently holds elsewhere
+  */
+class LockConflictException(message: String, val conflictingLock: Lock)
+    extends Exception(message)
+    with UserFacingError
 
 /**
   * Exception for handling the unique violations when trying to insert objects into the database

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -71,6 +71,13 @@ class TaskBundleController @Inject() (
         case None    => throw new InvalidException("No tasks found in this bundle.")
       }
 
+      val primaryTask = tasks.find(_.id == primaryId).getOrElse(tasks.head)
+      // Resolve the lock's bundle membership before setTaskStatus releases it as a side
+      // effect (TaskDAL#setTaskStatus), so we can broadcast the release the same way
+      // unbundleTasks/deleteTaskBundle do below - otherwise other tabs/sessions never
+      // learn these tasks were unlocked and keep showing them as locked-by-you.
+      val releasedTasks = this.taskDAL.resolveLockReleaseTasks(primaryTask)
+
       val completionResponses = request.body.asJson
       this.taskDAL.setTaskStatus(
         tasks,
@@ -91,6 +98,20 @@ class TaskBundleController @Inject() (
         if (tagList.nonEmpty) {
           this.addTagstoItem(task.id, tagList.map(new Tag(-1, _, tagType = this.tagType)), user)
         }
+      }
+
+      try {
+        if (releasedTasks.length > 1) {
+          webSocketProvider.sendMessage(
+            WebSocketMessages.tasksReleased(releasedTasks, Some(WebSocketMessages.userSummary(user)))
+          )
+        } else {
+          webSocketProvider.sendMessage(
+            WebSocketMessages.taskReleased(releasedTasks.head, Some(WebSocketMessages.userSummary(user)))
+          )
+        }
+      } catch {
+        case e: Exception => logger.warn(e.getMessage)
       }
 
       // Refetch to get updated data

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -103,11 +103,13 @@ class TaskBundleController @Inject() (
       try {
         if (releasedTasks.length > 1) {
           webSocketProvider.sendMessage(
-            WebSocketMessages.tasksReleased(releasedTasks, Some(WebSocketMessages.userSummary(user)))
+            WebSocketMessages
+              .tasksReleased(releasedTasks, Some(WebSocketMessages.userSummary(user)))
           )
         } else {
           webSocketProvider.sendMessage(
-            WebSocketMessages.taskReleased(releasedTasks.head, Some(WebSocketMessages.userSummary(user)))
+            WebSocketMessages
+              .taskReleased(releasedTasks.head, Some(WebSocketMessages.userSummary(user)))
           )
         }
       } catch {

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -6,7 +6,7 @@
 package org.maproulette.framework.controller
 
 import javax.inject.Inject
-import org.maproulette.exception.InvalidException
+import org.maproulette.exception.{InvalidException, LockConflictException}
 import org.maproulette.data._
 import org.maproulette.framework.model.{Task, Tag}
 import org.maproulette.framework.service.{TaskBundleService, ServiceManager, TagService}
@@ -231,7 +231,8 @@ class TaskBundleController @Inject() (
 
   /**
     * Creates a new task bundle with the task ids in the json body, assigning
-    * ownership of the bundle to the logged-in user
+    * ownership of the bundle to the logged-in user. Locks the bundle's primary task for
+    * the user, recording the other member task ids in that lock's bundledTasks.
     *
     * @return A TaskBundle representing the new bundle
     */
@@ -243,8 +244,12 @@ class TaskBundleController @Inject() (
         case Some(tasks) => tasks
         case None        => throw new InvalidException("No task ids provided for task bundle")
       }
-      val bundle = this.serviceManager.taskBundle.createTaskBundle(user, name, primaryId, taskIds)
-      Created(Json.toJson(bundle))
+      try {
+        val bundle = this.serviceManager.taskBundle.createTaskBundle(user, name, primaryId, taskIds)
+        Created(Json.toJson(bundle))
+      } catch {
+        case e: LockConflictException => this.lockConflictResponse(e)
+      }
     }
   }
 
@@ -254,15 +259,15 @@ class TaskBundleController @Inject() (
     * @param id The id for the bundle
     * @return Task Bundle
     */
-  def getTaskBundle(id: Long, lockTasks: Boolean): Action[AnyContent] = Action.async {
-    implicit request =>
-      this.sessionManager.authenticatedRequest { implicit user =>
-        Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id, lockTasks)))
-      }
+  def getTaskBundle(id: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
+    }
   }
 
   /**
-    *  Sets the bundle to the tasks provided, and unlock all tasks removed from current bundle
+    *  Sets the bundle to the tasks provided, and unlock all tasks removed from current bundle.
+    *  Re-locks the bundle's primary task with the updated bundledTasks membership.
     *
     * @param bundleId The id of the bundle
     * @param taskIds The task ids the bundle will reset to
@@ -272,9 +277,36 @@ class TaskBundleController @Inject() (
       taskIds: List[Long]
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      this.serviceManager.taskBundle.updateTaskBundle(user, id, taskIds)
-      Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
+      try {
+        this.serviceManager.taskBundle.updateTaskBundle(user, id, taskIds)
+        Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
+      } catch {
+        case e: LockConflictException => this.lockConflictResponse(e)
+      }
     }
+  }
+
+  /**
+    * Builds a 409 Conflict response describing the lock the user already holds elsewhere,
+    * so the client can release it (task release endpoint) and retry.
+    */
+  private def lockConflictResponse(e: LockConflictException): Result = {
+    val conflictingTaskId = e.conflictingLock.itemId
+    val conflictingParentName =
+      this.taskDAL
+        .retrieveById(conflictingTaskId)
+        .flatMap(t => this.serviceManager.challenge.retrieve(t.parent))
+        .map(_.name)
+    Conflict(
+      Json.obj(
+        "status"       -> "Conflict",
+        "message"      -> e.getMessage,
+        "lockedTaskId" -> conflictingTaskId,
+        "parentName"   -> conflictingParentName,
+        "bundledTasks" -> e.conflictingLock.bundledTasks,
+        "startedAt"    -> e.conflictingLock.lockedTime.map(_.toString)
+      )
+    )
   }
 
   /**

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -8,9 +8,10 @@ package org.maproulette.framework.controller
 import javax.inject.Inject
 import org.maproulette.exception.{InvalidException, LockConflictException}
 import org.maproulette.data._
-import org.maproulette.framework.model.{Task, Tag}
+import org.maproulette.framework.model.{Task, TaskBundle, Tag, User}
 import org.maproulette.framework.service.{TaskBundleService, ServiceManager, TagService}
 import org.maproulette.framework.mixins.TagsControllerMixin
+import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
 import org.maproulette.session.SessionManager
 import play.api.libs.json._
 import play.api.mvc._
@@ -27,7 +28,8 @@ class TaskBundleController @Inject() (
     val tagService: TagService,
     components: ControllerComponents,
     serviceManager: ServiceManager,
-    taskDAL: TaskDAL
+    taskDAL: TaskDAL,
+    webSocketProvider: WebSocketProvider
 ) extends AbstractController(components)
     with MapRouletteController
     with TagsControllerMixin[Task] {
@@ -246,6 +248,7 @@ class TaskBundleController @Inject() (
       }
       try {
         val bundle = this.serviceManager.taskBundle.createTaskBundle(user, name, primaryId, taskIds)
+        this.broadcastBundleClaimed(bundle, user)
         Created(Json.toJson(bundle))
       } catch {
         case e: LockConflictException => this.lockConflictResponse(e)
@@ -278,8 +281,22 @@ class TaskBundleController @Inject() (
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       try {
+        val previousTaskIds = this.serviceManager.taskBundle.getTaskBundle(user, id).taskIds
         this.serviceManager.taskBundle.updateTaskBundle(user, id, taskIds)
-        Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
+        val updatedBundle = this.serviceManager.taskBundle.getTaskBundle(user, id)
+
+        val removedTaskIds = previousTaskIds.filterNot(taskIds.contains)
+        if (removedTaskIds.nonEmpty) {
+          webSocketProvider.sendMessage(
+            WebSocketMessages.tasksReleased(
+              this.taskDAL.retrieveListById(-1, 0)(removedTaskIds),
+              Some(WebSocketMessages.userSummary(user))
+            )
+          )
+        }
+        this.broadcastBundleClaimed(updatedBundle, user)
+
+        Ok(Json.toJson(updatedBundle))
       } catch {
         case e: LockConflictException => this.lockConflictResponse(e)
       }
@@ -310,6 +327,34 @@ class TaskBundleController @Inject() (
   }
 
   /**
+    * Broadcasts a tasks-claimed websocket message for the bundle's current task
+    * membership, so other tabs/sessions of the same user (or anyone else subscribed
+    * to task/challenge updates) can resync their view of which tasks are bundled and
+    * locked together. Mirrors TaskController#startOnTask's single-task broadcast.
+    */
+  private def broadcastBundleClaimed(bundle: TaskBundle, user: User): Unit = {
+    val tasks = bundle.tasks.getOrElse(List())
+    if (tasks.nonEmpty) {
+      val challengeAndProject = for {
+        challenge <- this.serviceManager.challenge.retrieve(tasks.head.parent)
+        project   <- this.serviceManager.project.retrieve(challenge.general.parent)
+      } yield (challenge, project)
+
+      challengeAndProject.foreach {
+        case (challenge, project) =>
+          webSocketProvider.sendMessage(
+            WebSocketMessages.tasksClaimed(
+              tasks,
+              WebSocketMessages.challengeSummary(challenge),
+              WebSocketMessages.projectSummary(project),
+              WebSocketMessages.userSummary(user)
+            )
+          )
+      }
+    }
+  }
+
+  /**
     * Remove tasks from a bundle.
     *
     * @param id      The id for the bundle
@@ -321,7 +366,13 @@ class TaskBundleController @Inject() (
       taskIds: List[Long]
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
+      val removedTasks = this.taskDAL.retrieveListById(-1, 0)(taskIds)
       this.serviceManager.taskBundle.unbundleTasks(user, id, taskIds)
+      if (removedTasks.nonEmpty) {
+        webSocketProvider.sendMessage(
+          WebSocketMessages.tasksReleased(removedTasks, Some(WebSocketMessages.userSummary(user)))
+        )
+      }
       Ok(Json.toJson(this.serviceManager.taskBundle.getTaskBundle(user, id)))
     }
   }
@@ -334,7 +385,13 @@ class TaskBundleController @Inject() (
   def deleteTaskBundle(id: Long): Action[AnyContent] =
     Action.async { implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
+        val tasks = this.serviceManager.taskBundle.getTaskBundle(user, id).tasks.getOrElse(List())
         this.serviceManager.taskBundle.deleteTaskBundle(user, id)
+        if (tasks.nonEmpty) {
+          webSocketProvider.sendMessage(
+            WebSocketMessages.tasksReleased(tasks, Some(WebSocketMessages.userSummary(user)))
+          )
+        }
         Ok
       }
     }

--- a/app/org/maproulette/framework/mixins/Locking.scala
+++ b/app/org/maproulette/framework/mixins/Locking.scala
@@ -191,16 +191,22 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
         this.enforceSingleEditLock(user, item.id.asInstanceOf[Long])
       }
 
-      // first check to see if the item is already locked
+      // first check to see if the item is already locked - resolve through bundled_tasks
+      // too, since item may be a non-primary member of a bundle whose lock row is keyed
+      // on the primary's item_id
       val checkQuery =
-        s"""SELECT user_id FROM locked WHERE item_id = {itemId} AND item_type = ${item.itemType.typeId} FOR UPDATE"""
+        s"""SELECT user_id FROM locked
+            WHERE (item_id = {itemId} OR {itemId} = ANY(bundled_tasks)) AND item_type = ${item.itemType.typeId}
+            FOR UPDATE"""
       SQL(checkQuery)
         .on(Symbol("itemId") -> ParameterValue.toParameterValue(item.id)(p = keyToStatement))
         .as(SqlParser.long("user_id").singleOpt) match {
         case Some(id) =>
           if (id == user.id) {
             val query =
-              s"UPDATE locked SET locked_time = NOW() WHERE user_id = ${user.id} AND item_id = {itemId} AND item_type = ${item.itemType.typeId}"
+              s"""UPDATE locked SET locked_time = NOW()
+                  WHERE user_id = ${user.id}
+                  AND (item_id = {itemId} OR {itemId} = ANY(bundled_tasks)) AND item_type = ${item.itemType.typeId}"""
             SQL(query)
               .on(Symbol("itemId") -> ParameterValue.toParameterValue(item.id)(p = keyToStatement))
               .executeUpdate()
@@ -217,6 +223,28 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
             .executeUpdate()
           user.id
       }
+    }
+
+  /**
+    * Resolves the primary item id and bundled member ids of the lock currently covering
+    * the given item, regardless of who holds it. Returns None if the item is unlocked.
+    *
+    * @param item The item (primary or bundle member) to resolve the covering lock for
+    * @param c    A sql connection implicitly passed in from the calling function
+    * @return Some((primaryItemId, memberTaskIds)) if a lock covers the item, else None
+    */
+  def resolveLockBundle(
+      item: T
+  )(implicit c: Option[Connection] = None): Option[(Long, List[Long])] =
+    this.withMRTransaction { implicit c =>
+      SQL(
+        s"""SELECT item_id, bundled_tasks FROM locked
+            WHERE (item_id = {itemId} OR {itemId} = ANY(bundled_tasks)) AND item_type = ${item.itemType.typeId}"""
+      ).on(Symbol("itemId") -> ParameterValue.toParameterValue(item.id)(p = keyToStatement))
+        .as(
+          (SqlParser.long("item_id") ~ SqlParser.get[List[Long]]("bundled_tasks")).singleOpt
+        )
+        .map { case primaryItemId ~ bundledTasks => (primaryItemId, bundledTasks) }
     }
 
   /**
@@ -240,8 +268,11 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
       this.enforceSingleEditLock(user, primaryItem.id)
 
       val members = memberTaskIds.filterNot(_ == primaryItem.id).distinct
+      // Avoid the curly-brace array literal ('{}') here - anorm's SQL() scans the raw query
+      // text for {paramName} placeholders, and a literal {} in the empty case gets mistaken
+      // for one, corrupting the query. ARRAY[]::integer[] is equivalent and brace-free.
       val membersLiteral =
-        if (members.isEmpty) "'{}'::integer[]" else s"ARRAY[${members.mkString(",")}]::integer[]"
+        if (members.isEmpty) "ARRAY[]::integer[]" else s"ARRAY[${members.mkString(",")}]::integer[]"
 
       val checkQuery =
         s"""SELECT user_id FROM locked WHERE item_id = {itemId} AND item_type = ${primaryItem.itemType.typeId} FOR UPDATE"""
@@ -299,7 +330,7 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
 
     existingLock match {
       case Some(itemId ~ itemType ~ changesetId ~ bundledTasks ~ lockedTime)
-          if itemId != targetItemId =>
+          if itemId != targetItemId && !bundledTasks.contains(targetItemId) =>
         throw new LockConflictException(
           s"User ${user.id} already holds a lock on item ${itemId}",
           Lock(lockedTime, itemType, itemId, user.id, changesetId, bundledTasks)

--- a/app/org/maproulette/framework/mixins/Locking.scala
+++ b/app/org/maproulette/framework/mixins/Locking.scala
@@ -186,6 +186,31 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
     }
 
   /**
+    * Resolves who currently holds the lock covering the given item (primary or bundle
+    * member), without acquiring or refreshing anything. Used to report lock ownership on
+    * plain task reads so a task locked by the current user renders as locked-by-me even in
+    * a tab that never issued its own /start (e.g. the same task opened in a second tab).
+    *
+    * @param item The item (primary or bundle member) to resolve the covering lock for
+    * @param c    A sql connection implicitly passed in from the calling function
+    * @return Some((holderUserId, primaryItemId, memberTaskIds)) if a lock covers the item, else None
+    */
+  def resolveLockHolder(
+      item: T
+  )(implicit c: Option[Connection] = None): Option[(Long, Long, List[Long])] =
+    this.withMRTransaction { implicit c =>
+      SQL(
+        s"""SELECT user_id, item_id, bundled_tasks FROM locked
+            WHERE (item_id = {itemId} OR {itemId} = ANY(bundled_tasks)) AND item_type = ${item.itemType.typeId}"""
+      ).on(Symbol("itemId") -> ParameterValue.toParameterValue(item.id)(p = keyToStatement))
+        .as(
+          (SqlParser.long("user_id") ~ SqlParser.long("item_id") ~
+            SqlParser.get[List[Long]]("bundled_tasks")).singleOpt
+        )
+        .map { case userId ~ primaryItemId ~ bundledTasks => (userId, primaryItemId, bundledTasks) }
+    }
+
+  /**
     * Locks a bundle's primary task, recording the other bundle member task ids in the
     * bundled_tasks column instead of locking each member individually. Releasing, refreshing,
     * or checking the lock on any member task resolves to this single covering row (see

--- a/app/org/maproulette/framework/mixins/Locking.scala
+++ b/app/org/maproulette/framework/mixins/Locking.scala
@@ -9,21 +9,31 @@ import java.sql.Connection
 import anorm._
 
 import java.sql.PreparedStatement
+import org.joda.time.DateTime
 import org.maproulette.data.ItemType
-import org.maproulette.exception.LockedException
+import org.maproulette.exception.{LockConflictException, LockedException}
 import org.maproulette.framework.model.{Task, User}
 import org.maproulette.framework.psql.TransactionManager
-import org.maproulette.models.BaseObject
+import org.maproulette.models.{BaseObject, Lock}
 import org.maproulette.framework.repository.RepositoryMixin
 
 /**
+  * A user may hold at most one active edit lock at a time (enforced by a partial unique
+  * index on locked(user_id) WHERE NOT is_review_claim). When a task is the primary of a
+  * bundle, its lock row's bundled_tasks column lists the other member task ids that the
+  * same lock covers, instead of each member getting its own row. Review-claim locks
+  * (TaskReviewRepository) are tagged is_review_claim = true and are exempt from the
+  * one-lock invariant.
+  *
   * @author mcuthbert
   */
 trait Locking[T <: BaseObject[_]] extends TransactionManager {
   this: RepositoryMixin =>
 
   /**
-    * Unlocks an item in the database
+    * Unlocks an item in the database. If the item is a member of a bundle (i.e. covered by
+    * another task's bundled_tasks rather than being the item_id itself), this releases the
+    * single row that covers the whole bundle.
     *
     * @param user The user requesting to unlock the item
     * @param item The item being unlocked
@@ -35,20 +45,23 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
   def unlockItem(user: User, item: T)(implicit c: Option[Connection] = None): Int =
     this.withMRTransaction { implicit c =>
       val checkQuery =
-        s"""SELECT user_id FROM locked WHERE item_id = {itemId} AND item_type = ${item.itemType.typeId} FOR UPDATE"""
+        s"""SELECT user_id FROM locked
+            WHERE (item_id = {itemId} OR {itemId} = ANY(bundled_tasks)) AND item_type = ${item.itemType.typeId}
+            FOR UPDATE"""
       SQL(checkQuery)
         .on(Symbol("itemId") -> ParameterValue.toParameterValue(item.id)(p = keyToStatement))
         .as(SqlParser.long("user_id").singleOpt) match {
         case Some(id) =>
           if (id == user.id) {
             val query =
-              s"""DELETE FROM locked WHERE user_id = ${user.id} AND item_id = {itemId} AND item_type = ${item.itemType.typeId}"""
+              s"""DELETE FROM locked WHERE user_id = ${user.id}
+                  AND (item_id = {itemId} OR {itemId} = ANY(bundled_tasks)) AND item_type = ${item.itemType.typeId}"""
             SQL(query)
               .on(Symbol("itemId") -> ParameterValue.toParameterValue(item.id)(p = keyToStatement))
               .executeUpdate()
           } else {
             throw new LockedException(
-              s"Item ${item.id} currently locked by user ${user.id}"
+              s"Item ${item.id} currently locked by user ${id}"
             )
           }
         case None =>
@@ -69,20 +82,24 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
   def refreshItemLock(user: User, item: T)(implicit c: Option[Connection] = None): Int =
     this.withMRTransaction { implicit c =>
       val checkQuery =
-        s"""SELECT user_id FROM locked WHERE item_id = {itemId} AND item_type = ${item.itemType.typeId} FOR UPDATE"""
+        s"""SELECT user_id FROM locked
+            WHERE (item_id = {itemId} OR {itemId} = ANY(bundled_tasks)) AND item_type = ${item.itemType.typeId}
+            FOR UPDATE"""
       SQL(checkQuery)
         .on(Symbol("itemId") -> ParameterValue.toParameterValue(item.id)(p = keyToStatement))
         .as(SqlParser.long("user_id").singleOpt) match {
         case Some(id) =>
           if (id == user.id) {
             val query =
-              s"""UPDATE locked set locked_time=NOW() WHERE user_id = ${user.id} AND item_id = {itemId} AND item_type = ${item.itemType.typeId}"""
+              s"""UPDATE locked set locked_time=NOW()
+                  WHERE user_id = ${user.id}
+                  AND (item_id = {itemId} OR {itemId} = ANY(bundled_tasks)) AND item_type = ${item.itemType.typeId}"""
             SQL(query)
               .on(Symbol("itemId") -> ParameterValue.toParameterValue(item.id)(p = keyToStatement))
               .executeUpdate()
           } else {
             throw new LockedException(
-              s"Item ${item.id} currently locked by user ${user.id}"
+              s"Item ${item.id} currently locked by user ${id}"
             )
           }
         case None => throw new LockedException(s"Lock on item ${item.id} does not exist.")
@@ -154,15 +171,26 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
   /**
     * Locks an item in the database.
     *
-    * @param user The user requesting the lock
-    * @param item The item wanting to be locked
-    * @param c    A sql connection that is implicitly passed in from the calling function, this is an
-    *             implicit function because this will always be called from within the code and never
-    *             directly from an API call
+    * @param user        The user requesting the lock
+    * @param item        The item wanting to be locked
+    * @param reviewClaim Whether this lock represents a reviewer's review claim rather than an
+    *                    ordinary edit lock. Review-claim locks are exempt from the one-lock-per-user
+    *                    invariant.
+    * @param c           A sql connection that is implicitly passed in from the calling function, this is an
+    *                    implicit function because this will always be called from within the code and never
+    *                    directly from an API call
     * @return user id of who now holds the lock
     */
-  def lockItem(user: User, item: T)(implicit c: Option[Connection] = None): Long =
+  def lockItem(
+      user: User,
+      item: T,
+      reviewClaim: Boolean = false
+  )(implicit c: Option[Connection] = None): Long =
     this.withMRTransaction { implicit c =>
+      if (!reviewClaim) {
+        this.enforceSingleEditLock(user, item.id.asInstanceOf[Long])
+      }
+
       // first check to see if the item is already locked
       val checkQuery =
         s"""SELECT user_id FROM locked WHERE item_id = {itemId} AND item_type = ${item.itemType.typeId} FOR UPDATE"""
@@ -182,7 +210,8 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
           }
         case None =>
           val query =
-            s"INSERT INTO locked (item_type, item_id, user_id) VALUES (${item.itemType.typeId}, {itemId}, ${user.id})"
+            s"""INSERT INTO locked (item_type, item_id, user_id, is_review_claim)
+                VALUES (${item.itemType.typeId}, {itemId}, ${user.id}, $reviewClaim)"""
           SQL(query)
             .on(Symbol("itemId") -> ParameterValue.toParameterValue(item.id)(p = keyToStatement))
             .executeUpdate()
@@ -191,7 +220,96 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
     }
 
   /**
-    * Unlocks all the items that are associated with the current user
+    * Locks a bundle's primary task, recording the other bundle member task ids in the
+    * bundled_tasks column instead of locking each member individually. Releasing, refreshing,
+    * or checking the lock on any member task resolves to this single covering row (see
+    * unlockItem/refreshItemLock above).
+    *
+    * @param user          The user requesting the lock
+    * @param primaryItem   The bundle's primary task
+    * @param memberTaskIds The ids of the other tasks in the bundle (primary excluded automatically)
+    * @param c             A sql connection implicitly passed in from the calling function
+    * @return user id of who now holds the lock
+    */
+  def lockBundle(
+      user: User,
+      primaryItem: Task,
+      memberTaskIds: List[Long]
+  )(implicit c: Option[Connection] = None): Long =
+    this.withMRTransaction { implicit c =>
+      this.enforceSingleEditLock(user, primaryItem.id)
+
+      val members = memberTaskIds.filterNot(_ == primaryItem.id).distinct
+      val membersLiteral =
+        if (members.isEmpty) "'{}'::integer[]" else s"ARRAY[${members.mkString(",")}]::integer[]"
+
+      val checkQuery =
+        s"""SELECT user_id FROM locked WHERE item_id = {itemId} AND item_type = ${primaryItem.itemType.typeId} FOR UPDATE"""
+      SQL(checkQuery)
+        .on(Symbol("itemId") -> ParameterValue.toParameterValue(primaryItem.id)(p = keyToStatement))
+        .as(SqlParser.long("user_id").singleOpt) match {
+        case Some(id) if id != user.id => id
+        case Some(_) =>
+          val query =
+            s"""UPDATE locked SET locked_time = NOW(), bundled_tasks = $membersLiteral
+                WHERE user_id = ${user.id} AND item_id = {itemId} AND item_type = ${primaryItem.itemType.typeId}"""
+          SQL(query)
+            .on(
+              Symbol("itemId") -> ParameterValue.toParameterValue(primaryItem.id)(p = keyToStatement
+              )
+            )
+            .executeUpdate()
+          user.id
+        case None =>
+          val query =
+            s"""INSERT INTO locked (item_type, item_id, user_id, bundled_tasks)
+                VALUES (${primaryItem.itemType.typeId}, {itemId}, ${user.id}, $membersLiteral)"""
+          SQL(query)
+            .on(
+              Symbol("itemId") -> ParameterValue.toParameterValue(primaryItem.id)(p = keyToStatement
+              )
+            )
+            .executeUpdate()
+          user.id
+      }
+    }
+
+  /**
+    * Enforces the one-active-edit-lock-per-user invariant ahead of an insert/refresh on
+    * `targetItemId`. If the user already holds a different non-review-claim lock, throws
+    * LockConflictException carrying that lock's details - the caller is expected to release
+    * it explicitly (e.g. via the task release endpoint) before retrying, rather than this
+    * silently swapping the lock out from under them.
+    *
+    * Must be called from within an already-open withMRTransaction block (hence the plain,
+    * non-Option implicit Connection).
+    */
+  private def enforceSingleEditLock(user: User, targetItemId: Long)(
+      implicit c: Connection
+  ): Unit = {
+    val existingLock =
+      SQL("""SELECT item_id, item_type, changeset_id, bundled_tasks, locked_time
+             FROM locked WHERE user_id = {userId} AND NOT is_review_claim FOR UPDATE""")
+        .on(Symbol("userId") -> user.id)
+        .as(
+          (SqlParser.long("item_id") ~ SqlParser.int("item_type") ~
+            SqlParser.long("changeset_id") ~ SqlParser.get[List[Long]]("bundled_tasks") ~
+            SqlParser.get[Option[DateTime]]("locked_time")).singleOpt
+        )
+
+    existingLock match {
+      case Some(itemId ~ itemType ~ changesetId ~ bundledTasks ~ lockedTime)
+          if itemId != targetItemId =>
+        throw new LockConflictException(
+          s"User ${user.id} already holds a lock on item ${itemId}",
+          Lock(lockedTime, itemType, itemId, user.id, changesetId, bundledTasks)
+        )
+      case _ => // no existing lock, or it already covers the target item - nothing to do
+    }
+  }
+
+  /**
+    * Unlocks all the (non review-claim) edit locks associated with the current user
     *
     * @param user The user
     * @param c    an implicit connection, this function should generally be executed in conjunction
@@ -204,148 +322,11 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
     this.withMRTransaction { implicit c =>
       itemType match {
         case Some(it) =>
-          SQL"""DELETE FROM locked WHERE user_id = ${user.id} AND item_type = ${it.typeId}"""
+          SQL"""DELETE FROM locked WHERE user_id = ${user.id} AND item_type = ${it.typeId} AND NOT is_review_claim"""
             .executeUpdate()
         case None =>
-          SQL"""DELETE FROM locked WHERE user_id = ${user.id}""".executeUpdate()
-      }
-    }
-
-  /**
-    * Locks multiple items in a single database transaction.
-    *
-    * @param user  The user requesting the locks
-    * @param items The list of items to be locked
-    * @param c     A sql connection that is implicitly passed in from the calling function
-    * @return Map of item ids to the user ids that hold the lock for each conflicting item
-    */
-  def lockItems(user: User, items: List[Task])(
-      implicit c: Option[Connection] = None
-  ): Map[Long, Long] =
-    this.withMRTransaction { implicit c =>
-      if (items.isEmpty) {
-        Map.empty[Long, Long]
-      } else {
-        // Remove duplicates from the input list while preserving order
-        val distinctItems = items.distinctBy(_.id)
-
-        // Build a single query with multiple value sets for better performance
-        val valuesList = distinctItems
-          .map { item =>
-            s"(${item.itemType.typeId}, ${item.id}, ${user.id}, NOW())"
-          }
-          .mkString(", ")
-
-        val query =
-          s"""
-             |WITH upsert AS (
-             |  INSERT INTO locked (item_type, item_id, user_id, locked_time)
-             |  VALUES $valuesList
-             |  ON CONFLICT (item_type, item_id) 
-             |  DO UPDATE SET locked_time = NOW()
-             |  WHERE locked.user_id = ${user.id}
-             |  RETURNING item_id, user_id
-             |)
-             |SELECT l.item_id, l.user_id
-             |FROM upsert l
-           """.stripMargin
-
-        val results = SQL(query).as(
-          (SqlParser.long("item_id") ~ SqlParser.long("user_id")).*
-        )
-
-        val resultMap = results.map { case id ~ userId => (id -> userId) }.toMap
-
-        // Find items that failed to lock - fix type mismatch by explicitly converting to Long
-        val failedToLock = items.filter(item => !resultMap.contains(item.id))
-        // Find items locked by wrong user
-        val wrongUserLocks = resultMap.filter { case (_, lockUserId) => lockUserId != user.id }
-
-        if (failedToLock.nonEmpty || wrongUserLocks.nonEmpty) {
-          val failedItemsMsg = if (failedToLock.nonEmpty) {
-            s"Failed to lock items: ${failedToLock.map(_.id).mkString(", ")}"
-          } else ""
-
-          val wrongUserMsg = if (wrongUserLocks.nonEmpty) {
-            s"Items locked by different users: ${wrongUserLocks.keys.mkString(", ")}"
-          } else ""
-
-          val errorMsg = List(failedItemsMsg, wrongUserMsg).filter(_.nonEmpty).mkString(". ")
-          throw new IllegalAccessException(s"Lock operation failed. $errorMsg")
-        }
-
-        resultMap
-      }
-    }
-
-  /**
-    * Unlocks multiple items in a single database transaction.
-    *
-    * @param user  The user requesting to unlock the items
-    * @param items The list of items to be unlocked
-    * @param c     A sql connection that is implicitly passed in from the calling function
-    * @return Number of items successfully unlocked
-    * @throws LockedException if any items are locked by a different user or not locked at all
-    */
-  def unlockItems(user: User, items: List[Task])(
-      implicit c: Option[Connection] = None
-  ): Int =
-    this.withMRTransaction { implicit c =>
-      if (items.isEmpty) {
-        0
-      } else {
-        // Remove duplicates from the input list while preserving order
-        val distinctItems = items.distinctBy(_.id)
-        // Create a list of item IDs and types for the IN clause
-        val itemIds  = distinctItems.map(_.id)
-        val itemType = distinctItems.headOption.map(_.itemType.typeId).getOrElse(0)
-
-        // Check the lock status of all requested items
-        val checkQuery =
-          s"""
-             |SELECT item_id, user_id 
-             |FROM locked 
-             |WHERE item_id IN (${itemIds.mkString(",")})
-             |AND item_type = $itemType
-             |FOR UPDATE
-           """.stripMargin
-
-        val lockStatus = SQL(checkQuery)
-          .as(
-            (SqlParser.long("item_id") ~ SqlParser.long("user_id")).*
-          )
-          .map { case id ~ userId => (id -> userId) }
-          .toMap
-
-        // Find items that aren't locked at all
-        val notLockedItems = itemIds.filter(id => !lockStatus.contains(id))
-
-        // Find items locked by other users
-        val lockedByOthers = lockStatus.filter { case (_, lockUserId) => lockUserId != user.id }
-
-        if (notLockedItems.nonEmpty || lockedByOthers.nonEmpty) {
-          val notLockedMsg = if (notLockedItems.nonEmpty) {
-            s"Items not locked: ${notLockedItems.mkString(", ")}"
-          } else ""
-
-          val lockedByOthersMsg = if (lockedByOthers.nonEmpty) {
-            s"Items locked by different users: ${lockedByOthers.keys.mkString(", ")}"
-          } else ""
-
-          val errorMsg = List(notLockedMsg, lockedByOthersMsg).filter(_.nonEmpty).mkString(". ")
-          throw new LockedException(s"Unlock operation failed for user ${user.id}. $errorMsg")
-        }
-
-        // All items are locked by the current user, proceed with unlock
-        val deleteQuery =
-          s"""
-             |DELETE FROM locked 
-             |WHERE item_id IN (${itemIds.mkString(",")})
-             |AND item_type = $itemType
-             |AND user_id = ${user.id}
-           """.stripMargin
-
-        SQL(deleteQuery).executeUpdate()
+          SQL"""DELETE FROM locked WHERE user_id = ${user.id} AND NOT is_review_claim"""
+            .executeUpdate()
       }
     }
 

--- a/app/org/maproulette/framework/mixins/Locking.scala
+++ b/app/org/maproulette/framework/mixins/Locking.scala
@@ -107,68 +107,6 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
     }
 
   /**
-    * Method to lock all items returned in the lambda block. It will first all unlock all items
-    * that have been locked by the user.
-    *
-    * @param user     The user making the request
-    * @param itemType The type of item that will be locked
-    * @param block    The block of code to execute inbetween unlocking and locking items
-    * @param c        The connection
-    * @return List of objects
-    */
-  def withListLocking(user: User, itemType: Option[ItemType] = None)(
-      block: () => List[T]
-  )(implicit c: Option[Connection] = None): List[T] = {
-    this.withMRTransaction { implicit c =>
-      // if a user is requesting a task, then we can unlock all other tasks for that user, as only a single
-      // task can be locked at a time
-      this.unlockAllItems(user, itemType)
-      val results = block()
-      // once we have the tasks, we need to lock each one, if any fail to lock we just remove
-      // them from the list. A guest user will not lock any tasks, but when logged in will be
-      // required to refetch the current task, and if it is locked, then will have to get another
-      // task
-      if (!user.guest) {
-        val resultList = results.filter(lockItem(user, _) == user.id)
-        if (resultList.isEmpty) {
-          List[T]()
-        }
-        resultList
-      } else {
-        results
-      }
-    }
-  }
-
-  /**
-    * Method to lock a single optional item returned in a lambda block. It will first unlock all items
-    * that have been locked by the user
-    *
-    * @param user     The user making the request
-    * @param itemType The type of item that will be locked
-    * @param block    The block of code to execute inbetween unlocking and locking items
-    * @param c        The connection
-    * @return Option object
-    */
-  def withSingleLocking(user: User, itemType: Option[ItemType] = None)(
-      block: () => Option[T]
-  )(implicit c: Option[Connection] = None): Option[T] = {
-    this.withMRTransaction { implicit c =>
-      // if a user is requesting a task, then we can unlock all other tasks for that user, as only a single
-      // task can be locked at a time
-      this.unlockAllItems(user, itemType)
-      val result = block()
-      if (!user.guest) {
-        result match {
-          case Some(r) => lockItem(user, r)
-          case None    => // ignore
-        }
-      }
-      result
-    }
-  }
-
-  /**
     * Locks an item in the database.
     *
     * @param user        The user requesting the lock

--- a/app/org/maproulette/framework/model/LockedTaskData.scala
+++ b/app/org/maproulette/framework/model/LockedTaskData.scala
@@ -19,7 +19,12 @@ case class LockedTaskData(
     /**
       * The time that the task was locked
       */
-    startedAt: DateTime
+    startedAt: DateTime,
+    /**
+      * The ids of any other tasks covered by this same lock (bundle members), if this
+      * task is the primary of a bundle
+      */
+    bundledTasks: List[Long] = List.empty
 )
 
 // Define implicit Formats for LockedTaskData

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -11,7 +11,7 @@ import anorm.ToParameterValue
 import anorm.SqlParser.scalar
 import anorm._
 import javax.inject.{Inject, Singleton}
-import org.maproulette.exception.InvalidException
+import org.maproulette.exception.{InvalidException, LockConflictException}
 import org.maproulette.Config
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.BaseParameter
@@ -83,9 +83,13 @@ class TaskBundleRepository @Inject() (
     // Second transaction: add tasks to bundle
     this.bundleTasks(user, bundleId, taskIds)
 
-    // Lock the bundle's primary task, recording the other member ids as bundledTasks
-    // instead of locking each task individually.
-    this.lockBundleTasks(user, bundleId)
+    try {
+      this.lockBundleTasks(user, bundleId)
+    } catch {
+      case e: LockConflictException =>
+        this.deleteTaskBundle(user, bundleId)
+        throw e
+    }
 
     val tasks = this.taskDAL.retrieveListById(-1, 0)(taskIds)
 
@@ -268,8 +272,8 @@ class TaskBundleRepository @Inject() (
         Query.simple(List(BaseParameter("bundle_id", bundleId, table = Some("tb"))))
       )
 
-      // Release the bundle's lock (covers the primary and all bundled member tasks)
-      tasks.find(_.isBundlePrimary.getOrElse(false)).foreach { primary =>
+      if (tasks.nonEmpty) {
+        val primary = tasks.find(_.isBundlePrimary.getOrElse(false)).getOrElse(tasks.head)
         try {
           this.unlockItem(user, primary)
         } catch {

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -83,6 +83,10 @@ class TaskBundleRepository @Inject() (
     // Second transaction: add tasks to bundle
     this.bundleTasks(user, bundleId, taskIds)
 
+    // Lock the bundle's primary task, recording the other member ids as bundledTasks
+    // instead of locking each task individually.
+    this.lockBundleTasks(user, bundleId)
+
     val tasks = this.taskDAL.retrieveListById(-1, 0)(taskIds)
 
     // Return the created bundle
@@ -121,6 +125,9 @@ class TaskBundleRepository @Inject() (
       if (tasksToAdd.nonEmpty) {
         this.bundleTasks(user, bundleId, tasksToAdd)
       }
+
+      // Refresh the bundle's lock so bundledTasks reflects the final membership
+      this.lockBundleTasks(user, bundleId)
     }
   }
 
@@ -239,6 +246,13 @@ class TaskBundleRepository @Inject() (
           }
         }
       }
+
+      // Refresh the bundle's lock so bundledTasks no longer includes the removed tasks
+      try {
+        this.lockBundleTasks(user, bundleId)
+      } catch {
+        case e: Exception => this.logger.warn(e.getMessage)
+      }
     }
   }
 
@@ -253,6 +267,15 @@ class TaskBundleRepository @Inject() (
       val tasks = this.retrieveTasks(
         Query.simple(List(BaseParameter("bundle_id", bundleId, table = Some("tb"))))
       )
+
+      // Release the bundle's lock (covers the primary and all bundled member tasks)
+      tasks.find(_.isBundlePrimary.getOrElse(false)).foreach { primary =>
+        try {
+          this.unlockItem(user, primary)
+        } catch {
+          case e: Exception => this.logger.warn(e.getMessage)
+        }
+      }
 
       // Update tasks to set bundle_id and is_bundle_primary to NULL
       SQL(
@@ -318,24 +341,22 @@ class TaskBundleRepository @Inject() (
   }
 
   /**
-    * Locks tasks on bundle fetch if task is in an editable status
+    * Locks the bundle's primary task for the given user, recording the other member task
+    * ids in that lock's bundled_tasks column instead of locking each task individually.
+    * Throws LockConflictException if the user already holds an edit lock on a different
+    * task elsewhere - the caller is expected to have the client release that lock first.
     *
     * @param bundleId The id of the bundle
     */
-  def lockBundledTasks(user: User, tasks: List[Task]) = {
-    this.withMRConnection { implicit c =>
-      try {
-        if (tasks.isEmpty) {
-          // No valid tasks found
-          throw new Exception("No valid tasks found")
-        } else {
-          // Use bulk locking for better performance
-          this.lockItems(user, tasks)
-        }
-      } catch {
-        case e: Exception => this.logger.warn(e.getMessage)
-      }
-    }
+  private def lockBundleTasks(user: User, bundleId: Long): Unit = {
+    val tasks = this.retrieveTasks(
+      Query.simple(List(BaseParameter("bundle_id", bundleId, table = Some("tb"))))
+    )
 
+    if (tasks.nonEmpty) {
+      val primary   = tasks.find(_.isBundlePrimary.getOrElse(false)).getOrElse(tasks.head)
+      val memberIds = tasks.filterNot(_.id == primary.id).map(_.id)
+      this.lockBundle(user, primary, memberIds)
+    }
   }
 }

--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -38,11 +38,12 @@ class TaskClusterRepository @Inject() (
 
   val pointParser = this.challengeDAL.pointParser
 
-  private val joinClause = """
+  private val joinClause =
+    """
     INNER JOIN challenges c ON c.id = tasks.parent_id
     INNER JOIN projects p ON p.id = c.parent_id
     LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
-    LEFT OUTER JOIN locked l ON l.item_id = tasks.id
+    LEFT OUTER JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks))
   """
 
   // SQL query used to select list of ClusteredPoint data
@@ -278,7 +279,7 @@ class TaskClusterRepository @Inject() (
                l.user_id as locked_by
         FROM tasks
         INNER JOIN challenges c ON c.id = tasks.parent_id
-        LEFT JOIN locked l ON l.item_id = tasks.id AND l.item_type = 2
+        LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks)) AND l.item_type = 2
         WHERE $whereClause
         ORDER BY tasks.id
         LIMIT $limit OFFSET $offset
@@ -465,7 +466,7 @@ ORDER BY kmeans;
         FROM tasks
         INNER JOIN challenges c ON c.id = tasks.parent_id
         INNER JOIN projects p ON p.id = c.parent_id
-        LEFT JOIN locked l ON l.item_id = tasks.id AND l.item_type = 2
+        LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks)) AND l.item_type = 2
     """
 
       // Add joins for keywords filtering if keywords are provided
@@ -586,7 +587,7 @@ ORDER BY kmeans;
         FROM tasks
         INNER JOIN challenges c ON c.id = tasks.parent_id
         INNER JOIN projects p ON p.id = c.parent_id
-        LEFT JOIN locked l ON l.item_id = tasks.id AND l.item_type = 2
+        LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks)) AND l.item_type = 2
         $keywordJoins
         WHERE c.deleted = false
           AND c.enabled = true

--- a/app/org/maproulette/framework/repository/TaskRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskRepository.scala
@@ -63,7 +63,7 @@ class TaskRepository @Inject() (override val db: Database, config: Config)
         .build(s"""UPDATE tasks t SET completion_responses = {responses}::JSONB
               WHERE t.id = (
                 SELECT t2.id FROM tasks t2
-                LEFT JOIN locked l on l.item_id = t2.id AND l.item_type = {itemType}
+                LEFT JOIN locked l on (l.item_id = t2.id OR t2.id = ANY(l.bundled_tasks)) AND l.item_type = {itemType}
                 WHERE t2.id = {taskId} AND (l.user_id = {userId} OR l.user_id IS NULL)
               )""")
         .on(

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -92,7 +92,7 @@ class TaskReviewRepository @Inject() (
           .on(Symbol("taskId") -> task.id, Symbol("userId") -> user.id)
           .executeUpdate()
 
-        val lockerId = this.lockItem(user, task)
+        val lockerId = this.lockItem(user, task, reviewClaim = true)
         if (lockerId != user.id) {
           val lockHolder = this.userService.retrieve(lockerId) match {
             case Some(user) => user.osmProfile.displayName
@@ -370,7 +370,7 @@ class TaskReviewRepository @Inject() (
         }}${errorTagString}
                              WHERE task_review.task_id = (
                                 SELECT tasks.id FROM tasks
-                                LEFT JOIN locked l on l.item_id = tasks.id AND l.item_type = ${task.itemType.typeId}
+                                LEFT JOIN locked l on (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks)) AND l.item_type = ${task.itemType.typeId}
                                 WHERE tasks.id = ${task.id} AND (l.user_id = ${user.id} OR l.user_id IS NULL)
                               )""").executeUpdate()
       // if returning 0, then this is because the item is locked by a different user

--- a/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
+++ b/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
@@ -165,14 +165,21 @@ class UserSavedObjectsRepository @Inject() (
   )(implicit c: Option[Connection] = None): List[LockedTaskData] = {
     this.withMRTransaction { implicit c =>
       val parser = for {
-        id         <- get[Long]("id")
-        parent     <- get[Long]("tasks.parent_id")
-        parentName <- get[String]("challenges.challenge_name")
-        lockedTime <- get[DateTime]("locked.locked_time")
-      } yield (LockedTaskData(id, parent, parentName, lockedTime))
+        id           <- get[Long]("id")
+        parent       <- get[Long]("tasks.parent_id")
+        parentName   <- get[String]("challenges.challenge_name")
+        lockedTime   <- get[DateTime]("locked.locked_time")
+        bundledTasks <- get[Option[List[Long]]]("locked.bundled_tasks")
+      } yield (LockedTaskData(
+        id,
+        parent,
+        parentName,
+        lockedTime,
+        bundledTasks.getOrElse(List.empty)
+      ))
 
       val query = """
-                    SELECT t.id, t.parent_id, l.locked_time, c.name AS challenge_name
+                    SELECT t.id, t.parent_id, l.locked_time, l.bundled_tasks, c.name AS challenge_name
                     FROM tasks t
                     INNER JOIN locked l ON t.id = l.item_id
                     INNER JOIN challenges c ON t.parent_id = c.id

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -161,7 +161,7 @@ class TaskBundleService @Inject() (
     *
     * @param bundleId The id of the bundle
     */
-  def getTaskBundle(user: User, bundleId: Long, lockTasks: Boolean = false): TaskBundle = {
+  def getTaskBundle(user: User, bundleId: Long): TaskBundle = {
     val filterQuery =
       Query.simple(
         List(
@@ -174,9 +174,6 @@ class TaskBundleService @Inject() (
 
     if (ownerId.isEmpty) {
       throw new NotFoundException(s"Task Bundle not found with id $bundleId.")
-    }
-    if (lockTasks) {
-      this.repository.lockBundledTasks(user, tasks)
     }
 
     TaskBundle(bundleId, ownerId.get, tasks.map(_.id), Some(tasks))

--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -11,7 +11,7 @@ import anorm._
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.maproulette.Config
-import org.maproulette.data.SnapshotManager
+import org.maproulette.data.{SnapshotManager, TaskType}
 import org.maproulette.framework.model.{
   Task,
   User,
@@ -27,6 +27,7 @@ import org.maproulette.framework.model.Task.STATUS_CREATED
 import org.maproulette.framework.model._
 import org.maproulette.models.dal.DALManager
 import org.maproulette.provider.{EmailProvider, KeepRightBox, KeepRightError, KeepRightProvider}
+import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
 import org.maproulette.utils.BoundingBoxFinder
 import org.slf4j.LoggerFactory
 import play.api.Application
@@ -50,6 +51,7 @@ class SchedulerActor @Inject() (
     keepRightProvider: KeepRightProvider,
     boundingBoxFinder: BoundingBoxFinder,
     emailProvider: EmailProvider,
+    webSocketProvider: WebSocketProvider,
     implicit val snapshotManager: SnapshotManager
 ) extends Actor {
   // cleanOldTasks configuration
@@ -139,8 +141,37 @@ class SchedulerActor @Inject() (
     val start = System.currentTimeMillis
 
     this.db.withTransaction { implicit c =>
-      val query        = s"DELETE FROM locked WHERE AGE(NOW(), locked_time) > '${config.taskLockExpiry}'"
-      val locksDeleted = SQL(query).executeUpdate()
+      val expiredLocks =
+        SQL(
+          s"""DELETE FROM locked WHERE AGE(NOW(), locked_time) > '${config.taskLockExpiry}'
+              RETURNING item_id, item_type, bundled_tasks"""
+        ).as(
+          (SqlParser.long("item_id") ~ SqlParser.int("item_type") ~
+            SqlParser.get[List[Long]]("bundled_tasks")).*
+        )
+
+      val locksDeleted = expiredLocks.length
+
+      // Let any connected client know its stale task lock is gone, the same way an
+      // explicit release/skip/complete does - otherwise a session that's been idle
+      // past the expiry keeps showing the task as locked-by-you indefinitely. Include
+      // bundle members too - a bundle's lock is a single covering row on the primary
+      // task, so without bundled_tasks here a tab open on a member task would never
+      // learn its lock expired.
+      val expiredTaskIds = expiredLocks.collect {
+        case itemId ~ itemType ~ bundledTasks if itemType == TaskType().typeId =>
+          itemId :: bundledTasks
+      }.flatten
+      if (expiredTaskIds.nonEmpty) {
+        try {
+          val tasks = dALManager.task.retrieveListById(-1, 0)(expiredTaskIds, Some(c))
+          if (tasks.nonEmpty) {
+            webSocketProvider.sendMessage(WebSocketMessages.tasksReleased(tasks, None))
+          }
+        } catch {
+          case e: Exception => logger.warn(e.getMessage)
+        }
+      }
 
       val totalTime = System.currentTimeMillis - start
       logger.info(

--- a/app/org/maproulette/models/Lock.scala
+++ b/app/org/maproulette/models/Lock.scala
@@ -14,7 +14,9 @@ case class Lock(
     itemType: Int,
     itemId: Long,
     userId: Long,
-    changesetId: Long
+    changesetId: Long,
+    bundledTasks: List[Long] = List.empty,
+    isReviewClaim: Boolean = false
 )
 
 object Lock {

--- a/app/org/maproulette/models/dal/BaseDAL.scala
+++ b/app/org/maproulette/models/dal/BaseDAL.scala
@@ -56,11 +56,21 @@ trait BaseDAL[Key, T <: BaseObject[Key]]
       get[Option[Int]]("locked.item_type") ~
       get[Option[Long]]("locked.item_id") ~
       get[Option[Long]]("locked.user_id") ~
-      get[Option[Long]]("locked.changeset_id") map {
-      case locked_time ~ itemType ~ itemId ~ userId ~ changesetId =>
+      get[Option[Long]]("locked.changeset_id") ~
+      get[Option[List[Long]]]("locked.bundled_tasks") ~
+      get[Option[Boolean]]("locked.is_review_claim") map {
+      case locked_time ~ itemType ~ itemId ~ userId ~ changesetId ~ bundledTasks ~ isReviewClaim =>
         locked_time match {
           case Some(d) =>
-            Lock(locked_time, itemType.get, itemId.get, userId.get, changesetId.getOrElse(-1))
+            Lock(
+              locked_time,
+              itemType.get,
+              itemId.get,
+              userId.get,
+              changesetId.getOrElse(-1),
+              bundledTasks.getOrElse(List.empty),
+              isReviewClaim.getOrElse(false)
+            )
           case None => Lock.emptyLock
         }
     }

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1438,7 +1438,7 @@ class ChallengeDAL @Inject() (
               l.user_id as locked_by,
               ST_ClusterDBSCAN(tasks.location, eps := 0.000001, minpoints := 1) OVER () as cluster_id
             FROM tasks
-            LEFT JOIN locked l ON l.item_id = tasks.id AND l.item_type = 2
+            LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks)) AND l.item_type = 2
             WHERE tasks.parent_id = {id}"""
 
       val allTasks =
@@ -1983,7 +1983,7 @@ class ChallengeDAL @Inject() (
       }
 
       if (excludeLocked) {
-        joinClause ++= " LEFT JOIN locked l ON l.item_id = t.id "
+        joinClause ++= " LEFT JOIN locked l ON (l.item_id = t.id OR t.id = ANY(l.bundled_tasks)) "
         this.appendInWhereClause(whereClause, s"(l.id IS NULL OR l.user_id = ${user.id})")
       }
 
@@ -2615,7 +2615,7 @@ class ChallengeDAL @Inject() (
     val centerLon = (left + right) / 2
 
     val query = s"""SELECT tasks.${taskDAL.retrieveColumnsWithReview} FROM tasks
-      LEFT JOIN locked l ON l.item_id = tasks.id
+      LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks))
       LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
       WHERE parent_id = $challengeId AND
             tasks.location && ST_MakeEnvelope($left, $bottom, $right, $top, 4326) AND

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -582,7 +582,9 @@ class TaskDAL @Inject() (
       val primaryTask =
         if (lockPrimaryTaskId == referenceTask.id) referenceTask
         else this.retrieveById(lockPrimaryTaskId).getOrElse(referenceTask)
-      primaryTask :: this.retrieveListById(-1, 0)(lockBundledTasks.filterNot(_ == lockPrimaryTaskId))
+      primaryTask :: this.retrieveListById(-1, 0)(
+        lockBundledTasks.filterNot(_ == lockPrimaryTaskId)
+      )
     } else {
       List(referenceTask)
     }

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -666,7 +666,7 @@ class TaskDAL @Inject() (
 
     this.withMRTransaction { implicit c =>
       val startedLock =
-        (SQL"""SELECT created FROM locked l WHERE l.item_id = ${primaryTask.id} AND
+        (SQL"""SELECT created FROM locked l WHERE (l.item_id = ${primaryTask.id} OR ${primaryTask.id} = ANY(l.bundled_tasks)) AND
                  l.item_type = ${primaryTask.itemType.typeId} AND l.user_id = ${user.id}
                """).as(SqlParser.scalar[DateTime].singleOpt)
       for (task <- tasks) {
@@ -690,7 +690,7 @@ class TaskDAL @Inject() (
                                  completed_by = ${user.id}  #$bundleUpdate
                                  WHERE t.id = (
                                     SELECT t2.id FROM tasks t2
-                                    LEFT JOIN locked l on l.item_id = t2.id AND l.item_type = ${task.itemType.typeId}
+                                    LEFT JOIN locked l on (l.item_id = t2.id OR t2.id = ANY(l.bundled_tasks)) AND l.item_type = ${task.itemType.typeId}
                                     WHERE t2.id = ${task.id} AND (l.user_id = ${user.id} OR l.user_id IS NULL)
                                   )""".executeUpdate()
           // if returning 0, then this is because the item is locked by a  different user
@@ -1050,7 +1050,7 @@ class TaskDAL @Inject() (
       } yield task -> lock
       val query =
         s"""SELECT locked.*, tasks.$retrieveColumnsWithReview FROM tasks
-                      LEFT JOIN locked ON locked.item_id = tasks.id
+                      LEFT JOIN locked ON (locked.item_id = tasks.id OR tasks.id = ANY(locked.bundled_tasks))
                       LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
                       WHERE tasks.id > $currentTaskId AND tasks.parent_id = $parentId
                       AND status IN ({statusList})
@@ -1065,7 +1065,7 @@ class TaskDAL @Inject() (
         case None =>
           val loopQuery =
             s"""SELECT locked.*, tasks.$retrieveColumnsWithReview FROM tasks
-                              LEFT JOIN locked ON locked.item_id = tasks.id
+                              LEFT JOIN locked ON (locked.item_id = tasks.id OR tasks.id = ANY(locked.bundled_tasks))
                               LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
                               WHERE tasks.parent_id = $parentId
                               AND status IN ({statusList})
@@ -1096,7 +1096,7 @@ class TaskDAL @Inject() (
       } yield task -> lock
       val query =
         s"""SELECT locked.*, tasks.$retrieveColumnsWithReview FROM tasks
-                      LEFT JOIN locked ON locked.item_id = tasks.id
+                      LEFT JOIN locked ON (locked.item_id = tasks.id OR tasks.id = ANY(locked.bundled_tasks))
                       LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
                       WHERE tasks.id < $currentTaskId AND tasks.parent_id = $parentId
                       AND status IN ({statusList})
@@ -1112,7 +1112,7 @@ class TaskDAL @Inject() (
         case None =>
           val loopQuery =
             s"""SELECT locked.*, tasks.$retrieveColumnsWithReview FROM tasks
-                              LEFT JOIN locked ON locked.item_id = tasks.id
+                              LEFT JOIN locked ON (locked.item_id = tasks.id OR tasks.id = ANY(locked.bundled_tasks))
                               LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
                               WHERE tasks.parent_id = $parentId
                               AND status IN ({statusList})
@@ -1203,7 +1203,7 @@ class TaskDAL @Inject() (
 
         val select =
           s"""SELECT tasks.$retrieveColumnsWithReview FROM tasks
-          LEFT JOIN locked l ON l.item_id = tasks.id
+          LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks))
           LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
        """.stripMargin
 
@@ -1360,7 +1360,7 @@ class TaskDAL @Inject() (
 
     val query =
       s"""SELECT tasks.$retrieveColumnsWithReview FROM tasks
-      LEFT JOIN locked l ON l.item_id = tasks.id
+      LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks))
       LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
       WHERE tasks.id <> $proximityId AND
             tasks.parent_id = $challengeId AND

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -566,6 +566,29 @@ class TaskDAL @Inject() (
   def manager: DALManager = dalManager.get()
 
   /**
+    * Resolves the lock currently covering `referenceTask` (if any) into the concrete list of
+    * tasks a release broadcast should cover - just the task itself if unbundled, or the
+    * bundle's primary + member tasks if it's covered by a bundle lock. Must be called BEFORE
+    * whatever action actually releases the lock (e.g. setTaskStatus, which unlocks as a side
+    * effect), since resolving bundle membership requires the covering lock row to still exist.
+    *
+    * @param referenceTask The task whose covering lock (if any) should be resolved
+    * @return The tasks a task-released/tasks-released broadcast should include
+    */
+  def resolveLockReleaseTasks(referenceTask: Task): List[Task] = {
+    val (lockPrimaryTaskId, lockBundledTasks) =
+      this.resolveLockBundle(referenceTask).getOrElse((referenceTask.id, List.empty[Long]))
+    if (lockBundledTasks.nonEmpty) {
+      val primaryTask =
+        if (lockPrimaryTaskId == referenceTask.id) referenceTask
+        else this.retrieveById(lockPrimaryTaskId).getOrElse(referenceTask)
+      primaryTask :: this.retrieveListById(-1, 0)(lockBundledTasks.filterNot(_ == lockPrimaryTaskId))
+    } else {
+      List(referenceTask)
+    }
+  }
+
+  /**
     * Sets the task for a given user. The user cannot set the status of a task unless the object has
     * been locked by the same user before hand.
     * Will throw an InvalidException if the task status cannot be set due to the current task status
@@ -1278,10 +1301,14 @@ class TaskDAL @Inject() (
 
         implicit val ids = List[Long]()
         this.cacheManager.withIDListCaching { implicit cachedItems =>
-          this.withListLocking(user, Some(TaskType())) { () =>
-            this.withMRTransaction { implicit c =>
-              sqlWithParameters(query, parameters).as(this.parser.*)
-            }
+          // Read-only candidate lookup - the caller locks whichever task it actually
+          // navigates to via the explicit /start endpoint (TaskController#startOnTask),
+          // which is the sole place the one-lock-per-user conflict is enforced. This used
+          // to go through withListLocking, which unlocked ALL of the user's other task
+          // locks as a side effect before returning candidates - silently discarding a
+          // lock held in another tab/session with no conflict check at all.
+          this.withMRTransaction { implicit c =>
+            sqlWithParameters(query, parameters).as(this.parser.*)
           }
         }
       case None => List.empty

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -12,7 +12,7 @@ import javax.inject.Inject
 import org.joda.time.DateTime
 import org.maproulette.Config
 import org.maproulette.cache.CacheManager
-import org.maproulette.data.{Actions, TaskType, VirtualChallengeType}
+import org.maproulette.data.{Actions, VirtualChallengeType}
 import org.maproulette.exception.InvalidException
 import org.maproulette.framework.model.{User, ClusteredPoint, Point, PointReview, Task}
 import org.maproulette.framework.psql.Paging

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -304,7 +304,7 @@ class VirtualChallengeDAL @Inject() (
 
     val query =
       s"""SELECT tasks.${taskDAL.retrieveColumnsWithReview} FROM tasks
-            LEFT JOIN locked l ON l.item_id = tasks.id
+            LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks))
             LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
             INNER JOIN virtual_challenge_tasks vct ON vct.task_id = tasks.id
             ${whereClause.toString}
@@ -339,7 +339,7 @@ class VirtualChallengeDAL @Inject() (
       } yield task -> lock
       val query =
         s"""SELECT locked.*, tasks.${taskDAL.retrieveColumnsWithReview} FROM tasks
-                      LEFT JOIN locked ON locked.item_id = tasks.id
+                      LEFT JOIN locked ON (locked.item_id = tasks.id OR tasks.id = ANY(locked.bundled_tasks))
                       LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
                       WHERE tasks.id = (SELECT task_id
                                         FROM virtual_challenge_tasks
@@ -351,7 +351,7 @@ class VirtualChallengeDAL @Inject() (
         case None =>
           val loopQuery =
             s"""SELECT locked.*, tasks.${taskDAL.retrieveColumnsWithReview} FROM tasks
-                              LEFT JOIN locked ON locked.item_id = tasks.id
+                              LEFT JOIN locked ON (locked.item_id = tasks.id OR tasks.id = ANY(locked.bundled_tasks))
                               LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
                               WHERE tasks.id = (SELECT task_id
                                                 FROM virtual_challenge_tasks
@@ -381,7 +381,7 @@ class VirtualChallengeDAL @Inject() (
       } yield task -> lock
       val query =
         s"""SELECT locked.*, tasks.${taskDAL.retrieveColumnsWithReview} FROM tasks
-                      LEFT JOIN locked ON locked.item_id = tasks.id
+                      LEFT JOIN locked ON (locked.item_id = tasks.id OR tasks.id = ANY(locked.bundled_tasks))
                       LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
                       WHERE tasks.id = (SELECT task_id
                                         FROM virtual_challenge_tasks
@@ -393,7 +393,7 @@ class VirtualChallengeDAL @Inject() (
         case None =>
           val loopQuery =
             s"""SELECT locked.*, tasks.${taskDAL.retrieveColumnsWithReview} FROM tasks
-                              LEFT JOIN locked ON locked.item_id = tasks.id
+                              LEFT JOIN locked ON (locked.item_id = tasks.id OR tasks.id = ANY(locked.bundled_tasks))
                               LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
                               WHERE tasks.id = (SELECT task_id
                                                 FROM virtual_challenge_tasks
@@ -415,7 +415,7 @@ class VirtualChallengeDAL @Inject() (
       implicit c: Option[Connection] = None
   ): List[Task] = {
     val query = s"""SELECT tasks.${taskDAL.retrieveColumnsWithReview} FROM tasks
-      LEFT JOIN locked l ON l.item_id = tasks.id
+      LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks))
       LEFT JOIN virtual_challenge_tasks vct on vct.task_id = tasks.id
       LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
       WHERE tasks.id <> $proximityId AND
@@ -454,7 +454,7 @@ class VirtualChallengeDAL @Inject() (
     val centerLon = (left + right) / 2
 
     val query = s"""SELECT tasks.${taskDAL.retrieveColumnsWithReview} FROM tasks
-      LEFT JOIN locked l ON l.item_id = tasks.id
+      LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks))
       LEFT JOIN virtual_challenge_tasks vct on vct.task_id = tasks.id
       LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
       WHERE vct.virtual_challenge_id = $challengeId AND

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -310,15 +310,16 @@ class VirtualChallengeDAL @Inject() (
             ${whereClause.toString}
             ORDER BY $proximityOrdering tasks.status, RANDOM() LIMIT 1"""
 
-    this.withSingleLocking(user, Some(TaskType())) { () =>
-      withMRTransaction { implicit c =>
-        SQL(query)
-          .on(
-            Symbol("statusList") -> ToParameterValue.apply[List[Int]].apply(taskStatusList)
-          )
-          .as(taskDAL.parser.*)
-          .headOption
-      }
+    // Read-only candidate lookup - see TaskDAL#getRandomTasks for why this no longer
+    // goes through withSingleLocking (it used to unlock ALL of the user's other task
+    // locks as a side effect, with no conflict check).
+    withMRTransaction { implicit c =>
+      SQL(query)
+        .on(
+          Symbol("statusList") -> ToParameterValue.apply[List[Int]].apply(taskStatusList)
+        )
+        .as(taskDAL.parser.*)
+        .headOption
     }
   }
 

--- a/conf/evolutions/default/120.sql
+++ b/conf/evolutions/default/120.sql
@@ -1,0 +1,28 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+
+-- bundled_tasks holds the ids of the other tasks covered by this lock when
+-- the locked item is the primary task of a bundle. is_review_claim marks
+-- locks created by TaskReviewRepository's review-claim flow, which are
+-- exempt from the one-lock-per-user constraint below.
+ALTER TABLE locked ADD COLUMN IF NOT EXISTS bundled_tasks integer[] NOT NULL DEFAULT '{}';;
+ALTER TABLE locked ADD COLUMN IF NOT EXISTS is_review_claim boolean NOT NULL DEFAULT false;;
+
+-- Keep only the most recently created edit-lock row per user before adding
+-- the uniqueness constraint below, since a user could previously hold
+-- multiple simultaneous locks.
+DELETE FROM locked a USING locked b
+  WHERE a.user_id = b.user_id AND NOT a.is_review_claim AND NOT b.is_review_claim
+    AND a.id < b.id;;
+
+-- Enforce a single active edit lock per user. Review-claim locks are
+-- excluded so claiming a review doesn't conflict with an editing lock.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_locked_single_edit_lock ON locked(user_id)
+  WHERE NOT is_review_claim;;
+
+# --- !Downs
+
+DROP INDEX IF EXISTS idx_locked_single_edit_lock;;
+ALTER TABLE locked DROP COLUMN IF EXISTS is_review_claim;;
+ALTER TABLE locked DROP COLUMN IF EXISTS bundled_tasks;;

--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -2,7 +2,12 @@
 # tags: [ Bundle ]
 # operationId: bundle_create_a_task_bundle
 # summary: Create a task bundle
-# description: Create a new task bundle with the task ids in the supplied JSON body.
+# description: |
+#   Create a new task bundle with the task ids in the supplied JSON body. The bundle's
+#   primary task is locked for the calling user, with the other member task ids recorded
+#   in that lock's bundledTasks. A user may only hold one active edit lock at a time - if
+#   the user already holds a lock on a different task, this returns 409 Conflict describing
+#   that lock. The client should release that lock before retrying.
 # responses:
 #   '200':
 #     description: The newly created bundle with a unique id.
@@ -12,6 +17,8 @@
 #           $ref: '#/components/schemas/TaskBundle'
 #   '401':
 #     description: The user is not authorized to make this request
+#   '409':
+#     description: The user already holds a lock on a different task
 # requestBody:
 #   description: The JSON structure for the bundle body.
 #   required: true
@@ -42,21 +49,23 @@ POST    /taskBundle                                 @org.maproulette.framework.c
 #     in: path
 #     description: The id of the Task Bundle
 #     required: true
-#   - name: lockTasks
-#     in: query
-#     description: The tasks in the bundle will be locked by the user.
 ###
-POST     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long, lockTasks:Boolean ?= false)
+POST     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long)
 ###
 # tags: [ Bundle ]
 # operationId: bundle_updates_a_task_bundle
 # summary: Updates a Task Bundle
-# description: Sets the bundle to the tasks provided, and unlock all tasks removed from current bundle
+# description: |
+#   Sets the bundle to the tasks provided, and unlock all tasks removed from current bundle.
+#   Re-locks the bundle's primary task with the updated bundledTasks membership. Returns
+#   409 Conflict if the user holds a lock on a different task.
 # responses:
 #   '200':
 #     description: Ok with empty body
 #   '401':
 #     description: The user is not authorized to make this request
+#   '409':
+#     description: The user already holds a lock on a different task
 # parameters:
 #   - name: id
 #     in: path

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -271,7 +271,11 @@ GET     /tasks                                      @org.maproulette.controllers
 # tags: [ Task ]
 # operationId: task_start_working_on_a_task_locks_it_for_the_user
 # summary: Start working on a Task (locks it for the user)
-# description: Locks a Task based on the supplied ID in the URL.
+# description: |
+#   Locks a Task based on the supplied ID in the URL. A user may only hold one active
+#   edit lock at a time - if the user already holds a lock on a different task, this
+#   returns 409 Conflict describing that lock. The client should release that lock
+#   (GET /task/:id/release) before retrying to lock this one.
 # responses:
 #   '200':
 #     description: The locked Task
@@ -281,6 +285,8 @@ GET     /tasks                                      @org.maproulette.controllers
 #           $ref: '#/components/schemas/org.maproulette.framework.model.Task'
 #   '404':
 #     description: ID field supplied but no Task found matching the id
+#   '409':
+#     description: The user already holds a lock on a different task
 # parameters:
 #   - name: id
 #     in: path
@@ -1245,30 +1251,13 @@ PUT     /task/:taskId/unlock/request                @org.maproulette.framework.c
 GET     /taskCluster                                @org.maproulette.framework.controller.TaskController.getTaskClusters(points:Int ?= 100)
 ###
 # tags: [ Task ]
-# operationId: task_locks_a_bundle_of_tasks
-# summary: Locks a bundle of tasks
-# description: Attempts to lock a set of tasks. If successful, returns the tasks that were locked. If not successful, returns the tasks that were not locked.
-# responses:
-#   '200':
-#     description: List of tasks that were locked or list of tasks that were not locked. Boolean indicates if the tasks were locked.
-#   '401':
-#     description: The user is not authorized to make this request
-# requestBody:
-#   description: A JSON array of task IDs to lock.
-#   required: true
-#   content:
-#     application/json:
-#       schema:
-#         type: array
-#         items:
-#           type: integer
-###
-POST    /task/bundle/lock                         @org.maproulette.controllers.api.TaskController.lockTaskBundle(taskIds:List[Long])
-###
-# tags: [ Task ]
 # operationId: task_unlocks_a_bundle_of_tasks
 # summary: Unlocks a bundle of tasks
-# description: Unlocks the specified tasks in the bundle.
+# description: |
+#   Releases the calling user's lock covering any of the given task ids (bundles are
+#   now locked as a single row on the bundle's primary task, so this releases that
+#   covering lock if the user holds it - ids not currently locked by the user are
+#   ignored rather than erroring).
 # responses:
 #   '200':
 #     description: Success message

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -439,6 +439,32 @@ POST    /task/:id/skip                                  @org.maproulette.control
 GET     /task/:id/refreshLock                           @org.maproulette.controllers.api.TaskController.refreshTaskLock(id:Long)
 ###
 # tags: [ Task ]
+# operationId: task_lock_a_bundle_of_tasks
+# summary: Updates the lock on a task to cover a given set of bundle member tasks
+# description: |
+#   Updates the caller's existing lock on the primary task (locking it first if not
+#   already locked) to cover exactly the given member task ids, without creating or
+#   updating a persisted task_bundles record - that only happens when the bundle is
+#   actually submitted (see the taskBundle endpoints). Intended for interactively
+#   building up a bundle (e.g. lasso-select) so other tabs see the live working set.
+# responses:
+#   '200':
+#     description: The lock now covers the given member tasks
+#   '404':
+#     description: The primary task, its challenge, or its project was not found
+#   '409':
+#     description: The user already holds a lock on a different, unrelated task
+# parameters:
+#   - name: taskId
+#     in: path
+#     description: The id of the primary task to lock
+#   - name: taskIds
+#     in: query
+#     description: Comma-separated ids of the member tasks the lock should cover
+###
+PUT     /task/:taskId/lockBundle                        @org.maproulette.controllers.api.TaskController.lockTaskBundle(taskId:Long, taskIds:List[Long] ?= List())
+###
+# tags: [ Task ]
 # operationId: task_retrieves_task_by_name
 # summary: Retrieves an already existing Task
 # description: Retrieves an already existing Task based on the name of the Task rather than an ID

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -34,6 +34,9 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
           User.superUser
         )
 
+      // A user may only hold one active edit lock at a time - clear any lock left
+      // over from a previous test before creating a new bundle.
+      taskDAL.unlockAllItems(User.superUser)
       val response =
         this.service.createTaskBundle(
           User.superUser,
@@ -124,6 +127,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
           User.superUser
         )
 
+      taskDAL.unlockAllItems(User.superUser)
       val bundle =
         this.service.createTaskBundle(
           User.superUser,
@@ -149,6 +153,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
           User.superUser
         )
 
+      taskDAL.unlockAllItems(User.superUser)
       val bundle = this.service
         .createTaskBundle(
           User.superUser,
@@ -183,6 +188,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
           User.superUser
         )
 
+      taskDAL.unlockAllItems(User.superUser)
       val bundle = this.service
         .createTaskBundle(
           User.superUser,
@@ -222,6 +228,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
           User.superUser
         )
 
+      taskDAL.unlockAllItems(User.superUser)
       val bundle = this.service
         .createTaskBundle(
           User.superUser,
@@ -257,6 +264,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
           User.superUser
         )
 
+      taskDAL.unlockAllItems(User.superUser)
       val bundle = this.service
         .createTaskBundle(
           User.superUser,


### PR DESCRIPTION
Users could previously hold locks on multiple tasks at once (no constraint on locked.user_id), and bundling either didn't lock tasks at all or locked every member individually. Add a migration that enforces a single active edit lock per user (a partial unique index scoped away from reviewer review-claim locks, which stay independent) and gives locked a bundled_tasks column. Bundling now locks only the primary task and records the other member ids in bundled_tasks instead of locking each task, and all lock/unlock/refresh logic and lock-aware joins (TaskDAL, ChallengeDAL, VirtualChallengeDAL, TaskClusterRepository, TaskRepository, getLockedTasks) resolve a bundle member's lock through its primary. Locking a task or bundle while already holding a different lock now returns 409 with the held lock's details instead of silently succeeding or 500ing.