### PR TITLE
Include paused flag in challenge listings

### DIFF
--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -154,7 +154,8 @@ case class ChallengeListing(
     enabled: Boolean,
     virtualParents: Option[Array[Long]] = None,
     status: Option[Int],
-    isArchived: Boolean
+    isArchived: Boolean,
+    paused: Boolean = false
 )
 
 /**

--- a/app/org/maproulette/framework/repository/ChallengeListingRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeListingRepository.scala
@@ -55,7 +55,8 @@ object ChallengeListingRepository {
       |challenges.enabled, 
       |array_remove(array_agg(virtual_project_challenges.project_id), NULL) AS virtual_parent_ids,
       |challenges.status,
-      |challenges.is_archived""".stripMargin
+      |challenges.is_archived,
+      |challenges.paused""".stripMargin
 
   /**
     * The row parser for Anorm to enable the object to be read from the retrieved row directly
@@ -68,9 +69,10 @@ object ChallengeListingRepository {
       get[Boolean]("challenges.enabled") ~
       get[Option[Array[Long]]]("virtual_parent_ids") ~
       get[Option[Int]]("challenges.status") ~
-      get[Boolean]("challenges.is_archived") map {
-      case id ~ parent ~ name ~ enabled ~ virtualParents ~ status ~ isArchived =>
-        ChallengeListing(id, parent, name, enabled, virtualParents, status, isArchived)
+      get[Boolean]("challenges.is_archived") ~
+      get[Boolean]("challenges.paused") map {
+      case id ~ parent ~ name ~ enabled ~ virtualParents ~ status ~ isArchived ~ paused =>
+        ChallengeListing(id, parent, name, enabled, virtualParents, status, isArchived, paused)
     }
   }
 }

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1591,7 +1591,7 @@ class ChallengeDAL @Inject() (
       }
 
       val query =
-        s"""SELECT c.id, c.parent_id, c.name, c.enabled, array_remove(array_agg(vp.project_id), NULL) AS virtual_parent_ids, c.status, c.is_archived FROM challenges c
+        s"""SELECT c.id, c.parent_id, c.name, c.enabled, array_remove(array_agg(vp.project_id), NULL) AS virtual_parent_ids, c.status, c.is_archived, c.paused FROM challenges c
                       INNER JOIN projects p ON p.id = c.parent_id
                       LEFT OUTER JOIN virtual_project_challenges vp ON c.id = vp.challenge_id
                       WHERE c.deleted = false AND p.deleted = false


### PR DESCRIPTION
Expose challenges.paused on ChallengeListing so clients can tell a paused challenge from an active one without fetching the full challenge. The column is selected by both the listing repository query and ChallengeDAL.listing, which share the same row parser.