### PR TITLE
Award achievements based on the database, not the cached user

### DIFF
--- a/app/org/maproulette/framework/repository/UserRepository.scala
+++ b/app/org/maproulette/framework/repository/UserRepository.scala
@@ -297,24 +297,39 @@ class UserRepository @Inject() (
 
   /**
     * Add the given achievements to the user's metrics. Only new achievements
-    * not already possessed by the user will be added
+    * not already possessed by the user will be added.
+    *
+    * The delta is computed against the current database state (not against a
+    * possibly-stale in-memory user object) within the same transaction as the
+    * update, so the returned list reflects exactly what was newly inserted.
     *
     * @param userId       The id of the user who is to receive the achievements
     * @param achievements List of the achievements to award to the user
+    * @return the achievements that were actually newly added (empty if none)
     */
   def addAchievements(userId: Long, achievements: List[Int])(
       implicit c: Option[Connection] = None
-  ) = {
+  ): List[Int] = {
     this.withMRTransaction { implicit c =>
       // We need to make sure the user is in the database first
       ensureUserMetrics(userId)
 
-      val achievementArray = s"'{${achievements.mkString(",")}}'::int[]"
-      SQL"""
-        UPDATE user_metrics
-        SET achievements=array_distinct(achievements || #$achievementArray)
-        WHERE user_id = ${userId}
-      """.executeUpdate()
+      val existing = SQL"""
+        SELECT achievements FROM user_metrics WHERE user_id = ${userId}
+      """.as(get[List[Int]]("achievements").?.single).getOrElse(List.empty)
+
+      val newAchievements = achievements.distinct.filterNot(existing.toSet)
+
+      if (newAchievements.nonEmpty) {
+        val achievementArray = s"'{${newAchievements.mkString(",")}}'::int[]"
+        SQL"""
+          UPDATE user_metrics
+          SET achievements=array_distinct(achievements || #$achievementArray)
+          WHERE user_id = ${userId}
+        """.executeUpdate()
+      }
+
+      newAchievements
     }
   }
 

--- a/app/org/maproulette/framework/service/AchievementService.scala
+++ b/app/org/maproulette/framework/service/AchievementService.scala
@@ -116,34 +116,28 @@ class AchievementService @Inject() (
       return Some(user)
     }
 
-    // We need to invalidate the user in the cache
+    // Add the achievements, capturing exactly which ones were newly awarded.
+    // The delta is computed against the current database state inside
+    // addAchievements, so it does not depend on the possibly-stale achievements
+    // list carried by the in-memory user object.
+    var justAwarded: List[Int] = List.empty
     this.serviceManager.user.cacheManager.withDeletingCache(id =>
       this.serviceManager.user.retrieve(id)
     ) { implicit cachedItem =>
-      this.repository.addAchievements(user.id, achievements)
+      justAwarded = this.repository.addAchievements(user.id, achievements)
       Some(cachedItem)
     }(id = user.id)
 
     // Notify websocket clients of any new awards
-    val latestUser = this.serviceManager.user.retrieve(user.id)
-    latestUser match {
-      case Some(latest) =>
-        val justAwarded = latest.achievements
-          .getOrElse(List.empty)
-          .filterNot(
-            user.achievements.getOrElse(List.empty).toSet
-          )
-        if (!justAwarded.isEmpty) {
-          webSocketProvider.sendMessage(
-            WebSocketMessages.achievementAwarded(
-              WebSocketMessages.AchievementData(user.id, justAwarded)
-            )
-          )
-        }
-      case None => // nothing to do
+    if (!justAwarded.isEmpty) {
+      webSocketProvider.sendMessage(
+        WebSocketMessages.achievementAwarded(
+          WebSocketMessages.AchievementData(user.id, justAwarded)
+        )
+      )
     }
 
-    latestUser
+    this.serviceManager.user.retrieve(user.id)
   }
 
   /**


### PR DESCRIPTION
addAchievements now computes the new-achievement delta against the current user_metrics row inside the same transaction as the update and returns exactly what it inserted. AchievementService uses that return value for the websocket notification instead of diffing a freshly retrieved user against the possibly-stale in-memory user, which could either miss or duplicate award notifications.