### PR TITLE
Claim a review bundle with a single lock row

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -291,17 +291,16 @@ class TaskController @Inject() (
         )
       } catch {
         case e: LockConflictException =>
-          val conflictingTaskId = e.conflictingLock.itemId
+          val conflictingTaskId   = e.conflictingLock.itemId
+          val conflictingParentId = this.dal.retrieveById(conflictingTaskId).map(_.parent)
           val conflictingParentName =
-            this.dal
-              .retrieveById(conflictingTaskId)
-              .flatMap(t => this.serviceManager.challenge.retrieve(t.parent))
-              .map(_.name)
+            conflictingParentId.flatMap(this.serviceManager.challenge.retrieve).map(_.name)
           Conflict(
             Json.obj(
               "status"       -> "Conflict",
               "message"      -> e.getMessage,
               "lockedTaskId" -> conflictingTaskId,
+              "parentId"     -> conflictingParentId,
               "parentName"   -> conflictingParentName,
               "bundledTasks" -> e.conflictingLock.bundledTasks,
               "startedAt"    -> e.conflictingLock.lockedTime.map(_.toString)
@@ -372,17 +371,16 @@ class TaskController @Inject() (
           )
         } catch {
           case e: LockConflictException =>
-            val conflictingTaskId = e.conflictingLock.itemId
+            val conflictingTaskId   = e.conflictingLock.itemId
+            val conflictingParentId = this.dal.retrieveById(conflictingTaskId).map(_.parent)
             val conflictingParentName =
-              this.dal
-                .retrieveById(conflictingTaskId)
-                .flatMap(t => this.serviceManager.challenge.retrieve(t.parent))
-                .map(_.name)
+              conflictingParentId.flatMap(this.serviceManager.challenge.retrieve).map(_.name)
             Conflict(
               Json.obj(
                 "status"       -> "Conflict",
                 "message"      -> e.getMessage,
                 "lockedTaskId" -> conflictingTaskId,
+                "parentId"     -> conflictingParentId,
                 "parentName"   -> conflictingParentName,
                 "bundledTasks" -> e.conflictingLock.bundledTasks,
                 "startedAt"    -> e.conflictingLock.lockedTime.map(_.toString)

--- a/app/org/maproulette/framework/mixins/Locking.scala
+++ b/app/org/maproulette/framework/mixins/Locking.scala
@@ -219,16 +219,22 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
     * @param user          The user requesting the lock
     * @param primaryItem   The bundle's primary task
     * @param memberTaskIds The ids of the other tasks in the bundle (primary excluded automatically)
+    * @param reviewClaim   Whether this lock represents a reviewer's review claim rather than an
+    *                      ordinary edit lock. Review-claim locks are exempt from the
+    *                      one-lock-per-user invariant (see lockItem).
     * @param c             A sql connection implicitly passed in from the calling function
     * @return user id of who now holds the lock
     */
   def lockBundle(
       user: User,
       primaryItem: Task,
-      memberTaskIds: List[Long]
+      memberTaskIds: List[Long],
+      reviewClaim: Boolean = false
   )(implicit c: Option[Connection] = None): Long =
     this.withMRTransaction { implicit c =>
-      this.enforceSingleEditLock(user, primaryItem.id)
+      if (!reviewClaim) {
+        this.enforceSingleEditLock(user, primaryItem.id)
+      }
 
       val members = memberTaskIds.filterNot(_ == primaryItem.id).distinct
       // Avoid the curly-brace array literal ('{}') here - anorm's SQL() scans the raw query
@@ -236,28 +242,45 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
       // for one, corrupting the query. ARRAY[]::integer[] is equivalent and brace-free.
       val membersLiteral =
         if (members.isEmpty) "ARRAY[]::integer[]" else s"ARRAY[${members.mkString(",")}]::integer[]"
+      val coveredLiteral = s"ARRAY[${(primaryItem.id :: members).mkString(",")}]::integer[]"
 
-      val checkQuery =
-        s"""SELECT user_id FROM locked WHERE item_id = {itemId} AND item_type = ${primaryItem.itemType.typeId} FOR UPDATE"""
-      SQL(checkQuery)
-        .on(Symbol("itemId") -> ParameterValue.toParameterValue(primaryItem.id)(p = keyToStatement))
-        .as(SqlParser.long("user_id").singleOpt) match {
-        case Some(id) if id != user.id => id
-        case Some(_) =>
-          val query =
-            s"""UPDATE locked SET locked_time = NOW(), bundled_tasks = $membersLiteral
-                WHERE user_id = ${user.id} AND item_id = {itemId} AND item_type = ${primaryItem.itemType.typeId}"""
-          SQL(query)
-            .on(
-              Symbol("itemId") -> ParameterValue.toParameterValue(primaryItem.id)(p = keyToStatement
+      // Every task this lock will cover has to be free or already ours. Leaving another row
+      // covering one of them would mean two rows cover the same task, which breaks the
+      // singleOpt lookups in resolveLockHolder/resolveLockBundle.
+      val existing =
+        SQL(s"""SELECT user_id, item_id FROM locked
+                WHERE item_type = ${primaryItem.itemType.typeId}
+                  AND (item_id = ANY($coveredLiteral) OR bundled_tasks && $coveredLiteral)
+                FOR UPDATE""")
+          .as((SqlParser.long("user_id") ~ SqlParser.long("item_id")).*)
+          .map { case userId ~ itemId => (userId, itemId) }
+
+      existing.find { case (userId, _) => userId != user.id } match {
+        case Some((otherUserId, _)) => otherUserId
+        case None                   =>
+          // Fold any rows of our own that cover a member into the single primary row
+          if (existing.exists { case (_, itemId) => itemId != primaryItem.id }) {
+            SQL(s"""DELETE FROM locked
+                    WHERE user_id = ${user.id} AND item_type = ${primaryItem.itemType.typeId}
+                      AND item_id != {itemId}
+                      AND (item_id = ANY($coveredLiteral) OR bundled_tasks && $coveredLiteral)""")
+              .on(
+                Symbol("itemId") -> ParameterValue.toParameterValue(primaryItem.id)(
+                  p = keyToStatement
+                )
               )
-            )
-            .executeUpdate()
-          user.id
-        case None =>
+              .executeUpdate()
+          }
+
           val query =
-            s"""INSERT INTO locked (item_type, item_id, user_id, bundled_tasks)
-                VALUES (${primaryItem.itemType.typeId}, {itemId}, ${user.id}, $membersLiteral)"""
+            if (existing.exists { case (_, itemId) => itemId == primaryItem.id })
+              s"""UPDATE locked
+                  SET locked_time = NOW(), bundled_tasks = $membersLiteral, is_review_claim = $reviewClaim
+                  WHERE user_id = ${user.id} AND item_id = {itemId} AND item_type = ${primaryItem.itemType.typeId}"""
+            else
+              s"""INSERT INTO locked (item_type, item_id, user_id, bundled_tasks, is_review_claim)
+                  VALUES (${primaryItem.itemType.typeId}, {itemId}, ${user.id}, $membersLiteral, $reviewClaim)"""
+
           SQL(query)
             .on(
               Symbol("itemId") -> ParameterValue.toParameterValue(primaryItem.id)(p = keyToStatement

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -82,6 +82,26 @@ class TaskReviewRepository @Inject() (
         .on(Symbol("userId") -> user.id)
         .executeUpdate()
 
+      // The unclaim above only touches task_review, so drop the lock rows from any
+      // previous claim too - otherwise they accumulate and keep those tasks locked
+      SQL(s"""DELETE FROM locked WHERE user_id = ${user.id} AND is_review_claim""").executeUpdate()
+
+      // A bundle is covered by a single lock row on its primary task rather than one row
+      // per member (see Locking.lockBundle), so claim the whole list in one go. Releasing
+      // that row then releases every task in the bundle.
+      taskList.headOption.foreach { firstTask =>
+        val primary = taskList.find(_.isBundlePrimary.getOrElse(false)).getOrElse(firstTask)
+        val lockerId =
+          this.lockBundle(user, primary, taskList.map(_.id), reviewClaim = true)(Some(c))
+        if (lockerId != user.id) {
+          val lockHolder = this.userService.retrieve(lockerId) match {
+            case Some(user) => user.osmProfile.displayName
+            case None       => lockerId
+          }
+          throw new IllegalAccessException(s"Task is currently locked by user ${lockHolder}")
+        }
+      }
+
       for (task <- taskList) {
         Query
           .simple(List())
@@ -91,15 +111,6 @@ class TaskReviewRepository @Inject() (
           )
           .on(Symbol("taskId") -> task.id, Symbol("userId") -> user.id)
           .executeUpdate()
-
-        val lockerId = this.lockItem(user, task, reviewClaim = true)
-        if (lockerId != user.id) {
-          val lockHolder = this.userService.retrieve(lockerId) match {
-            case Some(user) => user.osmProfile.displayName
-            case None       => lockerId
-          }
-          throw new IllegalAccessException(s"Task is currently locked by user ${lockHolder}")
-        }
 
         implicit val id = task.id
         this.taskRepository.cacheManager.withUpdatingCache(this.taskRepository.retrieve) {
@@ -120,14 +131,16 @@ class TaskReviewRepository @Inject() (
     */
   def unclaimTaskReview(task: Task, user: User): Unit = {
     this.withMRTransaction { implicit c =>
+      // One lock row covers the whole bundle, so releasing it releases every member -
+      // the claim on each of those tasks has to be cleared to match
+      val claimedIds = this.resolveLockBundle(task)(Some(c)) match {
+        case Some((primaryId, memberIds)) => (primaryId :: memberIds).distinct
+        case None                         => List(task.id)
+      }
+
       val updatedRows =
-        Query
-          .simple(List())
-          .build(
-            """UPDATE task_review SET review_claimed_by = NULL, review_claimed_at = NULL
-              WHERE task_review.task_id = {taskId}"""
-          )
-          .on(Symbol("taskId") -> task.id)
+        SQL(s"""UPDATE task_review SET review_claimed_by = NULL, review_claimed_at = NULL
+                WHERE task_review.task_id = ANY(ARRAY[${claimedIds.mkString(",")}]::integer[])""")
           .executeUpdate()
 
       // if returning 0, then this is because the item is locked by a different user
@@ -138,7 +151,7 @@ class TaskReviewRepository @Inject() (
       }
 
       try {
-        this.unlockItem(user, task)
+        this.unlockItem(user, task)(Some(c))
       } catch {
         case e: Exception => logger.warn(e.getMessage)
       }


### PR DESCRIPTION
Split from https://github.com/maproulette/maproulette-backend/pull/1268

A reviewer claiming a bundle locked each member task individually, which left one `locked` row per task. Locking.lockBundle already models a bundle as one row on the primary task with the members in `bundled_tasks`, so the two representations disagreed and the singleOpt lookups in resolveLockHolder/resolveLockBundle could see two rows covering the same task.

- claimTaskReview now takes the whole list through lockBundle with reviewClaim = true, so one row covers the bundle. Review claims stay exempt from the one-lock-per-user invariant, which is what the new reviewClaim parameter on lockBundle carries through.
- lockBundle checks every task the row will cover, not just the primary, and folds any of our own overlapping rows into that one row. Without this a claim over tasks already covered by another of our rows would leave two rows covering the same task.
- claimTaskReview drops leftover rows from a previous claim. The unclaim it runs first only clears task_review, so those rows accumulated and kept their tasks locked.
- unclaimTaskReview clears the claim on every member of the bundle, since releasing the single row releases them all, and runs its unlock inside the surrounding transaction.
- A lock conflict response now carries parentId alongside parentName, so a client can link to the challenge holding the conflicting lock.