### PR TITLE
Allow cloning a challenge into a different project

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -1443,19 +1443,29 @@ class ChallengeController @Inject() (
   }
 
   /**
-    * Clones a challenge with a new name
+    * Clones a challenge with a new name, optionally into a different project
     *
-    * @param itemId  The item id of the challenge you want to clone
-    * @param newName The new name of the cloned challenge
+    * @param itemId    The item id of the challenge you want to clone
+    * @param newName   The new name of the cloned challenge
+    * @param projectId The project to clone the challenge into. Anything less than 1 clones
+    *                  the challenge into the same project as the original.
     * @return The newly created cloned challenge
     */
-  def cloneChallenge(itemId: Long, newName: String): Action[AnyContent] = Action.async {
-    implicit request =>
+  def cloneChallenge(itemId: Long, newName: String, projectId: Long): Action[AnyContent] =
+    Action.async { implicit request =>
       sessionManager.authenticatedRequest { implicit user =>
         dalManager.challenge.retrieveById(itemId) match {
           case Some(c) =>
             permission.hasWriteAccess(ProjectType(), user)(c.general.parent)
-            val clonedChallenge = c.copy(id = -1, name = newName)
+            val targetProjectId = if (projectId > 0) projectId else c.general.parent
+            if (targetProjectId != c.general.parent) {
+              permission.hasWriteAccess(ProjectType(), user)(targetProjectId)
+            }
+            val clonedChallenge = c.copy(
+              id = -1,
+              name = newName,
+              general = c.general.copy(parent = targetProjectId)
+            )
             Ok(Json.toJson(this.dal.insert(clonedChallenge, user)))
           case None =>
             throw new NotFoundException(
@@ -1463,7 +1473,7 @@ class ChallengeController @Inject() (
             )
         }
       }
-  }
+    }
 
   /**
     * Rebuilds a challenge if it uses a remote geojson or overpass query to generate it's tasks

--- a/conf/v2_route/challenge.api
+++ b/conf/v2_route/challenge.api
@@ -878,7 +878,7 @@ GET     /challenge/:id/children                     @org.maproulette.controllers
 # tags: [ Challenge ]
 # operationId: challenge_clones_a_challenge
 # summary: Clones a Challenge
-# description: Clones a challenge
+# description: Clones a challenge, optionally into a different project
 # responses:
 #   '200':
 #     description: The newly created cloned challenge
@@ -897,8 +897,11 @@ GET     /challenge/:id/children                     @org.maproulette.controllers
 #   - name: name
 #     in: path
 #     description: The name of the new challenge
+#   - name: projectId
+#     in: query
+#     description: The id of the project to clone the challenge into. Defaults to the project of the challenge being cloned.
 ###
-PUT     /challenge/:id/clone/:name                  @org.maproulette.controllers.api.ChallengeController.cloneChallenge(id:Long, name:String)
+PUT     /challenge/:id/clone/:name                  @org.maproulette.controllers.api.ChallengeController.cloneChallenge(id:Long, name:String, projectId:Long ?= -1)
 ###
 # tags: [ Challenge ]
 # operationId: challenge_rebuild_a_challenge


### PR DESCRIPTION
Add an optional projectId query parameter to the challenge clone endpoint. When it is greater than 0 the clone is created in that project instead of the original's parent, and write access to the target project is checked in addition to the source project.