### PR TITLE
Match explore keywords with a semi-join, not a tag join

### DIFF
--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -377,18 +377,11 @@ class TaskClusterRepository @Inject() (
       val keywordList   = parseKeywords(keywords)
       val keywordParams = keywordNamedParameters(keywordList)
 
-      // Build joins for keywords filtering if keywords are provided
-      val joins = if (keywordList.nonEmpty) {
-        " INNER JOIN tags_on_challenges toc ON c.id = toc.challenge_id" +
-          " INNER JOIN tags tags_table ON toc.tag_id = tags_table.id"
-      } else ""
-
       val query = s"""
 WITH eligible_challenges AS MATERIALIZED (
   SELECT c.id
   FROM challenges c
   INNER JOIN projects p ON p.id = c.parent_id
-  ${joins}
   WHERE c.deleted = false
     AND c.enabled = true
     AND c.is_archived = false
@@ -396,7 +389,7 @@ WITH eligible_challenges AS MATERIALIZED (
     AND p.enabled = true
     ${if (!global) "AND c.is_global = false" else ""}
     ${difficulty.map(d => s"AND c.difficulty = $d").getOrElse("")}
-    ${keywordInClause("tags_table.name", keywordList)}
+    ${keywordExistsClause("c", keywordList)}
 ),
 filtered_tasks AS MATERIALIZED (
   SELECT DISTINCT
@@ -469,12 +462,6 @@ ORDER BY kmeans;
         LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks)) AND l.item_type = 2
     """
 
-      // Add joins for keywords filtering if keywords are provided
-      if (keywordList.nonEmpty) {
-        query += " INNER JOIN tags_on_challenges toc ON c.id = toc.challenge_id"
-        query += " INNER JOIN tags t ON toc.tag_id = t.id"
-      }
-
       query += """
         WHERE c.deleted = false
         AND c.enabled = true
@@ -494,7 +481,7 @@ ORDER BY kmeans;
 
       // Filter by keywords if provided (bound as parameters, not interpolated)
       if (keywordList.nonEmpty) {
-        query += " " + keywordInClause("t.name", keywordList)
+        query += " " + keywordExistsClause("c", keywordList)
       }
 
       // Filter by difficulty if provided
@@ -558,13 +545,7 @@ ORDER BY kmeans;
       val keywordList   = parseKeywords(keywords)
       val keywordParams = keywordNamedParameters(keywordList)
 
-      // Build joins for keywords filtering if keywords are provided
-      val keywordJoins = if (keywordList.nonEmpty) {
-        " INNER JOIN tags_on_challenges toc ON c.id = toc.challenge_id" +
-          " INNER JOIN tags tags_table ON toc.tag_id = tags_table.id"
-      } else ""
-
-      val keywordFilter = keywordInClause("tags_table.name", keywordList)
+      val keywordFilter = keywordExistsClause("c", keywordList)
 
       val difficultyFilter = difficulty.map(d => s"AND c.difficulty = $d").getOrElse("")
 
@@ -588,7 +569,6 @@ ORDER BY kmeans;
         INNER JOIN challenges c ON c.id = tasks.parent_id
         INNER JOIN projects p ON p.id = c.parent_id
         LEFT JOIN locked l ON (l.item_id = tasks.id OR tasks.id = ANY(l.bundled_tasks)) AND l.item_type = 2
-        $keywordJoins
         WHERE c.deleted = false
           AND c.enabled = true
           AND c.is_archived = false
@@ -676,12 +656,6 @@ ORDER BY kmeans;
         INNER JOIN projects p ON p.id = c.parent_id
     """
 
-      // Add joins for keywords filtering if keywords are provided
-      if (keywordList.nonEmpty) {
-        query += " INNER JOIN tags_on_challenges toc ON c.id = toc.challenge_id"
-        query += " INNER JOIN tags t ON toc.tag_id = t.id"
-      }
-
       query += """
         WHERE c.deleted = false
         AND c.enabled = true
@@ -701,7 +675,7 @@ ORDER BY kmeans;
 
       // Filter by keywords if provided (bound as parameters, not interpolated)
       if (keywordList.nonEmpty) {
-        query += " " + keywordInClause("t.name", keywordList)
+        query += " " + keywordExistsClause("c", keywordList)
       }
 
       // Filter by difficulty if provided
@@ -738,4 +712,25 @@ ORDER BY kmeans;
     if (keywordList.isEmpty) ""
     else
       s"AND LOWER($column) IN (" + keywordList.indices.map(i => s"{kw$i}").mkString(", ") + ")"
+
+  /**
+    * `AND EXISTS (...)` clause restricting `<challengeAlias>` to challenges
+    * carrying at least one of the given keywords, or "" when empty.
+    *
+    * A keyword names a tag on the challenge, not on the task, so joining
+    * `tags_on_challenges` in would repeat every task of a challenge once per
+    * requested tag it carries. Anything that then counts rows (or clusters
+    * them) sees the same task several times. Asking with EXISTS keeps it to one
+    * row per challenge. Values are bound (see keywordNamedParameters).
+    */
+  private def keywordExistsClause(challengeAlias: String, keywordList: List[String]): String =
+    if (keywordList.isEmpty) ""
+    else
+      s"""AND EXISTS (
+            SELECT 1
+            FROM tags_on_challenges toc
+            INNER JOIN tags tg ON tg.id = toc.tag_id
+            WHERE toc.challenge_id = $challengeAlias.id
+              ${keywordInClause("tg.name", keywordList)}
+          )"""
 }

--- a/app/org/maproulette/framework/repository/TileAggregateRepository.scala
+++ b/app/org/maproulette/framework/repository/TileAggregateRepository.scala
@@ -128,8 +128,7 @@ class TileAggregateRepository @Inject() (override val db: Database) extends Repo
           FROM tasks t
           INNER JOIN challenges c ON c.id = t.parent_id
           INNER JOIN projects   p ON p.id = c.parent_id
-          ${filter.joins}
-          WHERE t.location && ST_Transform(
+            WHERE t.location && ST_Transform(
                   ST_MakeEnvelope({xMin}, {yMin}, {xMax}, {yMax}, 3857), 4326)
             AND NOT ST_IsEmpty(t.location)
             ${filter.where}
@@ -180,8 +179,7 @@ class TileAggregateRepository @Inject() (override val db: Database) extends Repo
           FROM tasks t
           INNER JOIN challenges c ON c.id = t.parent_id
           INNER JOIN projects   p ON p.id = c.parent_id
-          ${filter.joins}
-          WHERE t.location && ST_Transform(
+            WHERE t.location && ST_Transform(
                   ST_MakeEnvelope({xMin}, {yMin}, {xMax}, {yMax}, 3857), 4326)
             AND NOT ST_IsEmpty(t.location)
             ${filter.where}
@@ -283,13 +281,21 @@ class TileAggregateRepository @Inject() (override val db: Database) extends Repo
   // Internals
   // ---------------------------------------------------------------------------
 
-  /** Shared FROM-join / WHERE fragment + bound parameters for the live paths. */
-  private case class LiveFilter(joins: String, where: String, params: Seq[NamedParameter])
+  /** Shared WHERE fragment + bound parameters for the live paths. */
+  private case class LiveFilter(where: String, params: Seq[NamedParameter])
 
   /**
     * Build the eligibility + difficulty/global/keyword filter shared by the live
     * MVT queries. All user-provided values are bound parameters; only
     * code-controlled identifiers are interpolated.
+    *
+    * Keywords are matched with EXISTS rather than by joining `tags_on_challenges`.
+    * A keyword names a tag on the *challenge*, so joining multiplies every one of
+    * its tasks by the number of requested tags it carries -- a challenge matching
+    * two keywords counted each of its tasks twice, inflating cluster counts and
+    * pulling centroids toward multi-tagged challenges. A semi-join asks the
+    * question that was actually meant ("is this challenge tagged with any of
+    * these?") and answers it once per challenge.
     */
   private def liveFilter(
       difficulty: Option[Int],
@@ -301,16 +307,16 @@ class TileAggregateRepository @Inject() (override val db: Database) extends Repo
       .getOrElse(Nil)
     val hasKeywords = keywordList.nonEmpty
 
-    val joins =
-      if (hasKeywords)
-        "INNER JOIN tags_on_challenges toc ON c.id = toc.challenge_id " +
-          "INNER JOIN tags tg ON toc.tag_id = tg.id"
-      else ""
-
     val keywordParamNames = keywordList.indices.map(i => s"kw$i").toList
     val keywordClause =
       if (hasKeywords)
-        "AND LOWER(tg.name) IN (" + keywordParamNames.map(n => s"{$n}").mkString(", ") + ")"
+        s"""AND EXISTS (
+              SELECT 1
+              FROM tags_on_challenges toc
+              INNER JOIN tags tg ON tg.id = toc.tag_id
+              WHERE toc.challenge_id = c.id
+                AND LOWER(tg.name) IN (${keywordParamNames.map(n => s"{$n}").mkString(", ")})
+            )"""
       else ""
     val difficultyClause = if (difficulty.isDefined) "AND c.difficulty = {difficulty}" else ""
     val globalClause     = if (!global) "AND c.is_global = false" else ""
@@ -330,7 +336,7 @@ class TileAggregateRepository @Inject() (override val db: Database) extends Repo
     }
     if (difficulty.isDefined) params += NamedParameter("difficulty", difficulty.get)
 
-    LiveFilter(joins, where, params.toSeq)
+    LiveFilter(where, params.toSeq)
   }
 
   private def boundsParams(

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -2661,8 +2661,15 @@ class ChallengeDAL @Inject() (
   )(implicit c: Option[Connection] = None): List[Challenge] = {
     this.withMRConnection { implicit c =>
       val params = new ListBuffer[NamedParameter]()
+      // No DISTINCT: the only join here is many-to-one on the parent project, so
+      // nothing can duplicate a challenge. The keyword filter below is a
+      // semi-join for the same reason -- joining the tag tables in would return
+      // a challenge once per matching tag, which is what the DISTINCT used to
+      // hide. Dropping it also lets a sort order by an expression; under SELECT
+      // DISTINCT, Postgres requires every ORDER BY expression to appear in the
+      // select list.
       var query =
-        s"""SELECT DISTINCT c.*, ST_AsGeoJSON(c.location) AS locationJSON, ST_AsGeoJSON(c.bounding) AS boundingJSON
+        s"""SELECT c.*, ST_AsGeoJSON(c.location) AS locationJSON, ST_AsGeoJSON(c.bounding) AS boundingJSON
             FROM challenges c
             INNER JOIN projects p ON p.id = c.parent_id"""
 
@@ -2670,12 +2677,6 @@ class ChallengeDAL @Inject() (
         case Some(kws) if kws.trim.nonEmpty =>
           kws.split(",").map(_.trim.toLowerCase).filter(_.nonEmpty).toList
         case _ => List.empty[String]
-      }
-
-      // Add INNER JOIN for keywords filtering if keywords are provided
-      if (keywordList.nonEmpty) {
-        query += " INNER JOIN tags_on_challenges toc ON c.id = toc.challenge_id"
-        query += " INNER JOIN tags t ON toc.tag_id = t.id"
       }
 
       query += " WHERE c.deleted = false AND c.enabled = true AND c.is_archived = false"
@@ -2692,7 +2693,13 @@ class ChallengeDAL @Inject() (
             params += NamedParameter(s"kw$i", kw)
             s"{kw$i}"
         }
-        query += s" AND LOWER(t.name) IN (${placeholders.mkString(", ")})"
+        query += s""" AND EXISTS (
+                        SELECT 1
+                        FROM tags_on_challenges toc
+                        INNER JOIN tags t ON t.id = toc.tag_id
+                        WHERE toc.challenge_id = c.id
+                          AND LOWER(t.name) IN (${placeholders.mkString(", ")})
+                      )"""
       }
 
       // Filter by difficulty if provided


### PR DESCRIPTION
A keyword names a tag on the *challenge*, but the queries matched it by joining `tags_on_challenges` into a per-task query. That repeats every task of a challenge once per requested tag the challenge carries, so anything downstream that counts or clusters rows sees the same task several times.

Measured against a 166k-task database with two requested keywords, one challenge carrying both: 148,065 rows for 136,850 tasks.

What the duplication reached:
- Cluster counts on the keyword-filtered explore map were inflated, and cluster centroids were pulled toward multi-tagged challenges, since the duplicate rows also inflate the centroid weight.
- At zoom 12 a location holding 3 tasks reported 6, with ids repeated in `task_ids_str` ("8473,8473,8474,8474,8475,8475"), and a lone task reported 2 -- rendering as an overlap stack rather than a single clickable task.
- queryTaskMarkersWithOverlaps returned each task once per matching tag, and since it groups by location with DBSCAN, the duplicates of one task became a phantom overlap group.

The other three keyword call sites in TaskClusterRepository were already protected by SELECT DISTINCT / COUNT(DISTINCT), so they were correct; they move to the semi-join too, since it is the cheaper way to ask and leaves one spelling of the question in the file.

EXISTS is also the faster form, because it lets the planner narrow to the matching challenges before touching tasks. Best of 3 at zoom 0 on the same database: a keyword matching one challenge goes 44ms -> 0.26ms, and a keyword matching every challenge stays level (53.7ms -> 53.6ms) where a sequential scan was already the right plan.